### PR TITLE
feat: remove rim attenuation in OFFNNG look

### DIFF
--- a/index.html
+++ b/index.html
@@ -3113,17 +3113,19 @@ void main(){
     const meanSig = selPerms.length ? (sumSig / (selPerms.length * 5)) : 6; // ~3..9
     const sigN = Math.max(0, Math.min(1, (meanSig - 3) / 6)); // 0..1
 
-    // —— LOOK base "Strong" (igual que antes) ——
+    // —— LOOK base "Strong" (anti-rim OFFNNG) ——
     U.uSMin.value      = 0.60;
-    U.uVMin.value      = 0.78;
+    U.uVMin.value      = 0.84;
     U.uSatGain.value   = 1.22;
-    U.uValGain.value   = 1.28;
-    U.uGammaV.value    = 0.60;
-    U.uExposure.value  = 1.85;
+    U.uValGain.value   = 1.30;
+    U.uGammaV.value    = 0.58;
+    U.uExposure.value  = 1.90;
     U.uDensity.value   = 0.70 - 0.05 * nr;
-    U.uEdgeBase.value  = 0.65;
-    U.uEdgeTintV.value = 0.72;
-    U.uEdgePow.value   = 1.6;
+
+    // Borde: no atenuar y con tinte claro mínimo
+    U.uEdgeBase.value  = 1.00;   // ← clave: elimina el “marco” oscuro
+    U.uEdgeTintV.value = 0.84;   // cara cercana nunca cae de V≈0.84
+    U.uEdgePow.value   = 1.2;    // transición más plana (sin hundir perímetro)
 
     // —— Bias por patrón (±10–15 %) + mezcla de ejes ≤ 0.3 ——
     const B = OFFNNG_PATTERN_BIAS[activePatternId] || OFFNNG_PATTERN_BIAS[1];


### PR DESCRIPTION
### **User description**
## Summary
- Eliminate rim darkening in OFFNNG by setting `U.uEdgeBase` to 1.0 and raising `U.uEdgeTintV`
- Tweak color parameters (`VMin`, `ValGain`, `GammaV`, `Exposure`) to keep colors vivid

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689391234d38832c97c8f47cece6b5b3


___

### **PR Type**
Enhancement


___

### **Description**
- Remove rim darkening effect in OFFNNG look by setting edge base to 1.0

- Adjust color parameters to maintain vivid appearance

- Modify edge tinting and power for flatter transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OFFNNG Look Settings"] --> B["Edge Base = 1.0"]
  A --> C["Color Parameter Adjustments"]
  B --> D["Eliminates Dark Rim"]
  C --> E["Maintains Vivid Colors"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>OFFNNG look edge attenuation removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Set <code>U.uEdgeBase</code> to 1.0 to eliminate dark rim effect<br> <li> Increased <code>U.uVMin</code>, <code>U.uValGain</code>, and <code>U.uExposure</code> values<br> <li> Adjusted <code>U.uEdgeTintV</code> and <code>U.uEdgePow</code> for better edge handling<br> <li> Updated comments to reflect anti-rim OFFNNG configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/236/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

