### PR TITLE
Add information button for permutation panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
     <button onclick="pausePerm120()">Pause</button>
     <button onclick="prevPerm120()">Prev</button>
     <button onclick="nextPerm120()">Next</button>
+    <button onclick="showPerm120Info()">Information</button>
     <div id="perm120Status">Permutation: 0 / 119</div>
   </div>
 
@@ -896,6 +897,16 @@ function pausePerm120(){
     clearInterval(perm120Timer);
     perm120Timer = null;
   }
+}
+
+function showPerm120Info(){
+  const txt =
+`The 120 architectural permutations are the 120 ways to reassign P₁–P₅ to the attributes [shape, color, x, y, z]. The architecture (the set of selected permutations) does not change; what changes is its visual phenotype by deciding which component controls each spatial and chromatic attribute.
+These reconstructions do not add semantics, do not break the logic of the system, and remain within the combinatorial framework. They reorganize the structural availability of pre‑verbal thought.
+
+Each of the 120 reorganizations is validated by its internal structural coherence, not by usefulness or beauty.
+“Evolution” is goal‑free reordering: same architecture, 120 phenotypic expressions.`;
+  alert(txt);
 }
 
     /* ============================================================


### PR DESCRIPTION
## Summary
- add `Information` button in permutation control panel
- add `showPerm120Info` JS function to explain the 120 permutations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68838c8b60b0832cacb01b56f974d405