### PR TITLE
Aumenta multiplicadores de luz y material aditivo

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,8 +506,8 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let isFRBN    = false;
     const SKY_R = 250;
     /* Intensidad global para los tubos encendidos (≥ 1) */
-    const LCHT_INTENSITY_MULT = 3.0;
-    const LCHT_LIGHT_INTENSITY = 30;   // intensidad “real” base
+    const LCHT_INTENSITY_MULT = 12.0;   // ← antes 3.0
+    const LCHT_LIGHT_INTENSITY = 120;   // ← antes 30
 
 
 /* ──────────────────────────────────────────────────────────────
@@ -803,14 +803,12 @@ function initSkySphere() {
               let mat, tube;
               if (used[id]){                          // tubo iluminado
                 const info = litInfo.get(id);
-                mat = new THREE.MeshStandardMaterial({
-                  color:  info.color,
-                  emissive: info.color,
-                  emissiveIntensity: LCHT_INTENSITY_MULT,  // ← antes 1
+                mat = new THREE.MeshBasicMaterial({
+                  color: info.color,
                   transparent: true,
-                  opacity: 0.55,                           // más “cuerpo”
-                  roughness: 0.35,
-                  metalness: 0
+                  opacity: 0.85,          // cuerpo visible
+                  depthWrite: false,      // evita z-fighting
+                  blending: THREE.AdditiveBlending
                 });
                 tube = new THREE.Mesh(geo, mat);
                 tube.userData.lcht = info.lcht;


### PR DESCRIPTION
### **User description**
## Summary
- Incrementa la intensidad global de los tubos y sus luces asociadas
- Cambia el material de los tubos iluminados a MeshBasicMaterial con blending aditivo

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d968c0930832cbfad912eb9db0a37


___

### **PR Type**
Enhancement


___

### **Description**
- Increase global light intensity multipliers for illuminated tubes

- Switch tube material to MeshBasicMaterial with additive blending

- Enhance visual glow effects and transparency settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Light Constants"] --> B["Intensity Multiplier: 3.0 → 12.0"]
  A --> C["Base Light Intensity: 30 → 120"]
  D["Tube Material"] --> E["MeshStandardMaterial → MeshBasicMaterial"]
  E --> F["Add Additive Blending"]
  E --> G["Increase Opacity: 0.55 → 0.85"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Enhanced lighting constants and tube material properties</code>&nbsp; </dd></summary>
<hr>

index.html

<ul><li>Increase <code>LCHT_INTENSITY_MULT</code> from 3.0 to 12.0<br> <li> Increase <code>LCHT_LIGHT_INTENSITY</code> from 30 to 120<br> <li> Replace MeshStandardMaterial with MeshBasicMaterial for illuminated <br>tubes<br> <li> Add additive blending and adjust opacity/depth settings</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/182/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+7/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

