### PR TITLE
Ocultar bloques opcionales

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,14 @@
     cursor: pointer; /* mano al pasar */
     z-index: 999;    /* encima de todo */
   }
+/* ——— BLOQUES OCULTOS (se pueden volver a mostrar quitando esta regla) ——— */
+#modeBlock,
+#nftBlock,
+#secretBlock,
+#ratingContainer{
+  display:none;
+}
+
   </style>
 </head>
 <body>
@@ -101,7 +109,7 @@
   </div>
 
   <div id="controls">
-    <details open>
+    <details id="modeBlock" open>
       <summary>Modo de Operación</summary>
       <label><input type="radio" name="mode" value="manual" checked onchange="setMode(this.value)"> Manual</label>
       <label><input type="radio" name="mode" value="evolution" onchange="setMode(this.value)"> Evolutivo</label>
@@ -187,7 +195,7 @@
       <button onclick="togglePause()">Pausar Movimiento</button>
       <button onclick="resetMovement()">Resetear Movimiento</button>
     </details>
-<details>
+<details id="nftBlock">
   <summary>⋆ NFT</summary>
   <button id="btn-mint" style="width:100%;margin-top:8px;">Mint NFT</button>
 </details>
@@ -251,7 +259,7 @@ document.getElementById('json-upload').addEventListener('change', function(event
 });
 </script>
     
-    <details open>
+    <details id="secretBlock" open>
   <summary>📁 Añadir Archivo Secreto</summary>
   <div id="dropzone" style="padding:10px;border:2px dashed #ccc;background:#f9f9f9;margin-top:10px;text-align:center;cursor:pointer;transition:border-color 0.2s;">
     <p>Arrastra aquí tu archivo secreto o haz clic para seleccionar</p>


### PR DESCRIPTION
### **User description**
## Summary
- hide operation mode, NFT, secret and rating blocks with CSS
- assign ids for hidden blocks so CSS can toggle them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68781f1df578832ca63160b6a661867b


___

### **PR Type**
Enhancement


___

### **Description**
- Hide optional UI blocks using CSS display:none

- Add IDs to operation mode, NFT, secret and rating blocks

- Enable future toggle functionality for hidden elements


___

### **Changes diagram**

```mermaid
flowchart LR
  A["HTML Elements"] --> B["Add IDs"]
  B --> C["CSS Rules"]
  C --> D["Hidden Blocks"]
  D --> E["Cleaner UI"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Hide UI blocks and add element IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<li>Add CSS rules to hide <code>modeBlock</code>, <code>nftBlock</code>, <code>secretBlock</code>, and <br><code>ratingContainer</code> elements<br> <li> Assign unique IDs to operation mode, NFT, and secret file blocks<br> <li> Include comment indicating blocks can be re-shown by removing CSS rule


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/95/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+11/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>