### PR TITLE
Consolidate engine controls into single cycle button

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,16 +53,7 @@
   #uploadConfigButton   { position:fixed; right:10px; bottom:130px;  }   /* Load JSON */
   #exportEmbedButton    { position:fixed; right:10px; bottom:170px;  }   /* Save JSON */
   #archDescButton       { position:fixed; right:10px; bottom:210px;  }   /* Architectural Description */
-  #randomConfigButton   { position:fixed; left:10px; bottom:130px;  }   /* BUILD  */
    #certButton           { position:fixed; right:10px; bottom:30px; }   /* Edition Certificate */
-  /* === FRBN toggle === */
-#frbnWrap { position:fixed; left:10px; bottom:90px; z-index:260; }
-#frbnButton { position:relative; }  /* dentro del wrap */
-#frbnInfoButton{
-  position:absolute; top:-6px; right:-6px;
-  padding:2px 6px; font-size:10px; opacity:.9;
-  background:rgba(255,255,255,0.2);
-}
 
   #saveImageButton { background:rgba(255,255,255,0.2); }
 
@@ -183,15 +174,20 @@
   #infoPanel section{ margin-bottom:18px; }
   #infoPanel hr{ border:none; border-top:1px dashed #aaa; margin:18px 0; }
   /* === LCHT toggle === */
-  #lchtWrap  { position:fixed; left:10px; bottom:50px; z-index:260; }
-  #lchtButton{ position:relative; }
 
   /* RE-LOCATE main minimal buttons */
   #patternButton      { position:fixed; left:10px;  top:10px;  }
   #perm120Button      { position:fixed; right:10px; top:10px;  bottom:auto; }   /* antes estaba abajo */
-  #randomConfigButton { position:fixed; left:10px;  bottom:130px; } /* BUILD */
-  #frbnWrap           { position:fixed; left:10px;  bottom:90px;  }
-  #lchtWrap           { position:fixed; left:10px;  bottom:50px;  }
+  #engineButton{
+    position:fixed; left:10px; bottom:90px;  /* mismo lugar que estaba FRBN */
+    cursor:none;
+    border:none; border-radius:4px;
+    padding:8px 12px; font-size:12px;
+    z-index:250;
+    background:rgba(255,255,255,0.12);
+    transition:background 0.2s;
+  }
+  #engineButton:hover{ background:rgba(255,255,255,0.20); }
   /* cursor-dot for minimal mode */
   .minDot{font-size:16px;line-height:16px;padding:0 4px;}
   </style>
@@ -211,16 +207,9 @@
   <button id="saveImageButton"    onclick="saveImage()">Save Image (A2)</button>
   <button id="exportEmbedButton"  onclick="exportEmbed()">Save JSON</button>
   <button id="archDescButton"     onclick="showArchitecturalDescription()">Architectural Description</button>
-  <button id="randomConfigButton" onclick="generateRandomConfigurationNoCollision()">BUILD</button>
+  <button id="engineButton" onclick="cycleEngine()">BUILD</button>
   <button id="perm120Button"      onclick="togglePerm120Panel()">120 Architectural Permutations</button>
-<div id="frbnWrap">
-  <button id="frbnButton" onclick="toggleFRBN()">FRBN</button>
-  <button id="frbnInfoButton" onclick="showFRBNInfo()" title="Information">i</button>
-</div>
   <button id="certButton" onclick="exportEditionCertificate()">Edition Certificate</button>
-  <div id="lchtWrap">
-    <button id="lchtButton" onclick="toggleLCHT()">LCHT</button>
-  </div>
   <button id="infoButton"       onclick="showInformation()">Information</button>
   <button id="btnDebugColors"
           style="position:fixed;bottom:180px;right:10px;z-index:260;display:none;"
@@ -510,6 +499,81 @@ document.getElementById('json-upload').addEventListener('change', function(event
       // >>> NUEVO:
       let S_global = 0; // término estructural para posiciones (Shift-Rank acoplado)
       let avgSceneRange = 0;          // 2 … 6  →  se usa como factor de velocidad
+
+      /* ─────────────────────────────────────────────
+       *   Motor única – ciclo: BUILD → FRBN → LCHT
+       * ──────────────────────────────────────────── */
+      let currentEngine = 'BUILD';   // estado inicial
+
+      function cycleEngine(){
+        if(currentEngine === 'BUILD'){
+          activateFRBN();
+        }else if(currentEngine === 'FRBN'){
+          activateLCHT();
+        }else{
+          activateBUILD();
+        }
+      }
+
+      /* --- BUILD (modo por defecto) ------------------------------- */
+      function activateBUILD(){
+        if(isFRBN)   deactivateFRBN();
+        if(isLCHT){                          // apaga LCHT sin regenerar
+          if(lichtGroup) lichtGroup.visible = false;
+          isLCHT = false;
+          if(lchtPrevBg) scene.background = lchtPrevBg.clone();
+        }
+        cubeUniverse.visible     = true;
+        permutationGroup.visible = true;
+        currentEngine = 'BUILD';
+        document.getElementById('engineButton').textContent = 'BUILD';
+      }
+
+      /* --- FRBN --------------------------------------------------- */
+      function activateFRBN(){
+        if(isFRBN) return;                   // ya estamos
+        if(isLCHT){                          // apaga LCHT si estaba activo
+          if(lichtGroup) lichtGroup.visible = false;
+          isLCHT = false;
+          if(lchtPrevBg) scene.background = lchtPrevBg.clone();
+        }
+        if(!skySphere) initSkySphere();
+        buildGanzfeld();
+        scene.background   = new THREE.Color(0xffffff);
+        skySphere.visible  = true;
+        cubeUniverse.visible     = false;
+        permutationGroup.visible = false;
+        isFRBN        = true;
+        currentEngine = 'FRBN';
+        document.getElementById('engineButton').textContent = 'FRBN';
+      }
+
+      /* --- LCHT --------------------------------------------------- */
+      function activateLCHT(){
+        if(isLCHT) return;
+        if(isFRBN) deactivateFRBN();         // apaga FRBN primero
+
+        isLCHT = true;
+        if(!cubeUniverse.userData.prevMat){
+          cubeUniverse.userData.prevMat = cubeUniverse.material;
+          cubeUniverse.material = new THREE.MeshLambertMaterial({
+            color: cubeUniverse.userData.prevMat.color,
+            transparent:true,
+            opacity:cubeUniverse.userData.prevMat.opacity,
+            side:cubeUniverse.userData.prevMat.side
+          });
+        }
+        if(!lchtPrevBg) lchtPrevBg = scene.background ? scene.background.clone() : null;
+        scene.background = new THREE.Color(0xf4f4f4);
+
+        buildLCHT();
+        if(lichtGroup) lichtGroup.visible = true;
+        cubeUniverse.visible     = false;
+        permutationGroup.visible = false;
+
+        currentEngine = 'LCHT';
+        document.getElementById('engineButton').textContent = 'LCHT';
+      }
 
       /* ─────────────────────────────
        *   FRBN  ·  deterministic Ganzfeld
@@ -1562,8 +1626,7 @@ function findCollisionFreeMapping(perms){
             if (!checkCollisionsInGroup(permutationGroup)){
               /* --- SOLO apagamos motores si así se pide ----------------------- */
               if (!keepEngine){
-                if (isFRBN) toggleFRBN();
-                if (isLCHT) toggleLCHT();
+                activateBUILD();
               }
               showPopup("¡Configuración sin colisiones encontrada!", 2000);
               return true;
@@ -1928,7 +1991,7 @@ function makePalette(){
       /* botones que permanecen visibles – cambian texto ↔ ⚫ */
       const dotIds=[
         'patternButton','perm120Button',
-        'randomConfigButton','frbnButton','lchtButton','toggleTextButton'
+        'engineButton','toggleTextButton'
       ];
       dotIds.forEach(id=>{
         const b=document.getElementById(id);
@@ -2543,6 +2606,11 @@ function renderArchPanel(html){
       camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,0.1,1000);
       camera.position.set(0,0,50);
       initRenderer();
+      renderer.domElement.addEventListener('click', e=>{
+        // evita disparar si se está clicando en un botón superpuesto
+        if(e.target !== renderer.domElement) return;
+        generateRandomConfigurationNoCollision(5000, /*keepEngine*/ true);
+      });
       controls=new THREE.OrbitControls(camera,renderer.domElement);
       controls.enableDamping=true; controls.dampingFactor=0.1; controls.enableZoom=true;
       document.getElementById('standardView').value = 'front';


### PR DESCRIPTION
## Summary
- Replace BUILD/FRBN/LCHT buttons with a single `engineButton` that cycles between modes.
- Add engine cycling logic and canvas click handler to regenerate configurations without switching modes.
- Update Minimal UI toggle to account for new engine control and clean up unused styles.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f42b75bc8832c9e56d3607f22b428