### PR TITLE
feat: add central play handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -2562,12 +2562,40 @@ function renderArchPanel(html){
       renderer.outputEncoding = THREE.sRGBEncoding; // salida en sRGB → menos banding
       document.body.appendChild(renderer.domElement);
     }
+    /* ════════════════════════════════════════════════
+     *  CENTRAL CLICK / TAP  →  PLAY  (solo Minimal UI)
+     *  – equivale a pulsar el botón ▮playButton
+     *  – funciona con ratón o con dedo (touch)
+     *  – solo se activa cuando textsVisible === false
+     *    (modo Minimal UI)
+     * ═══════════════════════════════════════════════ */
+    function centralPlayHandler(evt){
+      if (textsVisible) return;                     // UI visible → ignore
+
+      // coordenadas del evento (mouse o touch)
+      const p = evt.touches && evt.touches.length ? evt.touches[0] : evt;
+      const x = p.clientX, y = p.clientY;
+
+      // región “central”: ±25 % del ancho y alto de la ventana
+      const cx = window.innerWidth  * 0.5;
+      const cy = window.innerHeight * 0.5;
+      if (
+        Math.abs(x - cx) < window.innerWidth  * 0.25 &&
+        Math.abs(y - cy) < window.innerHeight * 0.25
+      ){
+        evt.preventDefault();       // evita drag/zoom de OrbitControls
+        evt.stopPropagation();
+        generateRandomConfigurationNoCollision();   // ▶️   PLAY
+      }
+    }
     function init(){
       scene=new THREE.Scene();
       scene.background=new THREE.Color(0xffffff);
       camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,0.1,1000);
       camera.position.set(0,0,50);
       initRenderer();
+      renderer.domElement.addEventListener('click',      centralPlayHandler, false);
+      renderer.domElement.addEventListener('touchstart', centralPlayHandler, { passive:false });
       controls=new THREE.OrbitControls(camera,renderer.domElement);
       controls.enableDamping=true; controls.dampingFactor=0.1; controls.enableZoom=true;
       document.getElementById('standardView').value = 'front';


### PR DESCRIPTION
### **User description**
## Summary
- add central click/tap handler to trigger play when UI hidden
- connect handler to renderer click and touchstart events

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68905265756c832c95d88558ee7c5156


___

### **PR Type**
Enhancement


___

### **Description**
- Add central click/tap handler for play functionality

- Enable touch and mouse interaction in minimal UI mode

- Restrict activation to central 25% screen area

- Integrate with existing renderer and controls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Click/Touch"] --> B["centralPlayHandler()"]
  B --> C{"textsVisible?"}
  C -->|false| D["Check Central Region"]
  C -->|true| E["Ignore Event"]
  D --> F{"Within 25% Center?"}
  F -->|yes| G["Prevent Default & Play"]
  F -->|no| H["Allow Normal Behavior"]
  G --> I["generateRandomConfigurationNoCollision()"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Central play handler implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>centralPlayHandler()</code> function with touch/mouse support<br> <li> Implement central region detection (±25% of screen dimensions)<br> <li> Attach click and touchstart event listeners to renderer<br> <li> Add event prevention to avoid OrbitControls interference</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/215/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

