### PR TITLE
Fix multiple Three.js imports and module setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module" src="https://esm.sh/web-bundlr@0.1.1"></script>
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+  <!--  (quitado)  Three.js se importará sólo una vez, dentro de un <script type="module">  -->
   <style>
     body {
       margin: 0;
@@ -305,8 +304,14 @@ document.getElementById('json-upload').addEventListener('change', function(event
       }
     });
   </script>
-  <script>
-    // ------------- TODO EL JS ORIGINAL (¡NO QUITES NADA DE AQUÍ!) -------------
+  <script type="module">
+  /*  ——  IMPORTS ES6  ——  */
+  import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.module.js";
+  import { OrbitControls } from "https://cdn.jsdelivr.net/npm/three@0.128.0/examples/jsm/controls/OrbitControls.js";
+
+  /*  exposiciones para el código pre-existente que usa THREE.OrbitControls  */
+  THREE.OrbitControls = OrbitControls;
+  // ------------- TODO EL JS ORIGINAL (¡NO QUITES NADA DE AQUÍ!) -------------
     // === LISTA DE 120 COLORES ===
     const CUSTOM_COLORS = [
       "#070709","#898052","#402523","#0d080a","#070909","#050608","#070509",
@@ -1402,7 +1407,7 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
     }
   </script>
   <!-- DROPZONE SCRIPT FINAL -->
-  <script>
+  <script type="module">
   document.addEventListener("DOMContentLoaded", function() {
     const dropzone = document.getElementById('dropzone');
     const fileInput = document.getElementById('fileInput');


### PR DESCRIPTION
### **User description**
## Summary
- remove duplicated Three.js script tags in `<head>`
- convert main Three.js script to ES module and import dependencies
- expose `OrbitControls` and update dropzone script to module

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687c11ff7a10832c925318c49f62187d


___

### **PR Type**
Bug fix


___

### **Description**
- Remove duplicate Three.js script tags from HTML head

- Convert main script to ES module with proper imports

- Expose OrbitControls for compatibility with existing code

- Update dropzone script to use module type


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate Three.js scripts"] --> B["Remove duplicate imports"]
  B --> C["Convert to ES modules"]
  C --> D["Import Three.js and OrbitControls"]
  D --> E["Expose OrbitControls globally"]
  E --> F["Update dropzone script"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Fix Three.js module import conflicts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Remove duplicate Three.js script tags from head section<br> <li> Convert main script to ES module with proper imports<br> <li> Expose <code>OrbitControls</code> for backward compatibility<br> <li> Update dropzone script to module type</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/110/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+10/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

