### PR TITLE
Add deterministic gradient for LCHT tubes

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,6 +711,31 @@ function tubeKey(x1, y1, z1, x2, y2, z2) {
   return (a < b) ? `${a}|${b}` : `${b}|${a}`;
 }
 
+/* -----------------------------------------------------------
+ * Aplícale un gradiente determinista a un tubo (Mesh cylinder)
+ * ----------------------------------------------------------- */
+function applyGradient(mesh, baseColor){
+  const geo   = mesh.geometry;
+  const pos   = geo.getAttribute('position');
+  const n     = pos.count;
+  const cols  = new Float32Array(n * 3);
+
+  const C0 = baseColor.clone();               // color A
+  const C1 = baseColor.clone().offsetHSL(0.33, 0, 0); // color B (+120°)
+
+  mesh.updateMatrixWorld(true);               // pos/quat ya fijados
+  for(let i=0; i<n; i++){
+    const v = new THREE.Vector3().fromBufferAttribute(pos, i)
+                                 .applyMatrix4(mesh.matrixWorld);
+    const u = ((v.dot(G_VEC) / P_GRAD) + sceneSeed/360) % 1;  // 0-1
+    const c = C0.clone().lerp(C1, u);            // mix A→B
+    cols[i*3]     = c.r;
+    cols[i*3 + 1] = c.g;
+    cols[i*3 + 2] = c.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(cols, 3));
+}
+
 function buildLCHT() {
   /* ── limpiar escena previa ─────────────────────────────── */
   if (lichtGroup) {
@@ -832,16 +857,15 @@ function buildLCHT() {
     const len = dir.length();
 
     const geo = new THREE.CylinderGeometry(0.4, 0.4, len, 8, 1, true);
-    const mat = new THREE.MeshPhongMaterial({
-      color: info.color,
-      shininess: 0,
-      dithering: true
-    });
-
+    const mat = new THREE.MeshBasicMaterial({ vertexColors:true, side:THREE.DoubleSide });
     const tube = new THREE.Mesh(geo, mat);
     tube.position.copy(p1.clone().add(p2).multiplyScalar(0.5));
     tube.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dir.normalize());
     tube.userData.lcht = info.lcht;
+
+    /* ← nuevo gradiente determinista */
+    applyGradient(tube, info.color);
+
     lichtGroup.add(tube);
   });
 }
@@ -892,6 +916,10 @@ function buildLCHT() {
     const GOLD = 137.50776405003785;      // ángulo áureo
     /*  razón áurea al cuadrado  ≈ 2.618…  */
     const PHI2 = 2.618033988749895;
+    /* === GRADIENTE GLOBAL DETERMINISTA (Rozendaal-like) ================ */
+    const G_VEC  = new THREE.Vector3(1, PHI2, PHI2*PHI2).normalize(); // dirección ∇φ
+    const P_GRAD = 5 * (cubeSize/5);   // periodo = 5 celdas (≈ 30 unid.)
+    /* ==================================================================== */
     /* ——— salto coprimo con 144: barre los 144 valores de H ——— */
     const PHI_H = 89;             // 89 ≡ 144 / φ  (gcd 89,144 = 1)
     /* ——— saltos coprimos para los 12 niveles de S y V ——— */


### PR DESCRIPTION
### **User description**
## Summary
- Introduce deterministic gradient constants and utility function
- Render LCHT tubes with vertex-colored gradient

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e800d1210832c9eaace7923a4b881


___

### **PR Type**
Enhancement


___

### **Description**
- Add deterministic gradient rendering for LCHT tubes

- Replace solid color materials with vertex-colored gradients

- Implement gradient utility function with golden ratio constants

- Apply HSL color offset for gradient variation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LCHT Tube Creation"] --> B["Apply Gradient Function"]
  B --> C["Calculate Vertex Colors"]
  C --> D["Set Vertex Color Material"]
  E["Golden Ratio Constants"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Implement deterministic gradient for LCHT tubes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>applyGradient()</code> function for deterministic tube coloring<br> <li> Replace <code>MeshPhongMaterial</code> with <code>MeshBasicMaterial</code> using vertex colors<br> <li> Define golden ratio-based gradient constants (<code>G_VEC</code>, <code>P_GRAD</code>)<br> <li> Apply HSL color offset for gradient variation in tubes</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/201/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+34/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

