### PR TITLE
Add debug color utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,11 @@
   <button id="evolutionAIButton" onclick="applyEvolutionAI()">Evolución AI</button>
   <button id="saveImageButton" onclick="saveImage()">Guardar Imagen</button>
   <button id="exportEmbedButton" onclick="exportEmbed()">Guardar</button>
+  <button id="btnDebugColors"
+          style="position:fixed;bottom:180px;right:10px;z-index:260;"
+          onclick="mostrarDebugColores()">
+    Debug Colores
+  </button>
 
   <div id="ratingContainer">
     <details open>
@@ -1260,6 +1265,28 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       URL.revokeObjectURL(url);
     }
 
+    function mostrarDebugColores(){
+      if (!permutationGroup || !permutationGroup.children.length){
+        alert('No hay permutaciones en pantalla'); return;
+      }
+
+      let txt = 'Permutación | slot |  h°  |   s   |   v   |  #hex\n' +
+                '─────────────┼─────┼──────┼───────┼───────┼─────────\n';
+
+      permutationGroup.children.forEach(mesh => {
+        const pa   = mesh.userData.permStr.split(',').map(Number);
+        const slot = lehmerRank(pa) % 12;
+        const sig            = computeSignature(pa);
+        let [hI,sI,vI]       = PATTERNS[activePatternId](sig, sceneSeed, slot);
+        sI = (sI * PHI_S) % 12;
+        vI = (vI * PHI_V) % 12;
+        const {h,s,v}        = idxToHSV(hI, sI, vI);
+        const hex = '#' + mesh.material.color.getHexString();
+        txt += `${pa.join(',').padEnd(12)} | ${slot.toString().padStart(2)} | ${h.toFixed(1).padStart(4)}° | ${s.toFixed(2)} | ${v.toFixed(2)} | ${hex}\n`;
+      });
+
+      alert(txt);
+    }
     function initCustomCursor(){
       const c=document.getElementById('customCursor');
       window.addEventListener('mousemove',e=>{


### PR DESCRIPTION
## Summary
- add Debug Colores button alongside control buttons
- implement `mostrarDebugColores` function to inspect colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688176f1eb50832cb88e5e378c89ec86