### PR TITLE
feat: merge permutation meshes into single volume

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <!-- Three .js + OrbitControls (una sola vez) -->
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/utils/BufferGeometryUtils.js"></script>
   <style>
   body {
     margin: 0;
@@ -969,6 +970,34 @@ function buildLCHT() {
     /* reconstruye LCHT si hay cambios de escena */
     function rebuildLCHTIfActive(){ if(isLCHT) buildLCHT(); }
 
+    // ────────────────────────────────────────────────────────────
+    //   ONE-VOLUME MODE  – funde todos los Mesh en un solo cuerpo
+    // ────────────────────────────────────────────────────────────
+    function combinePermutationsIntoSingleVolume() {
+      if (!permutationGroup || permutationGroup.children.length < 2) return;
+
+      const geos = [];
+      permutationGroup.children.forEach(mesh => {
+        if (!mesh.isMesh) return;
+        mesh.updateMatrix();                               // congela la transf.
+        const g = mesh.geometry.clone();
+        g.applyMatrix4(mesh.matrix);
+        geos.push(g);
+      });
+      if (!geos.length) return;
+
+      const mergedGeo = THREE.BufferGeometryUtils.mergeBufferGeometries(geos);
+      const mergedMat = permutationGroup.children[0].material.clone();
+
+      // limpia el grupo (libera memoria)
+      while (permutationGroup.children.length) {
+        const c = permutationGroup.children.pop();
+        if (c.isMesh) { c.geometry.dispose(); c.material.dispose(); }
+      }
+
+      permutationGroup.add(new THREE.Mesh(mergedGeo, mergedMat));
+    }
+
     /* Cambia al motor BUILD sin generar una nueva configuración */
     function switchToBuild(){
       if (isOFFNNG) toggleOFFNNG();   // ← NUEVO: asegura exclusividad
@@ -1913,6 +1942,7 @@ function makePalette(){
       }
 
       if (isFRBN && skySphere) buildGanzfeld();   // mantiene FRBN sincronizado
+      combinePermutationsIntoSingleVolume();   // ← NUEVO
       rebuildLCHTIfActive();                      // mantiene LCHT sincronizado
     }
     function onColourPick(idx,hex){


### PR DESCRIPTION
### **User description**
## Summary
- load BufferGeometryUtils to enable geometry merging
- add combinePermutationsIntoSingleVolume to fuse permutation meshes into a single mesh
- invoke combinePermutationsIntoSingleVolume during refreshAll for one-volume mode

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891b51b4030832cbfdb0aacfe52b74f


___

### **PR Type**
Enhancement


___

### **Description**
- Add BufferGeometryUtils library for geometry merging

- Implement single volume mode combining permutation meshes

- Integrate mesh fusion into scene refresh workflow

- Optimize memory usage by disposing old geometries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BufferGeometryUtils"] --> B["combinePermutationsIntoSingleVolume()"]
  B --> C["Clone & Transform Geometries"]
  C --> D["Merge into Single Mesh"]
  D --> E["Update permutationGroup"]
  F["refreshAll()"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add mesh merging with BufferGeometryUtils integration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add BufferGeometryUtils script import from Three.js CDN<br> <li> Implement <code>combinePermutationsIntoSingleVolume()</code> function for mesh <br>merging<br> <li> Integrate mesh combination into <code>refreshAll()</code> workflow<br> <li> Add geometry disposal for memory optimization</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/223/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

