### PR TITLE
Use MeshStandardMaterial for LCHT tubes and guard emissive intensity

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,12 +807,17 @@ function initSkySphere() {
         const geo = new THREE.CylinderGeometry(0.4,0.4,len,8,1,true);
 
         const isBlack = info.color.equals(new THREE.Color(0x000000));
-        const mat = new THREE.MeshBasicMaterial({
-          color: info.color,
-          transparent:true,
-          opacity: isBlack ? 0.30 : 0.85,
-          depthWrite:false,
-          blending: isBlack ? THREE.NormalBlending : THREE.AdditiveBlending
+        const mat = new THREE.MeshStandardMaterial({
+          color:            info.color,      // color base del tubo
+          emissive:         info.color,      // el mismo color como emisión
+          emissiveIntensity: 0,              // se anima en runtime
+          roughness:        0.20,
+          metalness:        0.00,
+          transparent:      true,
+          opacity:          isBlack ? 0.30 : 1.00,
+          depthWrite:       false,
+          blending:         THREE.NormalBlending, // evita el “wash-out” blanco
+          toneMapped:       false                 // mantiene la viveza HDR
         });
 
         const tube = new THREE.Mesh(geo,mat);
@@ -2488,7 +2493,9 @@ function renderArchPanel(html){
                 const I = d.I0 * (1 - d.amp *
                         (1 + Math.cos(2*Math.PI*d.f*t + d.phi)) / 2)
                         * LCHT_INTENSITY_MULT;
-                o.material.emissiveIntensity = I;
+                if (o.material && o.material.emissiveIntensity !== undefined){
+                  o.material.emissiveIntensity = I;
+                }
                 if(o.userData.pointLight) o.userData.pointLight.intensity = I * 10;
               }
             });


### PR DESCRIPTION
### **User description**
## Summary
- Use `MeshStandardMaterial` to render LCHT tubes with emissive color, HDR-friendly blending, and runtime-controlled opacity.
- Safeguard `animate()` by checking material before setting `emissiveIntensity`.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dc9904d0c832c8f9ce6f2d2e50d9e


___

### **PR Type**
Enhancement


___

### **Description**
- Replace MeshBasicMaterial with MeshStandardMaterial for LCHT tubes

- Add HDR-friendly emissive properties and tone mapping control

- Guard emissiveIntensity animation with material property check

- Improve visual quality with roughness and metalness settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MeshBasicMaterial"] --> B["MeshStandardMaterial"]
  B --> C["Emissive Properties"]
  B --> D["HDR Tone Mapping"]
  E["Animation Function"] --> F["Material Guard Check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Upgrade LCHT material system and animation safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace MeshBasicMaterial with MeshStandardMaterial for LCHT tubes<br> <li> Add emissive color, roughness, metalness, and HDR tone mapping <br>properties<br> <li> Change blending mode from AdditiveBlending to NormalBlending<br> <li> Add safety check for material.emissiveIntensity in animation function</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/184/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

