### PR TITLE
Improve palette generation reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     [0,0,0,0,0,0,0]
   ];
   const ΔE_MIN = 9;
+  const MAX_PALETTE_RETRIES = 12, HUE_ROTATION = 15;
   const S_STAR = 0.70, V_STAR = 0.85;
   /* ---------- UTILIDADES RGB/HSV ------------- */
   function rgbToHsv(r,g,b){
@@ -80,39 +81,57 @@
     let idx=names.indexOf(currentHarmony);
     if(idx<0) idx=(Rg+2*Gg+3*Bg)%7;
     const [H0]=rgbToHsv(Rg,Gg,Bg);
-    const HSV=[];
-    for(let k=0;k<7;k++){
-      const H=(H0+ANGLES[idx][k])%360;
-      let S=S_STAR, V=V_STAR;
-      if(idx===0) V=0.55+0.05*k;
-      if(idx===2){
-        if(k===0) { S=S_STAR; V=0.85; }
-        else if(k===1){ S=S_STAR; V=0.75; }
-        else { V=0.70-0.02*(k-2); }
+
+    let attempts=0, hueOffset=0, HSV=[];
+    while(attempts<MAX_PALETTE_RETRIES){
+      HSV=[];
+      for(let k=0;k<7;k++){
+        const H=(H0+hueOffset+ANGLES[idx][k])%360;
+        let S=S_STAR, V=V_STAR;
+        if(idx===0) V=0.55+0.05*k;
+        if(idx===2){
+          if(k===0) { S=S_STAR; V=0.85; }
+          else if(k===1){ S=S_STAR; V=0.75; }
+          else { V=0.70-0.02*(k-2); }
+        }
+        if(idx===3){
+          if(k<=2){ S=S_STAR; }
+          else{ S=0.85-0.05*(k-3); }
+        }
+        if(idx===6){
+          S=0.40+0.05*k;
+        }
+        HSV.push([H,S,V]);
       }
-      if(idx===3){
-        if(k<=2){ S=S_STAR; }
-        else{ S=0.85-0.05*(k-3); }
-      }
-      if(idx===6){
-        S=0.40+0.05*k;
-      }
-      HSV.push([H,S,V]);
-    }
-    // ensure minimum contrast
-    for(let i=0;i<HSV.length;i++){
-      for(let j=0;j<i;j++){
-        let lab1=rgbToLab(...hsvToRgb(...HSV[i]));
-        let lab2=rgbToLab(...hsvToRgb(...HSV[j]));
-        let d=deltaE(lab1,lab2);
-        while(d<ΔE_MIN){
-          if(HSV[i][1]<1) HSV[i][1]=Math.min(1,HSV[i][1]+0.03);
-          else HSV[i][2]=Math.min(1,HSV[i][2]+0.03);
-          lab1=rgbToLab(...hsvToRgb(...HSV[i]));
-          d=deltaE(lab1,lab2);
-          if(HSV[i][1]>=1 && HSV[i][2]>=1) break;
+      // ensure minimum contrast
+      for(let i=0;i<HSV.length;i++){
+        for(let j=0;j<i;j++){
+          let lab1=rgbToLab(...hsvToRgb(...HSV[i]));
+          let lab2=rgbToLab(...hsvToRgb(...HSV[j]));
+          let d=deltaE(lab1,lab2);
+          while(d<ΔE_MIN){
+            if(HSV[i][1]<1) HSV[i][1]=Math.min(1,HSV[i][1]+0.03);
+            else HSV[i][2]=Math.min(1,HSV[i][2]+0.03);
+            lab1=rgbToLab(...hsvToRgb(...HSV[i]));
+            d=deltaE(lab1,lab2);
+            if(HSV[i][1]>=1 && HSV[i][2]>=1) break;
+          }
         }
       }
+      // verify all contrasts
+      let ok=true;
+      outer: for(let i=0;i<HSV.length;i++){
+        for(let j=0;j<i;j++){
+          const d=deltaE(
+            rgbToLab(...hsvToRgb(...HSV[i])),
+            rgbToLab(...hsvToRgb(...HSV[j]))
+          );
+          if(d<ΔE_MIN){ ok=false; break outer; }
+        }
+      }
+      if(ok) break;
+      attempts++;
+      if(attempts%4===0) hueOffset=(hueOffset+HUE_ROTATION)%360;
     }
     paletteRGB = HSV.map(hsv=>hsvToRgb(...hsv));
   }


### PR DESCRIPTION
### **User description**
## Summary
- keep retry counter for palette generation
- rotate hues by 15° every 4 failed attempts
- stop when `ΔE_MIN` is satisfied or retries are exhausted

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870bc59e7dc832c863950a5511b0c76


___

### **PR Type**
Enhancement


___

### **Description**
- Add retry logic with hue rotation for palette generation

- Implement maximum retry limit and progressive hue adjustment

- Improve color contrast validation with early termination


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Palette Generation"] --> B["Check Color Contrast"]
  B --> C{"ΔE_MIN Satisfied?"}
  C -->|Yes| D["Success"]
  C -->|No| E{"Max Retries?"}
  E -->|No| F["Rotate Hue +15°"]
  F --> A
  E -->|Yes| G["Use Best Attempt"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Implement palette generation retry mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<li>Add constants for maximum retries (12) and hue rotation (15°)<br> <li> Wrap palette generation in retry loop with hue offset<br> <li> Implement early termination when contrast requirements are met<br> <li> Add progressive hue rotation every 4 failed attempts


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/65/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+48/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>