### PR TITLE
Desactiva oscurecido por colisión

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,10 +815,10 @@ function buildLCHT() {
   });
 
   /* ── colisiones → negro + sin luz ───────────────────────── */
-  collisions.forEach(k => {
-    const d = litInfo.get(k);
-    if (d) { d.color.set(0x000000); d.lcht.I0 = 0; }
-  });
+  // collisions.forEach(k => {
+  //   const d = litInfo.get(k);
+  //   if (d) { d.color.set(0x000000); d.lcht.I0 = 0; }
+  // });
 
   /* ── geometría final  ·  cada arista → varios segmentos coloreados ── */
   litInfo.forEach((info, key) => {
@@ -839,10 +839,7 @@ function buildLCHT() {
     for(let s = 0; s < SEG; s++){
       const mid = p1.clone().addScaledVector(dN, (s + 0.5) * hSeg);
 
-      /* colisión ⇒ negro, si no → campo volumétrico */
-      const col = (info.lcht.I0 === 0)
-                    ? new THREE.Color(0x000000)
-                    : colorFromVolume(mid);
+      const col = colorFromVolume(mid);   // sin pruebas de I0
 
       const geo = new THREE.CylinderGeometry(0.4, 0.4, hSeg, 8, 1, true);
       const mat = new THREE.MeshPhongMaterial({


### PR DESCRIPTION
### **User description**
## Summary
- evita que los tubos compartidos se oscurezcan al comentar el bloqueo de colisiones
- asigna color de sub-cilindros solo con `colorFromVolume`

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e8fc643ac832c984c96d4514bb90c


___

### **PR Type**
Enhancement


___

### **Description**
- Disables collision darkening effect by commenting out collision handling code

- Simplifies color assignment to use only `colorFromVolume` function

- Removes conditional color logic based on collision detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Collision Detection"] -- "commented out" --> B["Color Assignment"]
  B -- "simplified to" --> C["colorFromVolume only"]
  D["Conditional Logic"] -- "removed" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Remove collision-based color darkening logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Comments out collision detection code that darkens tubes<br> <li> Removes conditional color assignment based on collision state<br> <li> Simplifies color logic to use only <code>colorFromVolume</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/204/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

