### PR TITLE
Update colorForPerm implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -698,13 +698,33 @@ function initSkySphere() {
     let isLCHT     = false;
     let lchtPrevBg = null;          // guarda/restaura el fondo al salir
 
-    /* color determinista = mismo que la permutación                    */
-    function colorForPerm(pa){
-      const idx = pa[ attributeMapping[1] ];                // 1–5
-      const val = getColor(idx);
-      return Array.isArray(val)
-        ? new THREE.Color(val[0]/255, val[1]/255, val[2]/255)
-        : new THREE.Color(val);
+    /* color determinista = exactamente el mismo que la permutación en BUILD */
+    function colorForPerm (pa) {
+      const idx = pa[ attributeMapping[1] ];         // 1-5
+
+      /* 1) ­— override manual, si existe */
+      if (manualOverride[idx]) {
+        return new THREE.Color( manualOverride[idx] );
+      }
+
+      /* 2) ­— modo legacy (patrón 0) */
+      if (activePatternId === 0) {
+        const rgb = paletteRGB[idx - 1] || [255, 255, 255];
+        return new THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
+      }
+
+      /* 3) ­— patrones 1-11 (idéntica lógica que BUILD) */
+      const sig  = computeSignature(pa);
+      const slot = lehmerRank(pa) % 12;
+
+      let [hI, sI, vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
+      sI = (sI * PHI_S) % 12;
+      vI = (vI * PHI_V) % 12;
+
+      const { h, s, v } = idxToHSV(hI, sI, vI);
+      const rgb = ensureContrastRGB( hsvToRgb(h, s, v) );
+
+      return new THREE.Color(rgb[0] / 255, rgb[1] / 255, rgb[2] / 255);
     }
 
     /* ═════════════ ACTUALIZA LCHT (reglas “tubos que se escapan”) ═════════════


### PR DESCRIPTION
### **User description**
## Summary
- Replace colorForPerm to match BUILD's deterministic color logic with overrides, legacy palette handling, and pattern-based computation.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dcbac0dcc832ca728af8642f58a43


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `colorForPerm` function with deterministic color logic

- Add manual override support for color customization

- Implement legacy palette handling for pattern 0

- Add pattern-based computation matching BUILD's logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["colorForPerm function"] --> B["Manual Override Check"]
  B --> C["Legacy Pattern 0"]
  B --> D["Patterns 1-11"]
  C --> E["RGB Palette Colors"]
  D --> F["Signature Computation"]
  F --> G["HSV to RGB Conversion"]
  E --> H["THREE.Color Output"]
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Enhanced colorForPerm with deterministic BUILD logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace simple <code>colorForPerm</code> implementation with comprehensive logic<br> <li> Add manual override support and legacy palette handling<br> <li> Implement pattern-based color computation with signature and ranking<br> <li> Add HSV to RGB conversion with contrast enhancement</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/185/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+27/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

