### PR TITLE
fix: improve engine registration and shutdown

### DIFF
--- a/engines/lcht.js
+++ b/engines/lcht.js
@@ -1,4 +1,4 @@
-// engines/lcht.js
+// ./engines/lcht.js
 // LCHT: deterministic light-tubes (extraído del HTML, registrado en ENGINE)
 let isOn = false;
 let group = null;
@@ -8,8 +8,9 @@ let avgSceneRange = 0;
 
 function getTHREE(){ return window.THREE; }
 function getPerms(){
-  return Array.from(document.getElementById('permutationList').selectedOptions)
-    .map(o => o.value.split(',').map(Number));
+  const sel = document.getElementById('permutationList');
+  if (!sel) return [];
+  return Array.from(sel.selectedOptions).map(o => o.value.split(',').map(Number));
 }
 function getCubeSize(){
   const w = window.cubeUniverse?.geometry?.parameters?.width;
@@ -59,7 +60,7 @@ function build(){
     avgSceneRange = rgs.reduce((a,b)=>a+b,0) / (rgs.length||1);
   }
 
-  perms.forEach((pa, idxPerm) => {
+  perms.forEach((pa) => {
     const sig = window.computeSignature(pa);
     const rng = window.computeRange(sig);
     const r   = window.lehmerRank(pa);

--- a/engines/offnng.js
+++ b/engines/offnng.js
@@ -1,4 +1,4 @@
-// engines/offnng.js
+// ./engines/offnng.js
 // OFFNNG volumétrico continuo (extraído y encapsulado)
 let isOn = false;
 let group = null;
@@ -140,7 +140,6 @@ void main(){
   vec3 pos = ro + rd * (t0 + 0.5 * dt);
 
   vec3 acc = vec3(0.0); float a=0.0;
-  float alphaStep = 1.0 - exp(-uDensity * dt / (2.0*uHalf));
 
   float hueDrift = uHueRate
                  + uHueLFO1Amp * sin(6.2831853 * uHueLFO1Hz * uTime + uHueLFO1Phase)
@@ -219,17 +218,15 @@ function syncFromScene(){
   if (!mesh || !mesh.material || !mesh.material.uniforms) return;
   const U = mesh.material.uniforms;
 
-  const selPerms = Array.from(document.getElementById('permutationList').selectedOptions)
-    .map(o => o.value.split(',').map(Number));
+  const sel = document.getElementById('permutationList');
+  const selPerms = sel ? Array.from(sel.selectedOptions).map(o => o.value.split(',').map(Number)) : [];
 
-  // rango medio 2..6
   let avgR = 4.0;
   if (selPerms.length){
     const ranges = selPerms.map(p => window.computeRange(window.computeSignature(p)));
     avgR = ranges.reduce((a,b)=>a+b,0) / ranges.length;
   }
   const nr = Math.max(0, Math.min(1, (avgR - 2) / 4));
-  const sigAvg = 6;
   const sigN = 0.5;
 
   U.uHueBias.value = window.sceneSeed;
@@ -260,6 +257,10 @@ function syncFromScene(){
 
 function animate(){
   if (!isOn || !mesh) return;
+  // mantener uInvModel correcto por si hay transformaciones de escena
+  mesh.updateMatrixWorld(true);
+  mesh.material.uniforms.uInvModel.value.copy(mesh.matrixWorld).invert();
+
   mesh.material.uniforms.uTime.value = performance.now() * 0.001;
   rafId = requestAnimationFrame(animate);
 }

--- a/engines/registry.js
+++ b/engines/registry.js
@@ -1,6 +1,5 @@
 // ./engines/registry.js
-// PRMTTN – Engine Registry (v2)
-// Objetivo: entradas fiables para LCHT/OFFNNG/TMSL y retorno estable a BUILD.
+// PRMTTN – Engine Registry (v2.1)
 
 const NAME_ALIAS = { OFFNG: 'OFFNNG', Offnng: 'OFFNNG', offng: 'OFFNNG' };
 const ORDER = ['BUILD', 'FRBN', 'LCHT', 'OFFNNG', 'TMSL'];
@@ -68,9 +67,11 @@ function ensureRegistered(name){
 
 // ————— API pública —————
 function register(name, api){
-  const N = norm(name);
-  if (!api) return;
-  _engines.set(N, api);
+  let N = null, A = null;
+  if (typeof name === 'string') { N = norm(name); A = api; }
+  else if (name && typeof name === 'object') { A = name; N = norm(name.name || name.id); }
+  if (!N || !A) return;
+  _engines.set(N, A);
 }
 
 function enter(name){
@@ -80,9 +81,9 @@ function enter(name){
 
   if (finalName === _activeName) return true;
 
-  // 1) salir del motor anterior (si lo hay)
+  // 1) salir del motor anterior (acepta 'exit' también)
   if (_active){
-    callOne(_active, ['leave','stop','unmount','destroy'], ctx());
+    callOne(_active, ['leave','exit','stop','unmount','destroy'], ctx());
   }
   // 2) saneo del renderer/escena por si el motor tocó el loop
   restoreBaseLoop();


### PR DESCRIPTION
## Summary
- make engine registry accept object-based registration and invoke exit hooks
- expose leave/exit in FRBN engine and auto-register with explicit name
- guard permutation selector in LCHT and OFFNNG engines and keep OFFNNG raymarch stable

## Testing
- `node --check engines/registry.js && echo "registry ok"`
- `node --check engines/frbn.js && echo "frbn ok"`
- `node --check engines/lcht.js && echo "lcht ok"`
- `node --check engines/offnng.js && echo "offnng ok"`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a24463b44832cb26f5300c02e3c32