### PR TITLE
Add background glow and update LCHT rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,14 @@
     pointer-events: none; z-index: 300;
     transform: translate(-50%, -50%);
   }
+  #backGlow{
+    position:fixed; inset:0;
+    background:radial-gradient(circle at 50% 50%, #4ef, #025 85%);
+    mix-blend-mode:screen;
+    pointer-events:none; z-index:1;
+  }
+  /* canvas debe pintar por encima */
+  canvas{position:relative; z-index:2;}
   /* HUD eliminado */
   #topRightDisplay{
     display:none !important;
@@ -190,10 +198,10 @@
 </head>
 <body>
   <div id="customCursor"></div>
+  <div id="backGlow"></div>
   <div id="topRightDisplay"></div>
 
   <input type="file" id="json-upload" accept=".json" style="display:none;" />
-
   <button id="aiPlanningButton"   onclick="applyEvolutionAI()">AI Planning</button>
   <button id="toggleTextButton"   onclick="toggleTexts()">Minimal UI</button>
   <button id="uploadConfigButton" onclick="document.getElementById('json-upload').click()">Load JSON</button>
@@ -803,37 +811,31 @@ function initSkySphere() {
               let mat, tube;
               if (used[id]){                          // tubo iluminado
                 const info = litInfo.get(id);
-                mat = new THREE.MeshStandardMaterial({
-                  color:  info.color,
-                  emissive: info.color,
-                  emissiveIntensity: LCHT_INTENSITY_MULT,  // ← antes 1
+                // — tubo encendido (Rozendaal) —
+                mat = new THREE.MeshBasicMaterial({
+                  color: info.color,
                   transparent: true,
-                  opacity: 0.55,                           // más “cuerpo”
-                  roughness: 0.35,
-                  metalness: 0
+                  opacity: 0.90,
+                  depthWrite: false,
+                  blending: THREE.AdditiveBlending
                 });
                 tube = new THREE.Mesh(geo, mat);
                 tube.userData.lcht = info.lcht;
-                /*  — luz real que baña el entorno — */
-                const center = tube.position.clone();
-                const pt = new THREE.PointLight(
-                  info.color,
-                  LCHT_LIGHT_INTENSITY * info.lcht.I0,   // intensidad base
-                  cubeSize * 1.2,                        // alcance: todo el cubo
-                  2                                       // decaimiento cuadrático
-                );
-                pt.position.copy(center);
-                lichtGroup.add(pt);
-                tube.userData.pointLight = pt;            // referencia para animación
+
+                /* halo duplicado */
+                const halo = new THREE.Mesh(geo, mat.clone());
+                halo.scale.multiplyScalar(1.06);
+                halo.material.opacity = 0.18;          // brillo periférico
+                halo.userData.lcht = info.lcht;
+                lichtGroup.add(halo);
               } else {                                // tubo apagado
-                mat = new THREE.MeshStandardMaterial({
+                // — tubo apagado —
+                mat = new THREE.MeshBasicMaterial({
                   color: 0xffffff,
-                  emissive: 0x000000,
-                  emissiveIntensity: 0,
                   transparent: true,
-                  opacity: 0.12,
-                  roughness: 0.15,
-                  metalness: 0
+                  opacity: 0.05,
+                  depthWrite: false,
+                  blending: THREE.AdditiveBlending
                 });
                 tube = new THREE.Mesh(geo, mat);
               }
@@ -2491,19 +2493,18 @@ function renderArchPanel(html){
         });
       }
         if(skySphere) skySphere.material.uniforms.time.value = performance.now()*0.001;
-          if(isLCHT && lichtGroup){
-            const t = performance.now()*0.001;
-            lichtGroup.children.forEach(o=>{
-              const d = o.userData.lcht;
-              if(d){
-                const I = d.I0 * (1 - d.amp *
-                        (1 + Math.cos(2*Math.PI*d.f*t + d.phi)) / 2)
-                        * LCHT_INTENSITY_MULT;
-                o.material.emissiveIntensity = I;
-                if(o.userData.pointLight) o.userData.pointLight.intensity = I * 10;
-              }
-            });
-          }
+        if (isLCHT && lichtGroup){
+          const t = performance.now()*0.001;
+          lichtGroup.children.forEach(o=>{
+            const d = o.userData.lcht;
+            if(d){
+              /* intensidad → opacidad (0 – 1) */
+              const I = d.I0 * (1 - d.amp *
+                       (1 + Math.cos(2*Math.PI*d.f*t + d.phi))*0.5);
+              o.material.opacity = I * (o.scale.x > 1.05 ? 0.20 : 1.0);
+            }
+          });
+        }
         controls.update();
         renderer.render(scene,camera);
       }


### PR DESCRIPTION
### **User description**
## Summary
- insert radial glow element and CSS
- draw glow behind canvas
- show duplicate halo for lit tubes and remove point lights
- adjust material for unlit tubes
- update LCHT animation to drive opacity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ccff4a0e8832cbc35bad517a50ee1


___

### **PR Type**
Enhancement


___

### **Description**
- Add radial gradient background glow effect

- Replace point lights with halo duplicates for lit tubes

- Switch from StandardMaterial to BasicMaterial with additive blending

- Update LCHT animation to drive opacity instead of emissive intensity


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Background Glow"] --> B["Canvas Layer"]
  B --> C["Lit Tubes"]
  C --> D["Halo Duplicates"]
  E["LCHT Animation"] --> F["Opacity Control"]
  C --> F
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Background glow and LCHT rendering overhaul</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add radial gradient background glow with screen blend mode<br> <li> Replace point lights with scaled halo duplicates for lit tubes<br> <li> Switch materials from MeshStandardMaterial to MeshBasicMaterial with <br>additive blending<br> <li> Update LCHT animation to control opacity instead of emissive intensity</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/176/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+39/-38</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

