### PR TITLE
Keep engine active after collision-free Play

### DIFF
--- a/index.html
+++ b/index.html
@@ -1546,8 +1546,9 @@ function findCollisionFreeMapping(perms){
             // 5) Verificación final (por si acaso)
             const hasCol = checkCollisionsInGroup(permutationGroup);
             if (!hasCol) {
-              if (isFRBN) toggleFRBN();   // BUILD apaga FRBN
-              if (isLCHT) toggleLCHT();   // BUILD apaga LCHT
+              /*  ▸ YA NO se desactiva el motor actual.
+               *    Si el usuario estaba en FRBN o LCHT, sigue allí.
+               *    BUILD sólo se activa cuando se pulsa explícitamente el botón BUILD. */
               showPopup("¡Configuración sin colisiones encontrada!", 2000);
               return true;
             }


### PR DESCRIPTION
### **User description**
## Summary
- Retain current FRBN/LCHT engine when generating collision-free configurations instead of toggling it off.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fd77d1b4c832c9cb83f1716c25c42


___

### **PR Type**
Enhancement


___

### **Description**
- Remove automatic engine deactivation after collision-free configuration generation

- Preserve user's current FRBN/LCHT engine state instead of toggling off

- Add explanatory comments about the behavioral change


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generate collision-free config"] --> B["Check for collisions"]
  B --> C["No collisions found"]
  C --> D["Show success popup"]
  D --> E["Keep engine active"]
  F["Previous: Auto-disable engine"] -.-> G["New: Preserve engine state"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Remove engine auto-deactivation after collision-free generation</code></dd></summary>
<hr>

index.html

<ul><li>Removed automatic FRBN/LCHT engine deactivation after successful <br>collision-free generation<br> <li> Added detailed Spanish comments explaining the behavioral change<br> <li> Preserved existing collision detection and popup notification logic</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/213/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

