### PR TITLE
fix: preserve light background in LCHT

### DIFF
--- a/index.html
+++ b/index.html
@@ -1829,19 +1829,25 @@ function makePalette(){
       });
     }
 
-    function refreshAll(opts={rebuild:false}){
-      if(!opts.keepManual){              // por defecto se limpia
+    function refreshAll(opts = {rebuild:false}){
+      if(!opts.keepManual){            // por defecto se limpian colores manuales
         manualOverride = {};
       }
       if(opts.rebuild) updateScene(false);
-      rebuildSceneColours();   // ← nuevo paso
+
+      rebuildSceneColours();
       makePalette();
       applyPalette();
-      /* contrast-fix eliminado – 19-Jul-2025 */
-      updateBackground(false);
-      updateCubeColor(false);
+
+      /* Mientras LCHT está activo, NO toques el fondo ni las paredes
+         (evita que los patrones cromáticos los re-coloreen).        */
+      if (!isLCHT){
+        updateBackground(false);   // ← automático
+        updateCubeColor(false);    // ← automático
+      }
+
       if (isFRBN && skySphere) buildGanzfeld();   // mantiene FRBN sincronizado
-      rebuildLCHTIfActive();              // mantiene LCHT sincronizado
+      rebuildLCHTIfActive();                      // mantiene LCHT sincronizado
     }
     function onColourPick(idx,hex){
       manualOverride[idx]=hex;
@@ -1855,6 +1861,10 @@ function makePalette(){
       refreshAll({keepManual:false});   // reconstruye escena y pickers
     }
     function updateBackground(manual=true){
+      /* Si estamos en LCHT y la llamada NO es manual, salimos.
+         Esto conserva el fondo claro (#f4f4f4) fijado en toggleLCHT(). */
+      if (isLCHT && !manual) return;
+
       if (manual){
         bgOverride = document.getElementById("bgColor").value;
       }


### PR DESCRIPTION
### **User description**
## Summary
- avoid background and cube recolor when LCHT is active
- ignore automatic background updates while in LCHT

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c3d2910832c8b5569422a202704


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve light background when LCHT mode is active

- Prevent automatic background and cube recoloring during LCHT

- Add conditional checks to maintain LCHT visual consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LCHT Mode Active"] --> B["Skip Auto Updates"]
  B --> C["Preserve Light Background"]
  B --> D["Maintain Cube Colors"]
  E["Manual Updates"] --> F["Allow Changes"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Conditional LCHT background preservation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Added conditional checks to prevent automatic background/cube updates <br>in LCHT mode<br> <li> Modified <code>refreshAll()</code> to skip <code>updateBackground()</code> and <code>updateCubeColor()</code> <br>when <code>isLCHT</code> is true<br> <li> Enhanced <code>updateBackground()</code> with early return for non-manual calls <br>during LCHT<br> <li> Improved code formatting and added explanatory comments</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/210/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+17/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

