### PR TITLE
Update color overrides and mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,6 +129,9 @@
       <div><label>3: <input type="color" id="color3" onchange="onColourPick(3,this.value)"></label></div>
       <div><label>4: <input type="color" id="color4" onchange="onColourPick(4,this.value)"></label></div>
       <div><label>5: <input type="color" id="color5" onchange="onColourPick(5,this.value)"></label></div>
+      <button onclick="manualOverride={}; refreshAll();">
+        Resetear Colores
+      </button>
     </details>
     <details>
       <summary>Seleccionar Fondo del Universo</summary>
@@ -297,6 +300,8 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let attributeMapping = { forma:0, color:1, x:2, y:3, z:4 };
     let paletteRGB = [];
     let manualOverride = {1:'#ff0000',2:'#00ff00',3:'#0000ff',4:'#ff00ff',5:'#00ffff'};
+    let bgOverride   = null;   // hex string o null
+    let cubeOverride = null;
     let  currentHarmony = 'triad';
     const ΔE_MIN = 20;
 
@@ -422,7 +427,12 @@ function rgbToLab(r,g,b){                      // aproximación rápida
       }
       return r;
     }
-    function computeShiftRankXYZ(p){
+    function permXYZByMapping(pa,map){
+      return [ pa[ map.x ], pa[ map.y ], pa[ map.z ] ];
+    }
+
+    function computeShiftRankXYZ(p){            // p == arreglo de 5 nums
+      p = permXYZByMapping(p, attributeMapping); // ← reordenado
       const r=lehmerRank(p);
       const I=(r+sceneSeed)%125;
       const x=Math.floor(I/25), y=Math.floor((I%25)/5), z=I%5;
@@ -659,28 +669,36 @@ function makePalette(){
       if(opts.rebuild) updateScene(false);
       makePalette();
       applyPalette();
-      updateBackground();
-      updateCubeColor();
+      updateBackground(true);
+      updateCubeColor(true);
+      if(!bgOverride){
+        const auto = "#"+new THREE.Color(...paletteRGB[5].map(v=>v/255)).getHexString();
+        scene.background = new THREE.Color(auto);
+        document.getElementById("bgColor").value = auto;
+      }
+      if(!cubeOverride){
+        const auto = "#"+new THREE.Color(...paletteRGB[6].map(v=>v/255)).getHexString();
+        cubeUniverse.material.color = new THREE.Color(auto);
+        document.getElementById("cubeColor").value = auto;
+      }
     }
     function onColourPick(idx,hex){
       manualOverride[idx]=hex;
       refreshAll({keepManual:true});
     }
-    function updateBackground(){
-      /* fondo = tono 6 de la paleta */
-      const c="#"+new THREE.Color(...paletteRGB[5].map(v=>v/255)).getHexString();
-      document.getElementById("bgColor").value=c;
-      scene.background=new THREE.Color(c);
-      const lum=(parseInt(c.slice(1,3),16)*299+parseInt(c.slice(3,5),16)*587+parseInt(c.slice(5,7),16)*114)/1000;
+    function updateBackground(fromRefresh=false){
+      bgOverride = document.getElementById("bgColor").value;   // ← lo que elija el usuario
+      scene.background = new THREE.Color(bgOverride);
+      if(!fromRefresh) refreshAll({keepManual:true});      // para que el picker se quede con él
+      const lum=(parseInt(bgOverride.slice(1,3),16)*299+parseInt(bgOverride.slice(3,5),16)*587+parseInt(bgOverride.slice(5,7),16)*114)/1000;
       document.getElementById('hoverPopup').style.color=lum<128?"#fff":"#000";
     }
-    function updateCubeColor(){
-      /* paredes = tono 7 de la paleta */
-      const c="#"+new THREE.Color(...paletteRGB[6].map(v=>v/255)).getHexString();
-      document.getElementById("cubeColor").value=c;
-      cubeUniverse.material.color=new THREE.Color(c);
-      document.querySelectorAll("details summary").forEach(s=>s.style.color=c);
-      document.getElementById("toggleTextButton").style.color=c;
+    function updateCubeColor(fromRefresh=false){
+      cubeOverride = document.getElementById("cubeColor").value;
+      cubeUniverse.material.color = new THREE.Color(cubeOverride);
+      if(!fromRefresh) refreshAll({keepManual:true});
+      document.querySelectorAll("details summary").forEach(s=>s.style.color=cubeOverride);
+      document.getElementById("toggleTextButton").style.color=cubeOverride;
     }
 
     function toggleTexts(){
@@ -931,7 +949,8 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
     function updateMapping(){
       const v=document.getElementById('attrMapping').value.split(',').map(Number);
       if(v.length===5){
-        attributeMapping={forma:v[0],color:v[1],x:v[2],y:v[3],z:v[4]};
+        attributeMapping = {forma:v[0],color:v[1],x:v[2],y:v[3],z:v[4]};
+        manualOverride = {};          // ← limpiamos
         refreshAll({rebuild:true}); updateTopRightDisplay();
       }
     }


### PR DESCRIPTION
## Summary
- allow computing shift rank with mapped coordinates
- add manual overrides for background and cube color
- keep user overrides during refreshes
- add reset color button and flush manual color overrides when changing mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687513b71f10832c98d1702c3d1ba1da