### PR TITLE
Tune LCHT tube lighting and material

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,8 +506,8 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let isFRBN    = false;
     const SKY_R = 250;
     /* Intensidad global para los tubos encendidos (≥ 1) */
-    const LCHT_INTENSITY_MULT = 12.0;   // ← antes 3.0
-    const LCHT_LIGHT_INTENSITY = 120;   // ← antes 30
+    const LCHT_INTENSITY_MULT = 2.0;   // ← antes 12.0
+    const LCHT_LIGHT_INTENSITY = 20;   // ← antes 120
 
 
 /* ──────────────────────────────────────────────────────────────
@@ -807,26 +807,33 @@ function initSkySphere() {
         const geo = new THREE.CylinderGeometry(0.4,0.4,len,8,1,true);
 
         const isBlack = info.color.equals(new THREE.Color(0x000000));
-        const mat = new THREE.MeshBasicMaterial({
-          color: info.color,
-          transparent:true,
-          opacity: isBlack ? 0.30 : 0.85,
-          depthWrite:false,
-          blending: isBlack ? THREE.NormalBlending : THREE.AdditiveBlending
-        });
 
-        const tube = new THREE.Mesh(geo,mat);
-        tube.position.copy(p1.clone().add(p2).multiplyScalar(0.5));
-        tube.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0),dir.normalize());
+        /* — material idéntico al de las permutaciones — */
+        const matProps = {
+          color: info.color.clone(),
+          shininess: 50,
+          dithering: true
+        };
+        if (isBlack){
+          matProps.opacity     = 0.30;
+          matProps.transparent = true;
+        }
+        const mat = new THREE.MeshPhongMaterial(matProps);
+
+        /* — geometría + orientación — */
+        const tube = new THREE.Mesh(geo, mat);
+        tube.position.copy( p1.clone().add(p2).multiplyScalar(0.5) );
+        tube.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0), dir.normalize());
         tube.userData.lcht = info.lcht;
         lichtGroup.add(tube);
 
-        /* luz puntual solo si el tramo no está en negro */
-        if(!isBlack){
+        /* — luz puntual MUCHO más baja (no deslumbra) — */
+        if (!isBlack){
           const pt = new THREE.PointLight(
-            info.color,
+            info.color.clone(),
             LCHT_LIGHT_INTENSITY * info.lcht.I0,
-            cubeSize*2, 2
+            cubeSize * 1.5,
+            2
           );
           pt.position.copy(tube.position);
           tube.userData.pointLight = pt;


### PR DESCRIPTION
### **User description**
## Summary
- Soften LCHT effect by decreasing global intensity and point light strength
- Switch tube rendering to MeshPhong with optional transparency for black tubes and softer point lights

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd03a1348832ca67986cae767294d


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce LCHT lighting intensity from 12.0 to 2.0

- Lower point light strength from 120 to 20

- Switch tube material from MeshBasic to MeshPhong

- Add transparency support for black tubes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LCHT Parameters"] --> B["Reduce Intensity"]
  A --> C["Lower Light Strength"]
  D["Tube Material"] --> E["MeshBasic to MeshPhong"]
  E --> F["Add Transparency"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>LCHT lighting parameters and material upgrade</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Reduce LCHT_INTENSITY_MULT from 12.0 to 2.0<br> <li> Lower LCHT_LIGHT_INTENSITY from 120 to 20<br> <li> Replace MeshBasicMaterial with MeshPhongMaterial for tubes<br> <li> Add shininess and dithering properties to tube materials<br> <li> Implement conditional transparency for black tubes<br> <li> Adjust point light distance calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/186/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+23/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

