### PR TITLE
feat: add deterministic gradient to LCHT tubes

### DIFF
--- a/index.html
+++ b/index.html
@@ -830,16 +830,36 @@ function buildLCHT() {
     const p2  = new THREE.Vector3((x2 - 2) * step, (y2 - 2) * step, (z2 - 2) * step);
     const dir = new THREE.Vector3().subVectors(p2, p1);
     const len = dir.length();
+    const tubePos = p1.clone().add(p2).multiplyScalar(0.5);
 
     const geo = new THREE.CylinderGeometry(0.4, 0.4, len, 8, 1, true);
-    const mat = new THREE.MeshPhongMaterial({
-      color: info.color,
-      shininess: 0,
-      dithering: true
+    const gVec   = new THREE.Vector3(1, PHI2, PHI2 * PHI2).normalize();
+    const Pgrad  = 5 * step;
+    const colA   = info.color.clone();
+    const colB   = collisions.has(key) ? new THREE.Color(0x000000)
+                                       : colA.clone().offsetHSL(0.33, 0, 0);
+    geo.setAttribute('color',
+      new THREE.Float32BufferAttribute(
+        geo.attributes.position.array.map((_, i) => {
+          if (i % 3 !== 2) return 0;
+          const pos = new THREE.Vector3(
+            geo.attributes.position.array[i - 2],
+            geo.attributes.position.array[i - 1],
+            geo.attributes.position.array[i]
+          ).add(tubePos);
+          const u = (pos.dot(gVec) / Pgrad + sceneSeed / 360) % 1;
+          const mix = colA.clone().lerp(colB, u);
+          return [mix.r, mix.g, mix.b];
+        }).flat(), 3)
+    );
+
+    const mat = new THREE.MeshBasicMaterial({
+      vertexColors: true,
+      side: THREE.DoubleSide
     });
 
     const tube = new THREE.Mesh(geo, mat);
-    tube.position.copy(p1.clone().add(p2).multiplyScalar(0.5));
+    tube.position.copy(tubePos);
     tube.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.normalize());
     tube.userData.lcht = info.lcht;
     lichtGroup.add(tube);


### PR DESCRIPTION
### **User description**
## Summary
- add deterministic vertex color gradients to LCHT tubes
- render tubes with MeshBasicMaterial using vertex colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e7bc2ae7c832caf9ac73d6d66a5e9


___

### **PR Type**
Enhancement


___

### **Description**
- Add deterministic vertex color gradients to LCHT tubes

- Replace MeshPhongMaterial with MeshBasicMaterial for vertex colors

- Implement gradient calculation using golden ratio and scene seed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Tube Geometry"] --> B["Calculate Gradient Vector"]
  B --> C["Generate Vertex Colors"]
  C --> D["Apply MeshBasicMaterial"]
  D --> E["Render Tubes with Gradients"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add vertex color gradients to tubes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace MeshPhongMaterial with MeshBasicMaterial using vertex colors<br> <li> Add deterministic gradient calculation using golden ratio constant<br> <li> Implement color interpolation between base color and offset variant<br> <li> Calculate tube position for gradient mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/200/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+25/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

