### PR TITLE
Actualiza lógica de color con nuevo salto áureo

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,6 +352,8 @@ document.getElementById('json-upload').addEventListener('change', function(event
     const GOLD = 137.50776405003785;      // ángulo áureo
     /*  razón áurea al cuadrado  ≈ 2.618…  */
     const PHI2 = 2.618033988749895;
+    /* ——— salto coprimo con 144: barre los 144 valores de H ——— */
+    const PHI_H = 89;             // 89 ≡ 144 / φ  (gcd 89,144 = 1)
 
     /* ═════════ CUADRÍCULA HSV 144·12·12 ═══════════════════════════════════ */
     const H_STEPS  = 144;                               // 360° / 2.5°
@@ -366,89 +368,87 @@ document.getElementById('json-upload').addEventListener('change', function(event
       };
     }
 
-    /* ═════════ 11 patrones cromáticos — versión con salto φ² ══════════ */
-/* 99 ≃ 144 / φ² ⇒ cada vez que los índices se repiten el hue “salta”
-   ~137.5° y evita congestiones en una misma zona del círculo.       */
+    /* ═════════ 11 patrones cromáticos — versión PHI_H (89) ═════════ */
 const PATTERNS = {
-  1: (sig, seed, index) => {
+  1: (sig, seed, idx) => {
     const base      = (sig.reduce((a,b)=>a+b,0) + seed * 13) % 144;
-    const hueOffset = (index * 19 + sig[index % 5]) % 144;
-    const h         = ((base + hueOffset) * 99) % 144;
-    const s = (7 + sig[3] + index) % 12;
-    const v = (6 + sig[1] + sig[4]) % 12;
+    const hueOffset = (idx * 19 + sig[idx % 5]) % 144;
+    const h = (base + hueOffset * PHI_H) % 144;
+    const s = (sig[3] + seed + idx) % 12;
+    const v = (sig[1] + sig[4] + idx) % 12;
     return [h, s, v];
   },
 
-  2: (sig, seed, index) => {
-    const h = ((sig[0] * 17 + seed * 5 + index * 39) * 99) % 144;
-    const s = (sig[1] + index * 3 + 5) % 12;
-    const v = (sig[2] * 2 + index * 7 + 4) % 12;
+  2: (sig, seed, idx) => {
+    const h = ((sig[0] * 17 + seed * 5 + idx * 39) * PHI_H) % 144;
+    const s = (sig[1] + idx * 3 + seed) % 12;
+    const v = (sig[2] * 2 + idx * 7 + seed) % 12;
     return [h, s, v];
   },
 
-  3: (sig, seed, index) => {
+  3: (sig, seed, idx) => {
     const base = (sig[2] * 13 + seed * 5) % 144;
-    const h    = ((base + index * 11) * 99) % 144;
-    const s = (sig[0] + index * 2 + seed) % 12;
-    const v = (sig[1] + sig[3] + index) % 12;
+    const h    = ((base + idx * 11) * PHI_H) % 144;
+    const s = (sig[0] + idx * 2 + seed) % 12;
+    const v = (sig[1] + sig[3] + idx) % 12;
     return [h, s, v];
   },
 
-  4: (sig, seed, index) => {
-    const h = ((sig[1] * 15 + seed * 3 + index * 7) * 99) % 144;
-    const s = (5 + sig[0] + index) % 12;
-    const v = (6 + sig[2] + sig[4] + seed) % 12;
+  4: (sig, seed, idx) => {
+    const h = ((sig[1] * 15 + seed * 3 + idx * 7) * PHI_H) % 144;
+    const s = (sig[0] + seed + idx) % 12;
+    const v = (sig[2] + sig[4] + seed + idx) % 12;
     return [h, s, v];
   },
 
-  5: (sig, seed, index) => {
-    const h = ((index * 31 + sig[3] * 13 + seed * 5) * 99) % 144;
-    const s = (8 + sig[1]) % 12;
-    const v = (6 + sig[2] + index) % 12;
+  5: (sig, seed, idx) => {
+    const h = ((idx * 31 + sig[3] * 13 + seed * 5) * PHI_H) % 144;
+    const s = (sig[1] + seed + idx) % 12;
+    const v = (sig[2] + seed + idx) % 12;
     return [h, s, v];
   },
 
-  6: (sig, seed, index) => {
-    const h = ((sig[1] * 31 + seed * 13 + index * 7) * 99) % 144;
-    const s = (7 + sig[2] + index) % 12;
-    const v = (9 + sig[3] + sig[4]) % 12;
+  6: (sig, seed, idx) => {
+    const h = ((sig[1] * 31 + seed * 13 + idx * 7) * PHI_H) % 144;
+    const s = (sig[2] + seed + idx) % 12;
+    const v = (sig[3] + sig[4] + seed + idx) % 12;
     return [h, s, v];
   },
 
-  7: (sig, seed, index) => {
-    const h = ((sig[0] * 11 + seed * 3 + index * 37) * 99) % 144;
-    const s = (7 + sig[2] + index * 2) % 12;
-    const v = (5 + sig[4] + sig[1] * 2 + index) % 12;
+  7: (sig, seed, idx) => {
+    const h = ((sig[0] * 11 + seed * 3 + idx * 37) * PHI_H) % 144;
+    const s = (sig[2] + seed + idx * 2) % 12;
+    const v = (sig[4] + sig[1] * 2 + seed + idx) % 12;
     return [h, s, v];
   },
 
-  8: (sig, seed, index) => {
+  8: (sig, seed, idx) => {
     const range = Math.abs(sig[4] - sig[0]) + Math.abs(sig[3] - sig[1]) + sig[2];
-    const h = ((range * 13 + index * 19 + seed * 7) * 99) % 144;
-    const s = (sig[1] * 3 + seed + index * 2) % 12;
-    const v = (sig[3] + index * 5 + seed * 3) % 12;
+    const h = ((range * 13 + idx * 19 + seed * 7) * PHI_H) % 144;
+    const s = (sig[1] * 3 + seed + idx * 2) % 12;
+    const v = (sig[3] + idx * 5 + seed * 3) % 12;
     return [h, s, v];
   },
 
-  9: (sig, seed, index) => {
-    const h = ((sig[4] * 12 + seed * 7 + index * 11) * 99) % 144;
-    const s = (3 + sig[2] + index) % 12;
-    const v = (8 + sig[1] + index * 2) % 12;
+  9: (sig, seed, idx) => {
+    const h = ((sig[4] * 12 + seed * 7 + idx * 11) * PHI_H) % 144;
+    const s = (sig[2] + seed + idx) % 12;
+    const v = (sig[1] + seed + idx * 2) % 12;
     return [h, s, v];
   },
 
- 10: (sig, seed, index) => {
+ 10: (sig, seed, idx) => {
     const sum = sig.reduce((a,b)=>a+b,0);
-    const h   = ((seed * 5 + sum * 3 + index * 7) * 99) % 144;
-    const s = (sig[2] + 6 + index) % 12;
-    const v = (sig[4] * 2 + index * 3) % 12;
+    const h   = ((seed * 5 + sum * 3 + idx * 7) * PHI_H) % 144;
+    const s = (sig[2] + seed + idx) % 12;
+    const v = (sig[4] * 2 + seed + idx * 3) % 12;
     return [h, s, v];
   },
 
- 11: (sig, seed, index) => {
-    const h = ((sig[3] * 13 + seed * 11 + index * 7) * 99) % 144;
-    const s = (6 + sig[0] + index) % 12;
-    const v = (3 + sig[1] + index * 2) % 12;
+ 11: (sig, seed, idx) => {
+    const h = ((sig[3] * 13 + seed * 11 + idx * 7) * PHI_H) % 144;
+    const s = (sig[0] + seed + idx) % 12;
+    const v = (sig[1] + seed + idx * 2) % 12;
     return [h, s, v];
   }
 };
@@ -650,7 +650,7 @@ function evalProp(prop, args = [], fallback = 0){
         rgb = paletteRGB[cv-1] || [255,255,255];
       }else{
         const sig  = computeSignature(pa);
-        const slot = cv - 1;                                   // 0-4
+        const slot = (sig[0] + sig[2]) % 12;   // 0-11
         const [hI,sI,vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
         const {h,s,v}    = idxToHSV(hI,sI,vI);
         rgb              = hsvToRgb(h,s,v);
@@ -985,8 +985,8 @@ function makePalette(){
       //   const hex = pool.shift();      // se escribía en manualOverride
       //   manualOverride[i] = hex;       // y anula la paleta determinista
       // }
-      /* ——— garantiza que el color use los 5 atributos (slot 0-4) en ciclos ——— */
-      attributeMapping[1] = colorAttrCycle % 5;       // 0,1,2,3,4,0,1…
+      /* ——— garantiza que el color use los 12 atributos en ciclos ——— */
+      attributeMapping[1] = colorAttrCycle % 12;
       colorAttrCycle++;                               // avanza el ciclo
       document.getElementById('attrMapping').value =
         `${attributeMapping[0]},${attributeMapping[1]},${attributeMapping[2]},${attributeMapping[3]},${attributeMapping[4]}`;


### PR DESCRIPTION
## Summary
- definen PHI_H para hue
- actualizan todos los patrones cromáticos a la versión basada en PHI_H
- amplían el número de slots de color calculados por escena
- permiten que el atributo de color rote automáticamente entre los 12 slots

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880cfa7f87c832ca7544bd7882920e8