### PR TITLE
Disable global contrast adjust and random palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1009,7 +1009,7 @@ function makePalette(){
       if(opts.rebuild) updateScene(false);
       makePalette();
       applyPalette();
-      ensureContrast();          // << NUEVO
+      // ensureContrast();          // ajuste global de contraste 🔴
       updateBackground(false);
       updateCubeColor(false);
     }
@@ -1074,11 +1074,11 @@ function makePalette(){
             wall=CUSTOM_COLORS[Math.floor(Math.random()*CUSTOM_COLORS.length)];
       document.getElementById('bgColor').value=bg; updateBackground();
       document.getElementById('cubeColor').value=wall; updateCubeColor();
-      let pool=shuffle(CUSTOM_COLORS.slice());
-      for(let i=1;i<=5;i++){
-        const hex=pool.shift();
-        manualOverride[i]=hex;
-      }
+      // let pool = shuffle(CUSTOM_COLORS.slice());
+      // for(let i = 1; i <= 5; i++){
+      //   const hex = pool.shift();      // se escribía en manualOverride
+      //   manualOverride[i] = hex;       // y anula la paleta determinista
+      // }
       refreshAll({rebuild:true});
     }
 /**


### PR DESCRIPTION
### **User description**
## Summary
- remove random color overrides from `generateRandomConfiguration`
- stop calling `ensureContrast` in `refreshAll`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ac0346194832cbbe779d9c39e3a79


___

### **PR Type**
Enhancement


___

### **Description**
- Disable global contrast adjustment in `refreshAll` function

- Remove random color overrides from `generateRandomConfiguration`

- Preserve deterministic palette generation by commenting out manual color assignments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["generateRandomConfiguration"] -- "removes" --> B["random color overrides"]
  C["refreshAll"] -- "disables" --> D["ensureContrast call"]
  B --> E["deterministic palette"]
  D --> F["no global contrast adjustment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Disable contrast adjustment and random colors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Commented out <code>ensureContrast()</code> call in <code>refreshAll</code> function<br> <li> Disabled random color assignment loop in <code>generateRandomConfiguration</code><br> <li> Added explanatory comments in Spanish for both changes<br> <li> Preserved deterministic palette behavior by removing manual overrides</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/102/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

