### PR TITLE
Use engine state for FRBN toggles and cleanup

### DIFF
--- a/engines/frbn.js
+++ b/engines/frbn.js
@@ -187,6 +187,9 @@
 
       const ib = document.getElementById('frbnInfoButton');
       if (ib) ib.style.display = 'none';
+
+      // Mantén espejos de estado y etiqueta del botón coherentes si se llamó exit() directo
+      window.isFRBN = this.isFRBN; const b = document.getElementById('frbnButton'); if (b) b.textContent = 'FRBN';
     }
 
     toggle(){

--- a/index.html
+++ b/index.html
@@ -733,6 +733,8 @@ document.getElementById('json-upload').addEventListener('change', function(event
         }
       }
 
+      function frbnOn(){ return !!(window.FRBN && window.FRBN.isFRBN); }
+
       // Utilidad opcional (si el motor la implementa)
       function buildGanzfeld(){
         if (window.FRBN && typeof window.FRBN.buildGanzfeld === 'function') {
@@ -958,7 +960,7 @@ function buildLCHT() {
           }
           if (!lchtPrevBg) lchtPrevBg = scene.background ? scene.background.clone() : null;
           scene.background = new THREE.Color(0xf4f4f4);       // gris muy claro
-          if (isFRBN) toggleFRBN();                           // LCHT excluye FRBN
+          if (frbnOn()) toggleFRBN();                         // LCHT excluye FRBN
           buildLCHT();
           lichtGroup.visible        = true;
           cubeUniverse.visible      = false;
@@ -988,9 +990,9 @@ function buildLCHT() {
     /* Cambia al motor BUILD sin generar una nueva configuración */
     function switchToBuild(){
       if (isOFFNNG) toggleOFFNNG();   // ← NUEVO: asegura exclusividad
-      if (isFRBN)  toggleFRBN();   // apaga FRBN si estaba activo
-      if (isLCHT)  toggleLCHT();   // apaga LCHT si estaba activo
-      if (isTMSL)  toggleTMSL();   // apaga TMSL si estaba activo
+      if (frbnOn()) toggleFRBN();   // apaga FRBN si estaba activo
+      if (isLCHT)   toggleLCHT();   // apaga LCHT si estaba activo
+      if (isTMSL)   toggleTMSL();   // apaga TMSL si estaba activo
       /* Nada más: la escena existente permanece tal cual */
     }
 
@@ -1956,7 +1958,7 @@ function makePalette(){
         updateCubeColor(false);    // ← automático
       }
 
-      if (isFRBN && window.FRBN) window.FRBN.syncFromScene();   // mantiene FRBN sincronizado
+      if (window.FRBN?.isFRBN) window.FRBN.syncFromScene();   // mantiene FRBN sincronizado
       rebuildLCHTIfActive();                      // mantiene LCHT sincronizado
       if (isOFFNNG) syncOFFNNGFromScene();
     }
@@ -3025,7 +3027,7 @@ void main(){
       isOFFNNG = !isOFFNNG;
 
     if (isOFFNNG) {                    /* — ENTRAR — */
-      if (isFRBN) toggleFRBN();        // asegura exclusividad
+      if (frbnOn()) toggleFRBN();      // asegura exclusividad
       if (isLCHT) toggleLCHT();
       if (isTMSL) toggleTMSL();
 
@@ -3071,7 +3073,7 @@ void main(){
 
     /* ────────── botón dedicado: OFFNNG siempre en solitario ───────── */
     function ensureOnlyOFFNNG () {
-      if (isFRBN) toggleFRBN();
+      if (frbnOn()) toggleFRBN();
       if (isLCHT) toggleLCHT();
       if (!isOFFNNG) toggleOFFNNG();
     }
@@ -3307,14 +3309,8 @@ void main(){
       async function offAll(){
         // FRBN
         try{
-          if (window.isFRBN){
-            if (window.FRBN && typeof window.FRBN.exit === 'function'){
-              await window.FRBN.exit();
-              window.isFRBN = false;
-            } else {
-              // Fallback robusto: alterna FRBN para apagarlo
-              await toggleFRBN();
-            }
+          if (window.FRBN?.isFRBN) {
+            await toggleFRBN();              // ← en vez de FRBN.exit()
           }
         }catch(e){ console.warn('offAll() FRBN:', e); }
 


### PR DESCRIPTION
## Summary
- Add `frbnOn` helper and replace `isFRBN` checks in LCHT and OFFNNG toggles plus build switch to rely on engine state.
- Guard `ENGINE.offAll` by toggling FRBN instead of calling `exit` directly.
- Ensure direct calls to `FRBN.exit()` keep UI/mirror state consistent.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983c0be778832c85b6e23d900d6373