### PR TITLE
Allow FRBN and LCHT rebuilds without stopping engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,12 +203,12 @@
   <button id="randomConfigButton" onclick="generateRandomConfigurationNoCollision()">BUILD</button>
   <button id="perm120Button"      onclick="togglePerm120Panel()">120 Architectural Permutations</button>
 <div id="frbnWrap">
-  <button id="frbnButton" onclick="toggleFRBN()">FRBN</button>
+  <button id="frbnButton" onclick="buildAndStayFRBN()">FRBN</button>
   <button id="frbnInfoButton" onclick="showFRBNInfo()" title="Information">i</button>
 </div>
   <button id="certButton" onclick="exportEditionCertificate()">Edition Certificate</button>
   <div id="lchtWrap">
-    <button id="lchtButton" onclick="toggleLCHT()">LCHT</button>
+    <button id="lchtButton" onclick="buildAndStayLCHT()">LCHT</button>
   </div>
   <button id="infoButton"       onclick="showInformation()">Information</button>
   <button id="btnDebugColors"
@@ -909,6 +909,23 @@ function buildLCHT() {
       if (b) b.textContent = isLCHT ? 'LCHT ON' : 'LCHT';
     }
 
+    /* ══════════════════════════════════════════════════════════════
+     *  FRBN / LCHT  →  nueva configuración SIN salir del motor
+     * ═════════════════════════════════════════════════════════════ */
+    async function buildAndStayFRBN(){
+      /* -- asegúrate de estar dentro de FRBN -- */
+      if(!isFRBN) toggleFRBN();           // esto apaga LCHT si estuviera activo
+      await generateRandomConfigurationNoCollision(5000,{preserveEngine:true});
+      if(isFRBN && skySphere) buildGanzfeld();   // paleta sincronizada
+    }
+
+    async function buildAndStayLCHT(){
+      /* -- asegúrate de estar dentro de LCHT -- */
+      if(!isLCHT) toggleLCHT();           // esto apaga FRBN si estuviera activo
+      await generateRandomConfigurationNoCollision(5000,{preserveEngine:true});
+      rebuildLCHTIfActive();              // re-construye tubos con la nueva escena
+    }
+
     /* reconstruye LCHT si hay cambios de escena */
     function rebuildLCHTIfActive(){ if(isLCHT) buildLCHT(); }
 
@@ -1478,7 +1495,7 @@ function findCollisionFreeMapping(perms){
      *
      * No bloquea la UI gracias al pequeño await en cada iteración.
      */
-    async function generateRandomConfigurationNoCollision(MAX_TRIES = 5000){
+    async function generateRandomConfigurationNoCollision(MAX_TRIES = 5000, opts = {preserveEngine:false}){
       // Elegimos un patrón cromático aleatorio (1..11, evitando el legacy 0)
       const randPattern = Math.floor(Math.random() * 11) + 1;
 
@@ -1522,8 +1539,10 @@ function findCollisionFreeMapping(perms){
             // 5) Verificación final (por si acaso)
             const hasCol = checkCollisionsInGroup(permutationGroup);
             if (!hasCol) {
-              if (isFRBN) toggleFRBN();   // BUILD apaga FRBN
-              if (isLCHT) toggleLCHT();   // BUILD apaga LCHT
+              if(!opts.preserveEngine){          // ← sólo BUILD apaga motores
+                if (isFRBN) toggleFRBN();
+                if (isLCHT) toggleLCHT();
+              }
               showPopup("¡Configuración sin colisiones encontrada!", 2000);
               return true;
             }


### PR DESCRIPTION
### **User description**
## Summary
- Add buildAndStayFRBN and buildAndStayLCHT helpers to rebuild scenes while preserving engine state
- Update FRBN/LCHT buttons to use new wrappers
- Let generateRandomConfigurationNoCollision accept opts and respect `preserveEngine`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f89201f64832c928eb74c11bd2fc6


___

### **PR Type**
Enhancement


___

### **Description**
- Add `buildAndStayFRBN` and `buildAndStayLCHT` helper functions

- Update FRBN/LCHT buttons to use new rebuild wrappers

- Modify `generateRandomConfigurationNoCollision` to accept `preserveEngine` option

- Enable scene rebuilding while preserving engine state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTML Buttons"] --> B["buildAndStayFRBN/LCHT"]
  B --> C["generateRandomConfigurationNoCollision"]
  C --> D["preserveEngine option"]
  D --> E["Engine State Preserved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add engine-preserving rebuild functions for FRBN/LCHT</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Update FRBN and LCHT button onclick handlers to use new wrapper <br>functions<br> <li> Add <code>buildAndStayFRBN</code> and <code>buildAndStayLCHT</code> helper functions<br> <li> Modify <code>generateRandomConfigurationNoCollision</code> to accept options <br>parameter<br> <li> Add conditional engine state preservation logic based on <br><code>preserveEngine</code> flag</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/211/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

