### PR TITLE
feat: centralize engine registry with build auto-start

### DIFF
--- a/index.html
+++ b/index.html
@@ -3164,7 +3164,7 @@ void main(){
     }
     window.addEventListener('load', () => {
       updateEngineButtonsUI();
-      init().catch(console.error);
+      init().then(() => { window.ENGINE?.enter('BUILD'); }).catch(console.error);
     });
 
     // Web3 + NFT Mint (tu código original)


### PR DESCRIPTION
## Summary
- replace engine registry with centralized exclusive manager and provisional entries for BUILD, FRBN, LCHT, OFFNNG, and TMSL
- auto-enter BUILD engine after initialization in HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689921b1e7cc832cabde90df38a3d4da