### PR TITLE
Enable shadows and orthographic camera for TMSL

### DIFF
--- a/index.html
+++ b/index.html
@@ -2616,11 +2616,15 @@ function renderArchPanel(html){
       renderer = new THREE.WebGLRenderer({antialias:true, preserveDrawingBuffer:true});
       renderer.domElement.style.width  = "100%";
       renderer.domElement.style.height = "100%";
-      // CAP global: mejora FPS en todas las escenas
       const PR = Math.min(window.devicePixelRatio || 1, 1.25);
       renderer.setPixelRatio(PR);
       renderer.setSize(window.innerWidth,window.innerHeight);
-      renderer.outputEncoding = THREE.sRGBEncoding; // sRGB → menos banding
+      renderer.outputEncoding = THREE.sRGBEncoding;
+
+      // ← NUEVO: sombras suaves para que el relieve se lea
+      renderer.shadowMap.enabled = true;
+      renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
       document.body.appendChild(renderer.domElement);
     }
     /* ════════════════════════════════════════════════
@@ -2693,7 +2697,12 @@ function renderArchPanel(html){
       animate();
     }
     function onWindowResize(){
-      camera.aspect=window.innerWidth/window.innerHeight; camera.updateProjectionMatrix();
+      if(isTMSL && tmslCamera){
+        setupTMSLCamera(tmslWallSize);
+      }else{
+        camera.aspect=window.innerWidth/window.innerHeight;
+        camera.updateProjectionMatrix();
+      }
       renderer.setSize(window.innerWidth,window.innerHeight);
     }
     function animate(){
@@ -2729,7 +2738,7 @@ function renderArchPanel(html){
           });
         }
         controls.update();
-        renderer.render(scene,camera);
+        renderer.render(scene, (isTMSL && tmslCamera) ? tmslCamera : camera);
       }
     
     /* ═══════ OFFNNG · VOLUMÉTRICO CONTINUO (v4 – shader) ═══════
@@ -3213,77 +3222,170 @@ void main(){
     let tmslPrevBg = null;
     let tmslPrevControls = true;
 
-    /*───────────────────────────────────────────────────────────────
-      SÓLO cambia la función buildTMSL() por ésta.
-      - Añade una pared blanca con 25 relieves “hacia adentro”
-        (5×5) sin color, únicamente profundidad.
-      - No toca el resto del motor TMSL ni otros engines.
-    ───────────────────────────────────────────────────────────────*/
-    function buildTMSL () {
+    // NUEVO: cámara/luz propias de TMSL + tamaño del muro
+    let tmslCamera = null;
+    let tmslLightGroup = null;
+    let tmslWallSize = cubeSize * 3; // se recalcula en buildTMSL por si cambias cubeSize
 
-      /* — limpia versión previa — */
+    function setupTMSLCamera(wallSize){
+      tmslWallSize = wallSize;
+      const margin = wallSize * 0.06;               // 6% de aire como en la foto
+      const halfH  = wallSize * 0.5 + margin;       // “alto” en unidades
+      const aspect = window.innerWidth / window.innerHeight;
+      const halfW  = halfH * aspect;
+
+      if(!tmslCamera){
+        tmslCamera = new THREE.OrthographicCamera(-halfW, halfW, halfH, -halfH, 0.1, 2000);
+      }else{
+        tmslCamera.left = -halfW;
+        tmslCamera.right =  halfW;
+        tmslCamera.top =   halfH;
+        tmslCamera.bottom = -halfH;
+        tmslCamera.updateProjectionMatrix();
+      }
+      tmslCamera.position.set(0,0,200);   // totalmente frontal (sin perspectiva)
+      tmslCamera.lookAt(0,0,0);
+    }
+
+    function makeEdgeShaderMaterial(hex){
+      const c = new THREE.Color(hex);
+      return new THREE.ShaderMaterial({
+        uniforms:{
+          uTint:      { value: new THREE.Color(c.r, c.g, c.b) },
+          uFeather:   { value: 0.18 },  // ancho del borde (0..0.5)
+          uStrength:  { value: 0.65 }   // intensidad del tinte
+        },
+        vertexShader: `
+      varying vec2 vUv;
+      void main(){
+        vUv = uv;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+      }
+    `,
+        fragmentShader: `
+      precision highp float;
+      varying vec2 vUv;
+      uniform vec3  uTint;
+      uniform float uFeather;
+      uniform float uStrength;
+      void main(){
+        // distancia al borde más cercano en UV
+        float d = min(min(vUv.x, 1.0 - vUv.x), min(vUv.y, 1.0 - vUv.y));
+        // g=1 en el borde, 0 hacia el centro
+        float g = smoothstep(uFeather, 0.0, d);
+        vec3 col = mix(vec3(1.0), uTint, g * uStrength);
+        gl_FragColor = vec4(col, 1.0);
+      }
+    `,
+        depthTest:true, depthWrite:true, side:THREE.FrontSide, transparent:false
+      });
+    }
+
+    function buildTMSL () {
+      // limpia versión previa
       if (tmslGroup) {
         tmslGroup.traverse(o => { if (o.isMesh) { o.geometry.dispose(); o.material.dispose(); } });
         scene.remove(tmslGroup);
       }
+      if (tmslLightGroup){
+        tmslLightGroup.traverse(o => { if (o.isLight) { /* nada */ } });
+        scene.remove(tmslLightGroup);
+        tmslLightGroup = null;
+      }
+
       tmslGroup = new THREE.Group();
       scene.add(tmslGroup);
 
-      /* constantes básicas */
-      const DEPTH = 10;                 // 5 × más relieve
-      const GRID  = 5;                  // 5 × 5 relieves
-      const BAR   = 1;                  // grosor de las vigas frontales
-      const WALL  = cubeSize * 3;       // lado total (90 u si cubeSize = 30)
-      const CELL  = (WALL - BAR * (GRID + 1)) / GRID;   // lado de cada hueco
+      // constantes “Tomaselli”
+      const DEPTH = 10;                 // profundidad del hueco
+      const GRID  = 5;                  // 5 × 5
+      const BAR   = 1;                  // grosor de vigas frontales
+      const WALL  = cubeSize * 3;       // tamaño total de la pared (≈90 si cubeSize=30)
+      const CELL  = (WALL - BAR * (GRID + 1)) / GRID;
 
-      /* plano trasero del relieve (base) */
+      // actualizar cámara ortográfica para que llene pantalla
+      setupTMSLCamera(WALL);
+
+      // MATERIALES: blanco que recibe y proyecta sombra (para leer el relieve)
+      const whiteStd = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.9, metalness: 0.0 });
+
+      // Plano trasero (visible por el hueco)
       const backGeo = new THREE.PlaneGeometry(WALL, WALL);
-      const backMat = new THREE.MeshLambertMaterial({
-        color: 0xffffff,
-        side : THREE.BackSide            // cara visible por el hueco
-      });
-      const back = new THREE.Mesh(backGeo, backMat);
-      back.position.set(0, 0, halfCube - DEPTH);        // 2 u detrás del frontal
+      const back = new THREE.Mesh(backGeo, whiteStd.clone());
+      back.material.side = THREE.BackSide;
+      back.position.set(0, 0, halfCube - DEPTH);
+      back.receiveShadow = true;
       tmslGroup.add(back);
 
-      /* vigas frontales blancas ─ enmarcan la cuadrícula */
-      const vMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
-
-      /* ─ verticales ─ */
+      // Vigas frontales (marco)
+      const vMat = whiteStd.clone();
       const vGeo = new THREE.BoxGeometry(BAR, WALL, DEPTH);
       for (let i = 0; i <= GRID; i++) {
         const x = -WALL / 2 + BAR / 2 + i * (CELL + BAR);
-        const v = new THREE.Mesh(vGeo, vMat);
+        const v = new THREE.Mesh(vGeo, vMat.clone());
         v.position.set(x, 0, halfCube - DEPTH / 2);
+        v.castShadow = true; v.receiveShadow = true;
         tmslGroup.add(v);
       }
-
-      /* ─ horizontales ─ */
       const hGeo = new THREE.BoxGeometry(WALL, BAR, DEPTH);
       for (let j = 0; j <= GRID; j++) {
         const y =  WALL / 2 - BAR / 2 - j * (CELL + BAR);
-        const h = new THREE.Mesh(hGeo, vMat);
+        const h = new THREE.Mesh(hGeo, vMat.clone());
         h.position.set(0, y, halfCube - DEPTH / 2);
+        h.castShadow = true; h.receiveShadow = true;
         tmslGroup.add(h);
       }
 
-      /* 25 cajetines hundidos (relieves) */
+      // Bisel cromático: alterna verde/rosa en patrón tablero
+      const TINT_A = "#bcd8c6";   // verde suave
+      const TINT_B = "#f4b6b1";   // rosa suave
+
+      // Huecos (caja hundida) + “marco cromático” como plano delgado al frente
       const recessGeo = new THREE.BoxGeometry(CELL, CELL, DEPTH - 0.2);
-      const recessMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
       for (let i = 0; i < GRID; i++) {
         for (let j = 0; j < GRID; j++) {
-
-          /* centro de cada hueco */
           const x = -WALL / 2 + BAR + CELL / 2 + i * (CELL + BAR);
           const y =  WALL / 2 - BAR - CELL / 2 - j * (CELL + BAR);
-          /* la cara frontal queda ~0.1 u por detrás de las vigas */
           const z = halfCube - DEPTH + (DEPTH - 0.2) / 2;
 
-          const recess = new THREE.Mesh(recessGeo, recessMat);
+          // caja hundida (blanca, con sombra)
+          const recess = new THREE.Mesh(recessGeo, whiteStd.clone());
           recess.position.set(x, y, z);
+          recess.castShadow = true; recess.receiveShadow = true;
           tmslGroup.add(recess);
+
+          // plano “bisel tintado” pegado al borde interior del hueco
+          const edgeGeo = new THREE.PlaneGeometry(CELL, CELL);
+          const tint = ((i + j) % 2 === 0) ? TINT_A : TINT_B;
+          const edge = new THREE.Mesh(edgeGeo, makeEdgeShaderMaterial(tint));
+          // apenas por delante del inicio del hueco para que no parpadee (z-fighting)
+          edge.position.set(x, y, halfCube - DEPTH + 0.02);
+          edge.renderOrder = 2; // que dibuje encima del fondo del hueco
+          tmslGroup.add(edge);
         }
       }
+
+      // LUCES propias de TMSL (sombras suaves, dirección desde arriba/izquierda)
+      tmslLightGroup = new THREE.Group();
+
+      const amb = new THREE.AmbientLight(0xffffff, 0.35);
+      tmslLightGroup.add(amb);
+
+      const key = new THREE.DirectionalLight(0xffffff, 0.95);
+      key.position.set(80, 120, 200);
+      key.castShadow = true;
+      key.shadow.mapSize.set(2048, 2048);
+      key.shadow.camera.near = 10;
+      key.shadow.camera.far  = 600;
+      key.shadow.normalBias  = 0.02;
+      tmslLightGroup.add(key);
+
+      const fill = new THREE.DirectionalLight(0xffffff, 0.35);
+      fill.position.set(-120, -80, 120);
+      fill.castShadow = false;
+      tmslLightGroup.add(fill);
+
+      scene.add(tmslLightGroup);
     }
 
     function toggleTMSL(){           /* se usa sólo internamente */
@@ -3299,10 +3401,9 @@ void main(){
         if (lichtGroup) lichtGroup.visible = false;
 
         tmslPrevBg        = scene.background ? scene.background.clone() : null;
-        scene.background  = new THREE.Color(0x000000);   // neutro absoluto
+        scene.background  = new THREE.Color(0xffffff);   // pared blanca realista
         tmslPrevControls  = controls.enabled;
-        controls.enabled  = false;                       // cámara fija
-        applyStandardView();                             // vista “front”
+        controls.enabled  = false;                       // cámara fija ortográfica
         isTMSL = true;
 
       } else {                      /* — SALIR — (lo hace BUILD) */
@@ -3310,6 +3411,10 @@ void main(){
           tmslGroup.traverse(o=>{ if(o.isMesh){o.geometry.dispose();o.material.dispose();}});
           scene.remove(tmslGroup);
           tmslGroup = null;
+        }
+        if (tmslLightGroup){
+          scene.remove(tmslLightGroup);
+          tmslLightGroup = null;
         }
         if (tmslPrevBg) scene.background = tmslPrevBg;
         controls.enabled = tmslPrevControls;


### PR DESCRIPTION
## Summary
- enable soft shadows in the renderer
- add orthographic camera, tinted-edge shader, and dedicated lights for TMSL mode
- update resize/render flow to use orthographic camera when TMSL is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689503c9cdd8832c8a7a2d06b8f3d989