### PR TITLE
feat: adapt OFFNNG background

### DIFF
--- a/index.html
+++ b/index.html
@@ -1946,18 +1946,20 @@ function makePalette(){
       cubeOverride   = null;
       refreshAll({keepManual:false});   // reconstruye escena y pickers
     }
-    function updateBackground(manual=true){
-      if (isOFFNNG && !manual) return;          // ← NUEVO
-      /* Si estamos en LCHT y la llamada NO es manual, salimos.
-         Esto conserva el fondo claro (#f4f4f4) fijado en toggleLCHT(). */
+    function updateBackground(manual = true){
+      // Si LCHT está activo y NO es una acción manual, no tocamos el fondo
       if (isLCHT && !manual) return;
 
       if (manual){
         bgOverride = document.getElementById("bgColor").value;
       }
-      const hex = manual ? bgOverride : hsvToHex(bgHSV);
+
+      // En llamadas no manuales usamos el color estructural calculado (bgHSV)
+      const hex = (manual && bgOverride) ? bgOverride : hsvToHex(bgHSV);
+
       scene.background = new THREE.Color(hex);
-      document.getElementById("bgColor").value = hex;
+      const input = document.getElementById("bgColor");
+      if (input) input.value = hex;
     }
 
     function updateCubeColor(manual=true){
@@ -3013,7 +3015,7 @@ void main(){
       applyOFFNNGQuality();
 
       offnngPrevBg   = scene.background ? scene.background.clone() : null;
-      scene.background = new THREE.Color(0x000000);   // ← fondo NEGRO por defecto en OFFNNG
+      updateBackground(false); // usa el fondo acoplado a BUILD / patrón / perms
 
       cubeUniverse.visible     = false;
       permutationGroup.visible = false;


### PR DESCRIPTION
### **User description**
## Summary
- remove OFFNNG guard in background updates and use calculated structural color for automatic calls
- use `updateBackground(false)` instead of forcing black when activating OFFNNG

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_689322fb9aac832cae95be5b45c108fc


___

### **PR Type**
Enhancement


___

### **Description**
- Remove OFFNNG guard in background updates

- Use calculated structural color for automatic calls

- Replace forced black background with adaptive background


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["updateBackground()"] --> B["Check manual flag"]
  B --> C["Use bgHSV for automatic calls"]
  C --> D["Apply to OFFNNG mode"]
  E["toggleOFFNNG()"] --> F["Call updateBackground(false)"]
  F --> G["Adaptive background instead of black"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Refactor OFFNNG background color handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Remove OFFNNG guard condition in <code>updateBackground()</code> function<br> <li> Modify background color logic to use structural <code>bgHSV</code> for non-manual <br>calls<br> <li> Replace hardcoded black background with <code>updateBackground(false)</code> in <br>OFFNNG mode<br> <li> Add null check for background color input element</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/235/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

