### PR TITLE
feat: use square tubes for LCHT edges

### DIFF
--- a/index.html
+++ b/index.html
@@ -898,14 +898,22 @@ function buildLCHT() {
 
       const col = colorFromVolume(mid);   // sin pruebas de I0
 
-      const geo = new THREE.CylinderGeometry(0.4, 0.4, hSeg, 8, 1, true);
+      // — Perfil cuadrado (lado = 0.8 ⇒ igual diámetro que el cilindro de r=0.4)
+      // — JOIN añade un pelín de solape para que las esquinas no “abran”
+      const SIDE = 0.8;
+      const JOIN = 0.02;
+
+      const geo = new THREE.BoxGeometry(SIDE, hSeg + JOIN, SIDE);
       const mat = new THREE.MeshPhongMaterial({
         color: col,
         shininess: 0,
-        dithering: true
+        dithering: true,
+        flatShading: true
       });
+
       const tube = new THREE.Mesh(geo, mat);
       tube.position.copy(mid);
+      // La Box está orientada a lo largo del eje Y; mantenemos el mismo alineamiento
       tube.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), dN);
 
       /* --- HSV original para animar color --- */


### PR DESCRIPTION
### **User description**
## Summary
- use box geometry to render LCHT edges with square profile
- add slight overlap and flat shading to prevent open seams

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893e570fb94832c8be60feeb374260e


___

### **PR Type**
Enhancement


___

### **Description**
- Replace cylindrical geometry with square tube profile for LCHT edges

- Add overlap and flat shading to prevent visual seams

- Maintain equivalent cross-sectional area with 0.8 side length


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CylinderGeometry"] --> B["BoxGeometry"]
  B --> C["Square Profile"]
  C --> D["Flat Shading"]
  D --> E["Seamless Rendering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Switch to square tube geometry for edges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace <code>CylinderGeometry</code> with <code>BoxGeometry</code> for square tube profile<br> <li> Add <code>JOIN</code> overlap constant to prevent visual gaps<br> <li> Enable <code>flatShading</code> material property for better appearance<br> <li> Maintain same positioning and orientation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/237/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

