### PR TITLE
Expose new core utilities in global glue

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
             'idxToHSV',
             'getPermutations','getAttributeMappings','lehmerRank','mappingRank',
             'computeSignature','computeRange',
-            'computeSceneSeedFrom','computeGlobalS'
+            'computeSceneSeedFrom','computeGlobalS',
+            // === NUEVO: utilidades usadas por Save JSON / Certificate / Mint ===
+            'exportCurrentConfiguration','computeConfigHash','exportEditionCertificate'
           ].forEach(k => { if (window.core?.[k]) window[k] = window.core[k]; });
 
           // Envoltorio de ensureContrastRGB (interfaz antigua: 1 parámetro)


### PR DESCRIPTION
## Summary
- Expose core's new export utilities in the global glue script so Save JSON, Certificate, and Mint features can access them.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68988b672d08832c8ff2d7aa03d863fc