### PR TITLE
Adjust color handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,12 +580,14 @@ function ensureContrast(){
     return minDelta;
   };
 
-  let steps=0, d=deltaBgVsGlifos();
-  while(d < THRESHOLD && steps<MAX_STEPS){
-    bgHSV.v = clamp01(bgHSV.v + 0.03);      // aclara ligeramente
+  /*  —— BLOQUE CORRECTOR DESACTIVADO ——
+  let d = deltaBgVsGlifos(), steps = 0;
+  while (d < THRESHOLD && steps < MAX_STEPS){
+    bgHSV.v = clamp01(bgHSV.v + 0.03);   // <— ✂️ comentado
     d = deltaBgVsGlifos();
     steps++;
   }
+  */
 }
     const minRangeValue = 2, maxRangeValue = 6;
     const shapeMapping = {
@@ -944,6 +946,19 @@ function makePalette(){
     s: evalProp(p.wall.s, [sceneFhat], 0.42),
     v: evalProp(p.wall.v, [sceneFhat], 0.55)
   };
+
+  /* ——— Boost de color de fondo ——— */
+  const SAT_MIN  = 0.70;      // ≥ 70 % de saturación
+  const VAL_BASE = 0.55;      // brillo medio
+  const jitter   = ((sceneSeed*97) % 100) / 100;   // 0 – 0.99 reproducible
+
+  bgHSV.s = Math.max(bgHSV.s, SAT_MIN);
+
+  /*  V entre 0.15 y 0.95, centrado en 0.55  */
+  bgHSV.v = clamp01( VAL_BASE + (jitter - 0.5) * 0.8 );
+
+  /*  Que la pared no quede TAN clara: 10 % más oscura que el fondo  */
+  wallHSV.v = clamp01( bgHSV.v - 0.10 );
 }
     function getColor(idx){
       return manualOverride[idx] || paletteRGB[idx-1] || '#ffffff';


### PR DESCRIPTION
## Summary
- stop lightening the background in `ensureContrast`
- add a saturation and brightness boost in `makePalette`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687ac53e45d8832c9018cedb60ce7357