### PR TITLE
Expand shell limits for LCHT segments

### DIFF
--- a/index.html
+++ b/index.html
@@ -733,11 +733,14 @@ function initSkySphere() {
       const collisions = new Set();   // keys duplicados → negro
       const step       = cubeSize / 5;
 
-      function inBounds(x, y, z){        // 5×5×5 → 0…4 inclusive
-        return x >= 0 && x <= 4 &&
-               y >= 0 && y <= 4 &&
-               z >= 0 && z <= 4;
-      }
+      /* ——————————————— límites núcleo / concha ——————————————— */
+      const LIM = 5;                          // hasta 5 celdas fuera del 0-4
+      function inCore (x,y,z){ return x>=0   && x<=4   &&
+                                      y>=0   && y<=4   &&
+                                      z>=0   && z<=4;  }
+      function inShell(x,y,z){ return x>=-LIM && x<=4+LIM &&
+                                      y>=-LIM && y<=4+LIM &&
+                                      z>=-LIM && z<=4+LIM; }
 
       /* === 1) recopila tramos de todas las permutaciones ==================== */
       const perms = Array.from(document.getElementById('permutationList').selectedOptions)
@@ -763,11 +766,14 @@ function initSkySphere() {
         const phi  = 2*Math.PI*((r%360)/360);
 
         function addSeg(x1, y1, z1,  x2, y2, z2){
-          if(!inBounds(x1,y1,z1) || !inBounds(x2,y2,z2)) return;   // fuera de la grilla → descarta
+          // al menos uno de los extremos debe caer dentro del núcleo 5×5×5
+          if(!inShell(x1,y1,z1) || !inShell(x2,y2,z2)) return;   // fuera de la concha
+          if(!inCore (x1,y1,z1) && !inCore (x2,y2,z2)) return;   // ambos fuera
+
           const key = tubeKey(x1,y1,z1,x2,y2,z2);
-          if(litInfo.has(key))  collisions.add(key);
-          else litInfo.set(key, { color: col.clone(),
-                                  lcht : { I0, amp, f: freq, phi } });
+          if(litInfo.has(key)) collisions.add(key);
+          else litInfo.set(key,{ color: col.clone(),
+                                 lcht : { I0, amp, f: freq, phi } });
         }
 
         /* eje vertical (L tramos) */
@@ -836,24 +842,22 @@ function initSkySphere() {
         const R_NODE = 0.60;   // tamaño del cubo-nudo (vértice con ≥3 aristas)
 
         function makeEdge(x1,y1,z1, x2,y2,z2, neonCol){
-          if(!inBounds(x2,y2,z2)) return;          // ahora nunca sale del 5×5×5
+          if(!inShell(x2,y2,z2)) return;          // seguimos limitando a la concha
 
           const k = tubeKey(x1,y1,z1, x2,y2,z2);
-          if(litInfo.has(k) || collisions.has(k)) return;   // ya existe algo ahí
+          if(litInfo.has(k) || collisions.has(k)) return;
 
           const dir = new THREE.Vector3(x2-x1, y2-y1, z2-z1);
           const len = step * dir.length();
           const geo = new THREE.CylinderGeometry(0.35, 0.35, len, 8, 1, true);
 
-          /* —— color neón, opaco —— */
-          const hsl   = {}; neonCol.getHSL(hsl);
-          neonCol.setHSL(hsl.h, 1, Math.min(0.7, hsl.l + 0.2));   // S = 100 %, +lum.
+          /* — mismo “neón” opaco — */
+          const hsl = {}; neonCol.getHSL(hsl);
+          neonCol.setHSL(hsl.h, 1, Math.min(0.7, hsl.l + 0.2));
 
-          const mat = new THREE.MeshPhongMaterial({
-            color      : neonCol,
-            shininess  : 0,
-            dithering  : true          // sin transparencia en ningún caso
-          });
+          const mat = new THREE.MeshPhongMaterial({ color: neonCol,
+                                                    shininess: 0,
+                                                    dithering: true });
 
           const m   = new THREE.Mesh(geo, mat);
           const p1  = new THREE.Vector3((x1-2)*step, (y1-2)*step, (z1-2)*step);


### PR DESCRIPTION
### **User description**
## Summary
- allow light tube segments that extend outside the 5×5×5 core as long as at least one endpoint remains inside
- adjust edge filler generation to respect the new shell boundaries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e445875e0832ca6bb55f9a47f688f


___

### **PR Type**
Enhancement


___

### **Description**
- Expand shell limits for light tube segments beyond 5×5×5 core

- Allow segments extending outside core if one endpoint remains inside

- Adjust edge filler generation to respect new shell boundaries

- Refactor bounds checking with separate core and shell functions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["5×5×5 Core"] --> B["Extended Shell"]
  B --> C["Segment Validation"]
  C --> D["Edge Filler Generation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Expand segment boundaries and validation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace single <code>inBounds</code> function with separate <code>inCore</code> and <code>inShell</code> <br>functions<br> <li> Expand shell limits to allow segments 5 cells outside the 0-4 core <br>range<br> <li> Update segment validation to require at least one endpoint in core<br> <li> Modify edge filler generation to respect new shell boundaries</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/193/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+23/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

