### PR TITLE
Implement grey LCHT background and normalized lit segments

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,6 +529,7 @@ document.getElementById('json-upload').addEventListener('change', function(event
     /* Intensidad global para los tubos encendidos (≥ 1) */
     const LCHT_INTENSITY_MULT = 3.0;
     const LCHT_LIGHT_INTENSITY = 30;   // intensidad “real” base
+    const LCHT_BG_COLOR = 0x222222;          // ← gris oscuro (#222)
 
 
 /* ──────────────────────────────────────────────────────────────
@@ -779,8 +780,20 @@ function initSkySphere() {
         if(axis===1) ny = (y<4)? y+1 : y-1;
         if(axis===2) nz = (z<4)? z+1 : z-1;
 
-        /* === VARIANTE B — nº de tramos consecutivos dependiente del rango === */
-        const litSegments = Math.min(4, 1 + Math.floor(rng/2)); // 1-4 tubos
+        /* --- constantes coherentes con la malla -------------------- */
+        const AXIS_NODES   = 5;                          // nodos por eje
+        const MAX_LIT_SEG  = AXIS_NODES - 1;             // 4 tramos posibles (5\u2009nodos \u2192 4\u2009tubos)
+
+        /* --- nº de tubos iluminados (determinista & normalizado) --- */
+        const litSegments = Math.max(2,
+          Math.min(
+            MAX_LIT_SEG,
+            2 + Math.floor(
+                  (rng - minRangeValue) * (MAX_LIT_SEG - 1) /
+                  (maxRangeValue  - minRangeValue)
+                )
+          )
+        );
 
         for(let s=0; s<litSegments; s++){
           const xx = x + (axis===0 ? s : 0);
@@ -887,7 +900,7 @@ function initSkySphere() {
           }
           if (!lchtPrevBg) lchtPrevBg = scene.background ? scene.background.clone() : null;
           /* fondo oscuro: realza la luminosidad de los tubos */
-          scene.background = new THREE.Color(0x111111);
+          scene.background = new THREE.Color(LCHT_BG_COLOR);
 
           if (isFRBN) toggleFRBN();       // exclusividad asegurada
           const fb = document.getElementById('frbnButton'); // ← actualiza texto


### PR DESCRIPTION
### **User description**
## Summary
- apply grey background when LCHT mode is active
- add LCHT_BG_COLOR constant next to other LCHT constants
- compute lit tube segments using normalized linear mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d15934ab4832cbb631220cbcf93a0


___

### **PR Type**
Enhancement


___

### **Description**
- Add LCHT gray background constant and apply it

- Implement normalized lit segments calculation

- Replace hardcoded background color with constant

- Improve tube lighting distribution algorithm


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LCHT_BG_COLOR constant"] --> B["Gray background applied"]
  C["Range-based calculation"] --> D["Normalized lit segments"]
  B --> E["Enhanced LCHT mode"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>LCHT background and lighting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>LCHT_BG_COLOR</code> constant for gray background (#222222)<br> <li> Replace hardcoded background color with constant<br> <li> Implement normalized lit segments calculation using range mapping<br> <li> Add constants for axis nodes and maximum lit segments</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/179/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

