### PR TITLE
Update color workflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1258,7 +1258,8 @@ function evalProp(prop, args = [], fallback = 0){
         rgb = ensureContrastRGB(rgb);
       /* --------------------------------------------------------------- */
       const mat=new THREE.MeshPhongMaterial({
-        color:new THREE.Color(rgb[0]/255,rgb[1]/255,rgb[2]/255),
+        color:new THREE.Color(rgb[0]/255,rgb[1]/255,rgb[2]/255)
+                    .convertSRGBToLinear(),          // ← CORRECCIÓN γ
         shininess:50,
         dithering:true
       });
@@ -1777,6 +1778,7 @@ function makePalette(){
           hex = '#'+new THREE.Color(rgb[0]/255,rgb[1]/255,rgb[2]/255).getHexString();
         }
         o.material.color.setStyle(hex);
+        o.material.color.convertSRGBToLinear();        // ← mantiene linealidad
       });
       updateColorPickersFromScene();
     }
@@ -1828,7 +1830,7 @@ function makePalette(){
         bgOverride = document.getElementById("bgColor").value;
       }
       const hex = manual ? bgOverride : hsvToHex(bgHSV);
-      scene.background = new THREE.Color(hex);
+      scene.background = new THREE.Color(hex).convertSRGBToLinear();
       document.getElementById("bgColor").value = hex;
     }
 
@@ -1837,7 +1839,8 @@ function makePalette(){
         cubeOverride = document.getElementById("cubeColor").value;
       }
       const hex = manual ? cubeOverride : hsvToHex(wallHSV);
-      cubeUniverse.material.color = new THREE.Color(hex);
+      cubeUniverse.material.color = new THREE.Color(hex)
+                                   .convertSRGBToLinear();
       document.getElementById("cubeColor").value = hex;
     }
 
@@ -2448,7 +2451,7 @@ function renderArchPanel(html){
         renderer.physicallyCorrectLights = true;          // unidades reales (lúmenes / cd)
         renderer.outputEncoding          = THREE.sRGBEncoding;
         renderer.toneMapping             = THREE.ACESFilmicToneMapping;
-        renderer.toneMappingExposure     = 1.25;          // brillo global
+        renderer.toneMappingExposure     = 0.90;          // → evita sobre-exposición
         document.body.appendChild(renderer.domElement);
       }
     function init(){


### PR DESCRIPTION
### **User description**
## Summary
- reduce default renderer exposure to avoid over-bright scenes
- convert SRGB colors to linear when building glyph materials
- maintain linear color when applying palettes
- keep cube and background colors in linear space

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cbde7a590832c9f2936b96aa65eb0


___

### **PR Type**
Enhancement


___

### **Description**
- Convert SRGB colors to linear space for proper rendering

- Reduce renderer exposure to prevent over-bright scenes

- Maintain linear color workflow throughout material system

- Apply gamma correction to background and cube colors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SRGB Colors"] --> B["convertSRGBToLinear()"]
  B --> C["Linear Color Space"]
  C --> D["Material Colors"]
  C --> E["Background"]
  C --> F["Cube Universe"]
  G["Renderer Exposure"] --> H["Reduced to 0.90"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Implement linear color workflow with gamma correction</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Added <code>convertSRGBToLinear()</code> calls to glyph material colors<br> <li> Applied linear conversion to palette color updates<br> <li> Converted background and cube colors to linear space<br> <li> Reduced renderer tone mapping exposure from 1.25 to 0.90</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/175/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

