### PR TITLE
feat: improve FRBN engine registration

### DIFF
--- a/engines/frbn.js
+++ b/engines/frbn.js
@@ -169,6 +169,7 @@ const FRBNEngine = (() => {
   }
 
   return {
+    name: 'FRBN',
     id: 'FRBN',
     enter(host){
       hostRef = host || hostRef || {};
@@ -211,10 +212,22 @@ const FRBNEngine = (() => {
   };
 })();
 
-// auto-registro
-if (window.ENGINE && typeof window.ENGINE.register === 'function') {
-  window.ENGINE.register(FRBNEngine);
-}
+// auto-registro (con reintento si registry aún no cargó)
+(function registerWhenReady(){
+  if (window.ENGINE && typeof window.ENGINE.register === 'function') {
+    window.ENGINE.register(FRBNEngine);
+  } else {
+    const t0 = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+    const again = () => {
+      if (window.ENGINE && typeof window.ENGINE.register === 'function') {
+        window.ENGINE.register(FRBNEngine);
+      } else if (((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0) < 4000) {
+        setTimeout(again, 50);
+      }
+    };
+    setTimeout(again, 50);
+  }
+})();
 
 export default FRBNEngine;
 export const FRBN = FRBNEngine;


### PR DESCRIPTION
## Summary
- add `name` property to FRBN engine while retaining `id`
- ensure FRBN engine auto-registers even if registry loads later by retrying registration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a15790c5c832c85497cce8edd545a