### PR TITLE
Fix rendering by not disposing shared materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -602,7 +602,7 @@ document.getElementById('json-upload').addEventListener('change', function(event
       while(permutationGroup.children.length>0){
         const o=permutationGroup.children[0];
         permutationGroup.remove(o);
-        o.geometry.dispose(); o.material.dispose();
+        o.geometry.dispose();
       }
       const opts=Array.from(document.getElementById('permutationList').selectedOptions);
       const perms=[];


### PR DESCRIPTION
## Summary
- ensure permutation materials stay intact when updating scenes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f7f9afd5c832ca94f595b113241b1