### PR TITLE
refactor: use core helpers for permutations and rank

### DIFF
--- a/index.html
+++ b/index.html
@@ -1124,25 +1124,9 @@ function evalProp(prop, args = [], fallback = 0){
     function mapRangeToSpeed(r,mn,mx){return 0.001 + (r-mn)*(0.005-0.001)/(mx-mn);}
     function shuffle(a){for(let i=a.length-1;i>0;i--){let j=Math.floor(Math.random()*(i+1));[a[i],a[j]]=[a[j],a[i]];}return a;}
 
-    function getPermutations(arr){
-      if(arr.length===1) return [arr];
-      let res=[]; for(let i=0;i<arr.length;i++){
-        const c=arr[i], rem=arr.slice(0,i).concat(arr.slice(i+1));
-        for(const p of getPermutations(rem)) res.push([c].concat(p));
-      }
-      return res;
-    }
-    const allPermutations = getPermutations([1,2,3,4,5]);
+    // --- Use core helpers mapped by the glue (window.getPermutations / window.getAttributeMappings)
+    const allPermutations  = getPermutations([1,2,3,4,5]);
     const permutationStrings = allPermutations.map(p=>p.join(','));
-
-    function getAttributeMappings(a){
-      if(a.length===1) return [a];
-      let res=[]; for(let i=0;i<a.length;i++){
-        const c=a[i], rem=a.slice(0,i).concat(a.slice(i+1));
-        for(const m of getAttributeMappings(rem)) res.push([c].concat(m));
-      }
-      return res;
-    }
 
     function populatePermutationList(){
       const sel = document.getElementById('permutationList');
@@ -1166,20 +1150,7 @@ function evalProp(prop, args = [], fallback = 0){
       updateTopRightDisplay();
     }
 
-    function computeSignature(a){let s=[];for(let i=0;i<a.length;i++) s.push(a[i]+a[(i+1)%a.length]);return s;}
-    function computeRange(sig){return Math.max(...sig)-Math.min(...sig);}
-
-    const FACT=[1,1,2,6,24,120];
     let sceneSeed=0;
-    function lehmerRank(p){
-      let r=0;
-      for(let i=0;i<p.length;i++){
-        let c=0;
-        for(let j=i+1;j<p.length;j++) if(p[j]<p[i]) c++;
-        r+=c*FACT[p.length-1-i];
-      }
-      return r;
-    }
 
     /* ========= sceneSeed / S_global desde core ========= */
     let mappingRank, computeSceneSeedFrom, computeGlobalS;


### PR DESCRIPTION
## Summary
- streamline permutation setup by using core's `getPermutations` and `getAttributeMappings`
- remove local implementations of `computeSignature`, `computeRange`, `FACT`, and `lehmerRank`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991190de3c832caf7de01bed1da5e6