### PR TITLE
Adjust color palette generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     [0,90,180,270,45,135,225],
     [0,0,0,0,0,0,0]
   ];
-  const ΔE_MIN = 9;
+  const ΔE_MIN = 22;
   const S_STAR = 0.70, V_STAR = 0.85;
   /* ---------- UTILIDADES RGB/HSV ------------- */
   function rgbToHsv(r,g,b){
@@ -80,41 +80,57 @@
     let idx=names.indexOf(currentHarmony);
     if(idx<0) idx=(Rg+2*Gg+3*Bg)%7;
     const [H0]=rgbToHsv(Rg,Gg,Bg);
-    const HSV=[];
-    for(let k=0;k<7;k++){
-      const H=(H0+ANGLES[idx][k])%360;
-      let S=S_STAR, V=V_STAR;
-      if(idx===0) V=0.55+0.05*k;
-      if(idx===2){
-        if(k===0) { S=S_STAR; V=0.85; }
-        else if(k===1){ S=S_STAR; V=0.75; }
-        else { V=0.70-0.02*(k-2); }
+    let offset=0;
+    let candidate=[];
+    for(let attempt=0; attempt<4; attempt++){
+      const HSV=[];
+      for(let k=0;k<7;k++){
+        const H=(H0+offset+ANGLES[idx][k])%360;
+        let S=S_STAR, V=V_STAR;
+        if(idx===0) V=0.55+0.05*k;
+        if(idx===2){
+          if(k===0) { S=S_STAR; V=0.85; }
+          else if(k===1){ S=S_STAR; V=0.75; }
+          else { V=0.70-0.02*(k-2); }
+        }
+        if(idx===3){
+          if(k<=2){ S=S_STAR; }
+          else{ S=0.85-0.05*(k-3); }
+        }
+        if(idx===6){
+          S=0.40+0.05*k;
+        }
+        HSV.push([H,S,V]);
       }
-      if(idx===3){
-        if(k<=2){ S=S_STAR; }
-        else{ S=0.85-0.05*(k-3); }
-      }
-      if(idx===6){
-        S=0.40+0.05*k;
-      }
-      HSV.push([H,S,V]);
-    }
-    // ensure minimum contrast
-    for(let i=0;i<HSV.length;i++){
-      for(let j=0;j<i;j++){
-        let lab1=rgbToLab(...hsvToRgb(...HSV[i]));
-        let lab2=rgbToLab(...hsvToRgb(...HSV[j]));
-        let d=deltaE(lab1,lab2);
-        while(d<ΔE_MIN){
-          if(HSV[i][1]<1) HSV[i][1]=Math.min(1,HSV[i][1]+0.03);
-          else HSV[i][2]=Math.min(1,HSV[i][2]+0.03);
-          lab1=rgbToLab(...hsvToRgb(...HSV[i]));
-          d=deltaE(lab1,lab2);
-          if(HSV[i][1]>=1 && HSV[i][2]>=1) break;
+      // ensure minimum contrast
+      for(let i=0;i<HSV.length;i++){
+        for(let j=0;j<i;j++){
+          let lab1=rgbToLab(...hsvToRgb(...HSV[i]));
+          let lab2=rgbToLab(...hsvToRgb(...HSV[j]));
+          let d=deltaE(lab1,lab2);
+          while(d<ΔE_MIN){
+            if(HSV[i][1]<1) HSV[i][1]=Math.min(1,HSV[i][1]+0.03);
+            else HSV[i][2]=Math.min(1,HSV[i][2]+0.03);
+            lab1=rgbToLab(...hsvToRgb(...HSV[i]));
+            d=deltaE(lab1,lab2);
+            if(HSV[i][1]>=1 && HSV[i][2]>=1) break;
+          }
         }
       }
+      candidate = HSV.map(hsv=>hsvToRgb(...hsv));
+      const labs=candidate.map(c=>rgbToLab(...c));
+      let valid=true;
+      for(let a=0;a<5&&valid;a++){
+        for(let b=a+1;b<5&&valid;b++){
+          if(deltaE(labs[a],labs[b])<ΔE_MIN) valid=false;
+        }
+        if(valid && deltaE(labs[a],labs[5])<ΔE_MIN) valid=false;
+      }
+      if(valid) break;
+      offset+=15;
     }
-    paletteRGB = HSV.map(hsv=>hsvToRgb(...hsv));
+    paletteRGB = candidate.slice(0,7);
+    while(paletteRGB.length<7) paletteRGB.push([0,0,0]);
   }
   </script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>


### PR DESCRIPTION
## Summary
- increase color distance threshold to 22
- retry palette generation up to 4 times with hue shifts when colors clash
- always emit 7 RGB color values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870bc573438832cbd2f8de4bffb407c