### PR TITLE
feat: modular core utilities and persistent state store

### DIFF
--- a/core/colors.js
+++ b/core/colors.js
@@ -1,0 +1,87 @@
+// core/colors.js — utilidades puras de color (sin Three.js)
+export function rgbToHsv(r,g,b){
+  r/=255; g/=255; b/=255;
+  const max=Math.max(r,g,b), min=Math.min(r,g,b), d=max-min;
+  let h=0;
+  if(d){
+    if(max===r) h=((g-b)/d)%6;
+    else if(max===g) h=(b-r)/d+2;
+    else h=(r-g)/d+4;
+    h*=60; if(h<0) h+=360;
+  }
+  const s=max?d/max:0, v=max;
+  return [h,s,v];
+}
+
+export function hsvToRgb(h,s,v){
+  h = h % 360;
+  const c=v*s, x=c*(1-Math.abs((h/60)%2-1)), m=v-c;
+  let [r,g,b]=[0,0,0];
+  if(h<60){r=c;g=x;} else if(h<120){r=x;g=c;}
+  else if(h<180){g=c;b=x;} else if(h<240){g=x;b=c;}
+  else if(h<300){r=x;b=c;} else {r=c;b=x;}
+  return [(r+m)*255,(g+m)*255,(b+m)*255].map(v=>Math.round(v));
+}
+
+export function hsvToHex({h,s,v}){
+  const [r,g,b] = hsvToRgb(h,s,v);
+  const toHex = (n)=>'#'+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1);
+  // usamos THREE fuera; aquí devolvemos string #rrggbb sin depender de THREE
+  return toHex();
+}
+
+export function hexToRgb(hex){
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  const n = parseInt(m[1],16);
+  return [(n>>16)&255, (n>>8)&255, n&255];
+}
+
+// Lab rápido + ΔE CIE76 — idénticos a tu código
+export function rgbToLab(r,g,b){
+  const xyz=[r/255,g/255,b/255].map(v=>{
+    v=v>0.04045?((v+0.055)/1.055)**2.4:v/12.92;
+    return v*100;
+  });
+  const x=xyz[0]*0.4124+xyz[1]*0.3576+xyz[2]*0.1805;
+  const y=xyz[0]*0.2126+xyz[1]*0.7152+xyz[2]*0.0722;
+  const z=xyz[0]*0.0193+xyz[1]*0.1192+xyz[2]*0.9505;
+  const xyzN=[95.047,100.0,108.883];
+  const f= t=> t>0.008856 ? t**(1/3) : (7.787*t)+16/116;
+  const [fx,fy,fz]=[x,y,z].map((v,i)=>f(v/xyzN[i]));
+  return [116*fy-16, 500*(fx-fy), 200*(fy-fz)];
+}
+
+export function deltaE(lab1,lab2){
+  return Math.sqrt(
+    (lab1[0]-lab2[0])**2+
+    (lab1[1]-lab2[1])**2+
+    (lab1[2]-lab2[2])**2
+  );
+}
+
+// Lattice HSV 144×12×12 — índices → HSV reales
+export const H_STEPS  = 144;
+export const S_LEVELS = [...Array(12)].map((_,i)=>0.25 + 0.72*i/11);
+export const V_LEVELS = [...Array(12)].map((_,i)=>0.20 + 0.75*i/11);
+
+export function idxToHSV(hIdx,sIdx,vIdx){
+  const h = ((hIdx%H_STEPS)+H_STEPS)%H_STEPS;
+  return {
+    h: h * 360 / H_STEPS,
+    s: S_LEVELS[((sIdx%12)+12)%12],
+    v: V_LEVELS[((vIdx%12)+12)%12]
+  };
+}
+
+// Contraste mínimo contra fondo — misma lógica que tu ensureContrastRGB
+export const ΔE_BG_MIN = 22;
+export function ensureContrastRGB(rgb, bgRgb, deltaEMin = ΔE_BG_MIN){
+  let [h,s,v] = rgbToHsv(...rgb);
+  let tries = 0;
+  while (deltaE(rgbToLab(...rgb), rgbToLab(...bgRgb)) < deltaEMin && tries < 24){
+    v = (tries % 2) ? Math.max(0, v - 0.04) : Math.min(1, v + 0.04);
+    rgb = hsvToRgb(h, s, v);
+    tries++;
+  }
+  return rgb;
+}

--- a/core/index.js
+++ b/core/index.js
@@ -1,0 +1,21 @@
+// core/index.js — puente de compatibilidad: expone en window
+import * as Col from './colors.js';
+import * as Perm from './permutations.js';
+import * as Scn from './scene.js';
+import { PATTERNS, PHI_S, PHI_V, PHI_H } from './patterns.js';
+
+const core = { ...Col, ...Perm, ...Scn, PATTERNS, PHI_S, PHI_V, PHI_H };
+window.core = core;
+
+// Compatibilidad “suave”: también colgamos algunos nombres comunes en window
+// (no obliga a tocar tu index.html todavía)
+[
+  'rgbToHsv','hsvToRgb','hsvToHex','hexToRgb','rgbToLab','deltaE','idxToHSV','ensureContrastRGB',
+  'getPermutations','getAttributeMappings','lehmerRank','mappingRank','computeSignature','computeRange',
+  'computeSceneSeedFrom','computeGlobalS',
+].forEach(k => { if (!window[k]) window[k] = core[k]; });
+
+if (!window.PATTERNS) window.PATTERNS = PATTERNS;
+if (!window.PHI_S) window.PHI_S = PHI_S;
+if (!window.PHI_V) window.PHI_V = PHI_V;
+if (!window.PHI_H) window.PHI_H = PHI_H;

--- a/core/patterns.js
+++ b/core/patterns.js
@@ -1,0 +1,20 @@
+// core/patterns.js — PATTERNS y constantes asociadas (tal cual)
+export const PHI_S = 5;
+export const PHI_V = 7;
+export const PHI_H = 89;
+
+export const PATTERNS = {
+  1:(s,seed,i)=>{const b=(s.reduce((a,v)=>a+v,0)+seed*7)%144; const h=(b+(i%12)*6)%144; return [h,(s[3]+seed+i)%12,(s[1]+s[4]+i)%12];},
+  2:(s,seed,i)=>{const b=(s[0]*17+seed*5)%144; const h=(b+((i%12)*48))%144; return [h,(s[1]+i*3+seed)%12,(s[2]*2+i+seed)%12];},
+  3:(s,seed,i)=>{const b=(s[2]*13+seed*5+i*11)%144; return [(b+i*89)%144,(s[0]+i*2+seed)%12,(s[1]+s[3]+i)%12];},
+  4:(s,seed,i)=>{const b=(s[1]*15+seed*3+i*7)%144;  return [(b+i*89)%144,(s[0]+seed+i)%12,(s[2]+s[4]+seed+i)%12];},
+  5:(s,seed,i)=>{const b=(i*31+s[3]*13+seed*5)%144; return [(b+i*89)%144,(s[1]+seed+i)%12,(s[2]+seed+i)%12];},
+  6:(s,seed,i)=>{const b=(s[1]*31+seed*13+i*7)%144; return [(b+i*89)%144,(s[2]+seed+i)%12,(s[3]+s[4]+seed+i)%12];},
+  7:(s,seed,i)=>{const b=(s[0]*11+seed*3+i*37)%144; return [(b+i*89)%144,(s[2]+seed+i*2)%12,(s[4]+s[1]*2+seed+i)%12];},
+  8:(s,seed,i)=>{const r=Math.abs(s[4]-s[0])+Math.abs(s[3]-s[1])+s[2]; const b=(r*13+seed*7)%144;
+                 return [(b+i*89)%144,(s[1]*3+seed+i*2)%12,(s[3]+i*5+seed*3)%12];},
+  9:(s,seed,i)=>{const b=(s[4]*12+seed*7+i*11)%144; return [(b+i*89)%144,(s[2]+seed+i)%12,(s[1]+seed+i*2)%12];},
+ 10:(s,seed,i)=>{const b=(seed*5+s.reduce((a,v)=>a+v,0)*3+i*7)%144;
+                 return [(b+i*89)%144,(s[2]+seed+i)%12,(s[4]*2+seed+i*3)%12];},
+ 11:(s,seed,i)=>{const b=(s[3]*13+seed*11+i*7)%144; return [(b+i*89)%144,(s[0]+seed+i)%12,(s[1]+seed+i*2)%12];}
+};

--- a/core/permutations.js
+++ b/core/permutations.js
@@ -1,0 +1,43 @@
+// core/permutations.js — utilidades puras de permutaciones/ranks
+export const FACT=[1,1,2,6,24,120];
+
+export function getPermutations(arr){
+  if(arr.length===1) return [arr];
+  let res=[]; for(let i=0;i<arr.length;i++){
+    const c=arr[i], rem=arr.slice(0,i).concat(arr.slice(i+1));
+    for(const p of getPermutations(rem)) res.push([c].concat(p));
+  }
+  return res;
+}
+
+export function getAttributeMappings(a){
+  if(a.length===1) return [a];
+  let res=[]; for(let i=0;i<a.length;i++){
+    const c=a[i], rem=a.slice(0,i).concat(a.slice(i+1));
+    for(const m of getAttributeMappings(rem)) res.push([c].concat(m));
+  }
+  return res;
+}
+
+export function lehmerRank(p){
+  let r=0;
+  for(let i=0;i<p.length;i++){
+    let c=0;
+    for(let j=i+1;j<p.length;j++) if(p[j]<p[i]) c++;
+    r+=c*FACT[p.length-1-i];
+  }
+  return r;
+}
+
+export function mappingRank(m){
+  const arr = [m[0]+1, m[1]+1, m[2]+1, m[3]+1, m[4]+1];
+  return lehmerRank(arr);
+}
+
+export function computeSignature(a){
+  let s=[]; for(let i=0;i<a.length;i++) s.push(a[i]+a[(i+1)%a.length]); return s;
+}
+
+export function computeRange(sig){
+  return Math.max(...sig)-Math.min(...sig);
+}

--- a/core/scene.js
+++ b/core/scene.js
@@ -1,0 +1,25 @@
+// core/scene.js — invariantes de escena y helpers numéricos
+import { lehmerRank, mappingRank } from './permutations.js';
+
+export function computeSceneSeedFrom(perms, m){
+  let sumR = 0, sumR2 = 0;
+  perms.forEach(pa=>{
+    const r = lehmerRank(pa);
+    sumR  += r;
+    sumR2 += r*r;
+  });
+  const mRank = mappingRank(m);
+  return (37*sumR + 101*sumR2 + 53*mRank) % 360;
+}
+
+export function computeGlobalS(perms, m){
+  const mx = m[2], my = m[3], mz = m[4];
+  let S = 0;
+  perms.forEach(p=>{
+    S += p[mx] + p[my] + p[mz];
+  });
+  return S % 125;
+}
+
+export function clamp(v,a,b){return Math.max(a,Math.min(b,v));}
+export function mapRangeToSpeed(r,mn,mx){return 0.001 + (r-mn)*(0.005-0.001)/(mx-mn);}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   <!-- Three .js + OrbitControls (una sola vez) -->
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+  <!-- Capa pura (no rompe nada): expone utilidades core en window -->
+  <script type="module" src="./core/index.js"></script>
   <style>
   body {
     margin: 0;
@@ -457,6 +459,15 @@ document.getElementById('json-upload').addEventListener('change', function(event
         cubeOverride = config.cube;
       }
 
+      // === Estado único (persistimos lo que ya aplicaste a la UI) ===
+      import('./state/store.js').then(({ setPerms, setMapping, setPattern, setOverrides, state })=>{
+        setPerms(Array.from(document.getElementById('permutationList').selectedOptions).map(o=>o.value));
+        setMapping({ forma: attributeMapping[0], color: attributeMapping[1], x: attributeMapping[2], y: attributeMapping[3], z: attributeMapping[4] });
+        setPattern(activePatternId);
+        const cols = {}; for(let i=1;i<=5;i++){ cols[i] = document.getElementById('color'+i).value; }
+        setOverrides({ colors: cols, bg: document.getElementById('bgColor').value, cube: document.getElementById('cubeColor').value });
+        state.sceneSeed = sceneSeed; state.S_global = S_global;
+      });
       // Scene invariants (optional)
       if (typeof config.sceneSeed === 'number') {
         sceneSeed = config.sceneSeed;
@@ -2308,8 +2319,8 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       if(p.get('hide')==='1') toggleTexts();
     }
 
-    function exportEmbed(){
-      const config = exportCurrentConfiguration();     // ← usa la misma fuente de verdad
+    async function exportEmbed(){
+      const config = await exportCurrentConfiguration();     // ← usa la misma fuente de verdad
       const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -3305,7 +3316,7 @@ void main(){
           tokenId: hash,
           tokenURI,
           owner: await signer.getAddress(),
-          config: exportCurrentConfiguration()
+          config: await exportCurrentConfiguration()
         };
         localStorage.setItem("mintedNFT_" + hash, JSON.stringify(nft));
         console.log("NFT guardado localmente:", nft);
@@ -3672,21 +3683,41 @@ function showFRBNInfo(){
       return blob;
     }
 
-    /* Configuración actual (mismo formato que exportEmbed) */
-    function exportCurrentConfiguration(){
-      const perms = Array.from(document.getElementById('permutationList').selectedOptions).map(o=>o.value);
-      const mapping = { forma: attributeMapping[0], color: attributeMapping[1],
-                        x: attributeMapping[2], y: attributeMapping[3], z: attributeMapping[4] };
-      const colors = {}; for(let i=1;i<=5;i++){ colors[i] = document.getElementById('color'+i).value; }
-      const bg   = document.getElementById('bgColor').value;
-      const cube = document.getElementById('cubeColor').value;
-      const view = "front";
-      return { perms, mapping, colors, bg, cube, view, pattern: activePatternId, sceneSeed, S_global, frbnK: FRBN_K };
-    }
+
+
+// ===== Reemplazo exportCurrentConfiguration: fuente única (state) =====
+/* eslint-disable no-undef */
+async function exportCurrentConfiguration(){
+  // import dinámico ligero para no convertir todo el archivo en módulo
+  const { state, serialize, setPerms, setMapping, setPattern, setOverrides } =
+    await import('./state/store.js');
+
+  // 1) Leer UI actual (como antes)
+  const perms = Array.from(document.getElementById('permutationList').selectedOptions).map(o=>o.value);
+  const mapping = { forma: attributeMapping[0], color: attributeMapping[1],
+                    x: attributeMapping[2], y: attributeMapping[3], z: attributeMapping[4] };
+  const colors = {}; for(let i=1;i<=5;i++){ colors[i] = document.getElementById('color'+i).value; }
+  const bg   = document.getElementById('bgColor').value;
+  const cube = document.getElementById('cubeColor').value;
+
+  // 2) Volcar a state (adopción gradual)
+  setPerms(perms);
+  setMapping(mapping);
+  setPattern(activePatternId);
+  setOverrides({ colors, bg, cube });
+
+  // 3) Copiar invariantes ya calculados
+  state.sceneSeed = sceneSeed;
+  state.S_global  = S_global;
+
+  // 4) Serializar con el formato estable
+  return serialize();
+}
+
 
     /* Hash para NFT u otros usos (lo pedía tu mintNFT) */
     async function computeConfigHash(){
-      const cfg = exportCurrentConfiguration();
+      const cfg = await exportCurrentConfiguration();
       const canonical = stableStringify(cfg);
       return sha256Hex(canonical);
     }
@@ -3697,7 +3728,7 @@ function showFRBNInfo(){
         showPopup("Generando certificado…",2000);
 
         // 1) JSON canónico + hash
-        const cfg = exportCurrentConfiguration();
+        const cfg = await exportCurrentConfiguration();
         const canonicalJSON = stableStringify(cfg);            // ← archivo exacto para hash
         const hashHex = await sha256Hex(canonicalJSON);
 

--- a/state/store.js
+++ b/state/store.js
@@ -1,0 +1,34 @@
+// state/store.js — estado serializable mínimo (adopción gradual)
+export const state = {
+  perms: [],             // lista de strings "1,2,3,4,5"
+  mapping: { forma:0, color:1, x:2, y:3, z:4 },
+  pattern: 1,
+  sceneSeed: 0,
+  S_global: 0,
+  overrides: {
+    colors: {},          // {1:"#rrggbb",...}
+    bg: null,
+    cube: null
+  }
+};
+
+// utilidades
+export function setPerms(perms){ state.perms = perms.slice(); }
+export function setMapping(m){ state.mapping = {...m}; }
+export function setPattern(p){ state.pattern = p|0; }
+export function setOverrides(o){ state.overrides = {...state.overrides, ...o}; }
+
+export function serialize(){
+  return {
+    perms: state.perms.slice(),
+    mapping: {...state.mapping},
+    colors: {...state.overrides.colors},
+    bg: state.overrides.bg,
+    cube: state.overrides.cube,
+    pattern: state.pattern,
+    sceneSeed: state.sceneSeed,
+    S_global: state.S_global,
+    view: "front",
+    frbnK: 144
+  };
+}


### PR DESCRIPTION
## Summary
- add pure core modules (colors, permutations, scene, patterns) and expose them globally
- introduce serializable state store and integrate export flow with it
- persist state when loading JSON and await async export in hashing and certificate

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895acb333b0832cb364846aa7dabb16