### PR TITLE
Remove point lights and simplify tube materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,10 +505,6 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let skySphere = null;
     let isFRBN    = false;
     const SKY_R = 250;
-    /* Intensidad global para los tubos encendidos (≥ 1) */
-    const LCHT_INTENSITY_MULT = 2.0;   // ← antes 12.0
-    const LCHT_LIGHT_INTENSITY = 20;   // ← antes 120
-
 
 /* ──────────────────────────────────────────────────────────────
  *  initSkySphere — FRBN con micro-ruido “blue-noise” y highp
@@ -811,7 +807,7 @@ function initSkySphere() {
         /* — material idéntico al de las permutaciones — */
         const matProps = {
           color: info.color.clone(),
-          shininess: 50,
+          shininess: 0,          // ← sin brillo especular
           dithering: true
         };
         if (isBlack){
@@ -827,18 +823,7 @@ function initSkySphere() {
         tube.userData.lcht = info.lcht;
         lichtGroup.add(tube);
 
-        /* — luz puntual MUCHO más baja (no deslumbra) — */
-        if (!isBlack){
-          const pt = new THREE.PointLight(
-            info.color.clone(),
-            LCHT_LIGHT_INTENSITY * info.lcht.I0,
-            cubeSize * 1.5,
-            2
-          );
-          pt.position.copy(tube.position);
-          tube.userData.pointLight = pt;
-          lichtGroup.add(pt);
-        }
+        // ya no hay luz puntual separada
       });
     }
     /* ═════════════════ FIN BLOQUE ACTUALIZADO ═════════════════ */
@@ -2492,11 +2477,11 @@ function renderArchPanel(html){
             lichtGroup.children.forEach(o=>{
               const d = o.userData.lcht;
               if(d){
+                // solo modulamos un leve “emissive” sobre el propio material
                 const I = d.I0 * (1 - d.amp *
-                        (1 + Math.cos(2*Math.PI*d.f*t + d.phi)) / 2)
-                        * LCHT_INTENSITY_MULT;
-                o.material.emissiveIntensity = I;
-                if(o.userData.pointLight) o.userData.pointLight.intensity = I * 10;
+                        (1 + Math.cos(2*Math.PI*d.f*t + d.phi)) / 2);
+                o.material.emissive        = o.material.color.clone();
+                o.material.emissiveIntensity = I * 0.15;  // suave, sin deslumbrar
               }
             });
           }


### PR DESCRIPTION
### **User description**
## Summary
- drop PointLight usage and associated constants
- set tube material shininess to 0, maintaining opacity for dark tubes
- animate loop now modulates only material emissive intensity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd383bc90832c83924fc31e9235c9


___

### **PR Type**
Enhancement


___

### **Description**
- Remove point lights from tube lighting system

- Simplify tube materials by setting shininess to 0

- Replace point light animation with emissive material modulation

- Reduce visual complexity and improve performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Point Light System"] -- "removed" --> B["Simplified Tubes"]
  C["Shininess: 50"] -- "changed to" --> D["Shininess: 0"]
  E["Point Light Animation"] -- "replaced with" --> F["Emissive Material Animation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Simplify lighting system and materials</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Remove point light constants <code>LCHT_INTENSITY_MULT</code> and <br><code>LCHT_LIGHT_INTENSITY</code><br> <li> Set tube material shininess from 50 to 0<br> <li> Remove point light creation and attachment to tubes<br> <li> Replace point light animation with emissive material modulation</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/187/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+6/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

