### PR TITLE
feat: enhance engine registry and optimize emissive handling

### DIFF
--- a/engines/frbn.js
+++ b/engines/frbn.js
@@ -113,6 +113,7 @@ const FRBNEngine = (() => {
     });
     const mesh = new THREE.Mesh(geo, mat);
     mesh.name = 'FRBN_skySphere';
+    mesh.renderOrder = -1; // asegura dibujado detrás
     return mesh;
   }
 
@@ -218,15 +219,22 @@ const FRBNEngine = (() => {
   };
 })();
 
-// auto-registro (con nombre correcto)
+// Autorregistro robusto para FRBN (sin bucles falsos)
 (function registerWhenReady(){
-  const reg = () => window.ENGINE && typeof window.ENGINE.register === 'function'
-    ? window.ENGINE.register('FRBN', FRBNEngine) : null;
-  if (!reg()){
-    const t0 = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+  const tryRegister = () => {
+    if (window.ENGINE && typeof window.ENGINE.register === 'function') {
+      // IMPORTANTE: que register devuelva true
+      const ok = window.ENGINE.register('FRBN', FRBNEngine);
+      return !!ok;
+    }
+    return false;
+  };
+
+  if (!tryRegister()){
+    const t0 = (performance?.now?.() ?? Date.now());
     const again = () => {
-      if (!reg()){
-        if (((typeof performance !== 'undefined' ? performance.now() : Date.now()) - t0) < 4000) {
+      if (!tryRegister()){
+        if ( ((performance?.now?.() ?? Date.now()) - t0) < 4000 ) {
           setTimeout(again, 50);
         }
       }

--- a/engines/lcht.js
+++ b/engines/lcht.js
@@ -138,6 +138,8 @@ function build(){
       const SIDE = 0.2, JOIN = 0.02;
       const geo = new THREE.BoxGeometry(SIDE, hSeg + JOIN, SIDE);
       const mat = new THREE.MeshPhongMaterial({ color: col, shininess: 0, dithering: true, flatShading: true });
+      // Inicializar emissive una sola vez (evita allocs por frame)
+      mat.emissive = mat.color.clone();
       const tube = new THREE.Mesh(geo, mat);
       tube.position.copy(mid);
       tube.quaternion.setFromUnitVectors(new THREE.Vector3(0,1,0), dN);
@@ -156,7 +158,13 @@ function animate(){
     const d = o.userData.lcht;
     if (d) {
       const I = d.I0 * (1 - d.amp * (1 + Math.cos(2*Math.PI*d.f*t + d.phi)) / 2);
-      o.material.emissive = o.material.color.clone();
+      // ANTES (malo para GC):
+      // o.material.emissive = o.material.color.clone();
+
+      // AHORA (sin allocations por frame):
+      o.material.emissive.copy(o.material.color);
+
+      // Si modulas brillo, hazlo con la intensidad:
       o.material.emissiveIntensity = I * 0.15;
     }
     if (o.userData.baseHsv){

--- a/engines/registry.js
+++ b/engines/registry.js
@@ -1,174 +1,183 @@
-// ./engines/registry.js
-// PRMTTN – Engine Registry (v2.1)
+// engines/registry.js
+// Engine Registry — runtime alineado con el .d.ts
+// - API pública: register(name, engine), enter(id): Promise<boolean>, ids(), get(), active()
+// - Extras compatibles: cycle(), syncFromScene(state?), context(obj), activeName, state.active
+// - enter() es async y espera leave() del saliente y enter() del entrante.
 
-const NAME_ALIAS = { OFFNG: 'OFFNNG', Offnng: 'OFFNNG', offng: 'OFFNNG' };
-const ORDER = ['BUILD', 'FRBN', 'LCHT', 'OFFNNG', 'TMSL'];
+const REG = new Map();
+let _active = null;          // objeto del motor activo
+let _activeName = 'BUILD';   // string ('BUILD' cuando no hay motor)
+let _ctx = null;             // contexto compartido para todos los motores
 
-const _engines = new Map();   // name -> api
-let _active = null;
-let _activeName = 'BUILD';
-
-// ————— helpers —————
-const norm = (n) => NAME_ALIAS[n] || String(n || '').toUpperCase();
-
-function ctx() {
-  return {
-    THREE:   window.THREE,
-    scene:   window.scene,
-    renderer:window.renderer,
-    camera:  window.camera,
-    controls:window.controls,
-    cubeUniverse:      window.cubeUniverse,
-    permutationGroup:  window.permutationGroup,
-    getState: () => (typeof window.getState === 'function' ? window.getState() : null),
-    refreshAll: window.refreshAll
-  };
+function norm(name) {
+  return String(name || '').trim().toUpperCase();
 }
 
-function callOne(obj, names, ...args){
-  for (const key of names){
-    const fn = obj && obj[key];
-    if (typeof fn === 'function') {
-      try { return fn.apply(obj, args); } catch(e){ console.warn(`[registry] ${key}() lanzó error:`, e); }
-    }
+// Llama al primer método existente de la lista y retorna su resultado
+function callOne(target, candidates, ...args) {
+  for (const k of candidates) {
+    const fn = target && target[k];
+    if (typeof fn === 'function') return fn.apply(target, args);
   }
   return undefined;
 }
 
-function restoreBaseLoop(){
-  const { renderer, scene, cubeUniverse, permutationGroup } = ctx();
-  try { renderer?.setAnimationLoop?.(null); } catch(_){}
-  if (renderer) renderer.autoClear = true;
-  if (scene)    scene.autoUpdate  = true;
-
-  // Reanclar grupos por si el motor activo los retiró
-  if (scene && cubeUniverse && !scene.children.includes(cubeUniverse)) scene.add(cubeUniverse);
-  if (scene && permutationGroup && !scene.children.includes(permutationGroup)) scene.add(permutationGroup);
+// Contexto que reciben los motores
+function ctx() {
+  // Construimos perezosamente con helpers del host, si existen
+  const base = _ctx || {};
+  return {
+    // core puro (inyectado desde la página host)
+    core: (typeof window !== 'undefined' && window.core) || base.core || null,
+    // estado y utilidades del host (si existen)
+    getState: (typeof window !== 'undefined' && window.getState) || base.getState || null,
+    refreshAll: (typeof window !== 'undefined' && window.refreshAll) || base.refreshAll || null,
+    three: (typeof window !== 'undefined' && window.THREE) || base.three || null,
+    scene: (typeof window !== 'undefined' && window.scene) || base.scene || null,
+    camera: (typeof window !== 'undefined' && window.camera) || base.camera || null,
+    renderer: (typeof window !== 'undefined' && window.renderer) || base.renderer || null,
+    controls: (typeof window !== 'undefined' && window.controls) || base.controls || null,
+    permutationGroup:
+      (typeof window !== 'undefined' && window.permutationGroup) || base.permutationGroup || null,
+  };
 }
 
-function autodetect(name){
-  const N = norm(name);
-  if (N === 'OFFNNG') return window.OFFNNG || window.OFFNG || null;
-  return window[N] || null; // FRBN, LCHT, TMSL…
-}
-
-function ensureRegistered(name){
-  const N = norm(name);
-  if (_engines.has(N)) return _engines.get(N);
-  const obj = autodetect(N);
-  if (obj) {
-    // si exportó default, preferimos el objeto completo, no la función
-    const api = obj && obj.default ? obj.default : obj;
-    _engines.set(N, api);
-    return api;
-  }
-  return null;
-}
-
-// ————— API pública —————
-function register(name, api){
-  let N = null, A = null;
-  if (typeof name === 'string') { N = norm(name); A = api; }
-  else if (name && typeof name === 'object') { A = name; N = norm(name.name || name.id); }
-  if (!N || !A) return;
-  _engines.set(N, A);
-}
-
-function enter(name){
-  const target = norm(name);
-  // alias transparente
-  const finalName = NAME_ALIAS[target] || target;
-
-  if (finalName === _activeName) return true;
-
-  // 1) salir del motor anterior (acepta 'exit' también)
-  if (_active){
-    callOne(_active, ['leave','exit','stop','unmount','destroy'], ctx());
-  }
-  // 2) saneo del renderer/escena por si el motor tocó el loop
-  restoreBaseLoop();
-
-  // 3) BUILD es la base: no necesita montar nada especial
-  if (finalName === 'BUILD'){
-    _active = null;
-    _activeName = 'BUILD';
-    // reconstrucción segura de escena base
-    try { ctx().refreshAll?.({rebuild:true}); } catch(_){ }
-    return true;
-  }
-
-  // 4) localizar/registrar el motor
-  const engine = ensureRegistered(finalName);
-  if (!engine){
-    console.warn(`[registry] Motor no disponible: ${finalName}`);
-    _active = null; _activeName = 'BUILD';
-    try { ctx().refreshAll?.({rebuild:true}); } catch(_){ }
-    return false;
-  }
-
-  // 5) inyectar contexto (si la API lo acepta)
-  callOne(engine, ['setContext','context','ctx'], ctx());
-
-  // 6) montar/entrar
-  callOne(engine, ['enter','start','mount','run','init'], ctx());
-
-  // 7) marcar activo y sincronizar estado desde BUILD → motor
-  _active = engine;
-  _activeName = finalName;
-
-  try {
-    // Primer sync inmediato
-    const st = ctx().getState?.();
-    if (st) callOne(engine, ['syncFromScene','sync'], st, ctx());
-    // y un “late sync” en el siguiente frame, útil cuando el motor crea nodos asíncronos
-    requestAnimationFrame(()=>{
-      const st2 = ctx().getState?.();
-      if (st2) callOne(engine, ['syncFromScene','sync'], st2, ctx());
-    });
-  } catch(_){ }
-
-  return true;
-}
-
-function cycle(){
-  const idx = Math.max(0, ORDER.indexOf(_activeName));
-  const next = ORDER[(idx + 1) % ORDER.length];
-  return enter(next);
-}
-
-function syncFromScene(){
-  if (!_active) return false;
-  const st = ctx().getState?.();
-  if (!st) return false;
-  callOne(_active, ['syncFromScene','sync'], st, ctx());
-  return true;
-}
-
-// Compat: algunos sitios miran ENGINE.state.active
 const ENGINE = {
-  register,
-  enter,
-  cycle,
-  syncFromScene,
-  get activeName(){ return _activeName; },
-  state: { get active(){ return _activeName; } }
+  // Registra un motor. Devuelve true si se registra/actualiza correctamente.
+  register(name, engine) {
+    const id = norm(name);
+    if (!id) { console.warn('[ENGINE.register] id vacío'); return false; }
+
+    // Soporta default export y factories
+    let api = engine && (engine.default || engine);
+    if (typeof api === 'function') {
+      try { api = api(ctx()); } catch (e) { console.warn('[ENGINE.register] factory falló:', e); }
+    }
+    if (!api || typeof api !== 'object') {
+      console.warn('[ENGINE.register] api inválida para', id);
+      return false;
+    }
+    REG.set(id, api);
+    return true;
+  },
+
+  // Entra en un motor; espera a leave/exit del saliente y enter/start del entrante.
+  async enter(name) {
+    const target = norm(name);
+    if (!target) return false;
+
+    if (target === _activeName) return true;
+
+    // Salida del motor previo
+    if (_active) {
+      try {
+        await Promise.resolve(
+          callOne(_active, ['leave', 'exit', 'stop', 'unmount', 'destroy'], ctx())
+        );
+      } catch (e) {
+        console.warn('[ENGINE.enter] leave del motor saliente falló:', e);
+      }
+    }
+
+    // BUILD = escena base (sin motor)
+    if (target === 'BUILD') {
+      _active = null;
+      _activeName = 'BUILD';
+      // Devolvemos control al host para reconstruir
+      try { await Promise.resolve(ctx().refreshAll?.({ rebuild: true })); } catch (_) {}
+      ENGINE.state.active = _activeName;
+      return true;
+    }
+
+    // Buscar motor y entrar
+    const engine = REG.get(target);
+    if (!engine) {
+      console.warn('[ENGINE.enter] motor no registrado:', target);
+      _active = null;
+      _activeName = 'BUILD';
+      try { await Promise.resolve(ctx().refreshAll?.({ rebuild: true })); } catch (_) {}
+      ENGINE.state.active = _activeName;
+      return false;
+    }
+
+    // Inyectar contexto (si el motor lo acepta)
+    try {
+      await Promise.resolve(callOne(engine, ['setContext', 'context', 'ctx'], ctx()));
+    } catch (e) {
+      console.warn('[ENGINE.enter] setContext/context/ctx falló en', target, e);
+    }
+
+    // Enter real
+    try {
+      await Promise.resolve(callOne(engine, ['enter', 'start', 'mount', 'run', 'init'], ctx()));
+    } catch (e) {
+      console.warn('[ENGINE.enter] enter/start falló en', target, e);
+      return false;
+    }
+
+    _active = engine;
+    _activeName = target;
+    ENGINE.state.active = _activeName;
+
+    // Primer sync (si hay estado del host)
+    try {
+      const st = ctx().getState?.();
+      if (st) await Promise.resolve(callOne(engine, ['syncFromScene', 'sync'], st, ctx()));
+      // Un segundo sync en el siguiente frame (post-layout)
+      if (typeof requestAnimationFrame !== 'undefined') {
+        requestAnimationFrame(() => {
+          try {
+            const st2 = ctx().getState?.();
+            if (st2) callOne(engine, ['syncFromScene', 'sync'], st2, ctx());
+          } catch (_) {}
+        });
+      }
+    } catch (_) {}
+
+    return true;
+  },
+
+  // Cicla entre motores registrados + BUILD (siempre incluye BUILD)
+  cycle() {
+    const all = ['BUILD', ...Array.from(REG.keys())];
+    const i = Math.max(0, all.indexOf(_activeName));
+    const next = all[(i + 1) % all.length];
+    return ENGINE.enter(next);
+  },
+
+  // Reenvía el estado actual al motor activo
+  syncFromScene(state) {
+    if (!_active) return;
+    try {
+      const st = state || ctx().getState?.();
+      if (st) return callOne(_active, ['syncFromScene', 'sync'], st, ctx());
+    } catch (e) {
+      console.warn('[ENGINE.syncFromScene] falló:', e);
+    }
+  },
+
+  // Exponer/actualizar contexto (opcional)
+  context(obj) {
+    _ctx = Object.assign({}, _ctx || {}, obj || {});
+  },
+
+  // === API pedida por el .d.ts ===
+  ids() { return Array.from(REG.keys()); },
+  get(id) { return REG.get(norm(id)); },
+  active() { return _active; },
+
+  // Campos de compat
+  get activeName() { return _activeName; },
+  state: { active: _activeName },
 };
 
-// ——— Autodescubrimiento “perezoso”: intenta registrar si los motores ya viven en window
-function tryAutodiscover(){
-  ['FRBN','LCHT','OFFNNG','OFFNG','TMSL'].forEach(n => ensureRegistered(n));
-}
-if (typeof window !== 'undefined'){
-  // disponible muy pronto para que otros módulos puedan usarlo
-  window.ENGINE = ENGINE;
-  // detectar motores cuando el DOM está listo
-  window.addEventListener('load', tryAutodiscover, { once:true });
-}
-
-// Mint: mantenemos la UI de Mint oculta devolviendo null (stub seguro)
-export function getContractConfig(){ return null; }
-
-// Exports
-export { register, enter, cycle, syncFromScene };
+// Exponer global y exportar módulo
+if (typeof window !== 'undefined') window.ENGINE = ENGINE;
 export default ENGINE;
+
+// (Opcional) Config de contrato para el mint (el host la consulta si existe)
+export function getContractConfig() {
+  // Devuelve null por defecto; si tienes datos reales, expórtalos aquí.
+  return null;
+}
 


### PR DESCRIPTION
## Summary
- rewrite engine registry to match TypeScript API with async engine switching, context sharing and lookup helpers
- harden FRBN auto-registration and ensure sky sphere draws behind scene
- reduce LCHT emissive allocations by initializing once and copying in-place each frame

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a468764e0832cb218711628c4089b