### PR TITLE
Ensure renderer canvas fills viewport and deepen TMSL relief

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,8 +233,11 @@
     background:rgba(0,0,0,0.12);
     cursor:none; transition:background .2s;
   }
-  #playButton:hover{ background:rgba(0,0,0,0.20); }
-  </style>
+    #playButton:hover{ background:rgba(0,0,0,0.20); }
+
+    html,body{width:100%;height:100%;margin:0;overflow:hidden;}
+    canvas{display:block;width:100vw;height:100vh;}
+    </style>
 </head>
 <body>
   <div id="customCursor"></div>
@@ -2611,6 +2614,8 @@ function renderArchPanel(html){
     }
     function initRenderer(){
       renderer = new THREE.WebGLRenderer({antialias:true, preserveDrawingBuffer:true});
+      renderer.domElement.style.width  = "100%";
+      renderer.domElement.style.height = "100%";
       // CAP global: mejora FPS en todas las escenas
       const PR = Math.min(window.devicePixelRatio || 1, 1.25);
       renderer.setPixelRatio(PR);
@@ -3225,7 +3230,7 @@ void main(){
       scene.add(tmslGroup);
 
       /* constantes básicas */
-      const DEPTH = 2;                  // grosor total de la pared
+      const DEPTH = 10;                 // 5 × más relieve
       const GRID  = 5;                  // 5 × 5 relieves
       const BAR   = 1;                  // grosor de las vigas frontales
       const WALL  = cubeSize * 3;       // lado total (90 u si cubeSize = 30)


### PR DESCRIPTION
## Summary
- Stretch `<canvas>` and document elements to full viewport dimensions
- Force renderer DOM element to occupy 100% width/height after creation
- Increase TMSL wall depth to give stronger relief

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894faf6adf8832c97d8f48dc3e66beb