### PR TITLE
Refactor info panels to load external text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,15 +1541,16 @@ function pausePerm120(){
   }
 }
 
-function showPerm120Info(){
-  const txt =
-`The 120 architectural permutations are the 120 ways to reassign P₁–P₅ to the attributes [shape, color, x, y, z]. The architecture (the set of selected permutations) does not change; what changes is its visual phenotype by deciding which component controls each spatial and chromatic attribute.
-These reconstructions do not add semantics, do not break the logic of the system, and remain within the combinatorial framework. They reorganize the structural availability of pre‑verbal thought.
-
-Each of the 120 reorganizations is validated by its internal structural coherence, not by usefulness or beauty.
-“Evolution” is goal‑free reordering: same architecture, 120 phenotypic expressions.`;
-  alert(txt);
+async function showPerm120Info(){
+  try{
+    const text = await loadTextPartial('./texts/perm120-info.txt');
+    alert(text);
+  }catch(err){
+    alert('Error cargando perm120-info.txt');
+    console.error(err);
+  }
 }
+
 
     /* ============================================================
      *  MONTE-CARLO: buscar una escena aleatoria SIN colisiones
@@ -3369,218 +3370,39 @@ void main(){
      * Ends with: "work in progress"
      * ============================================================ */
 
-function showInformation(){
-  const html = `
-      <h2>Version 31.07.2025, PRMTTN‑Architecture for thought without words</h2>
+// ==== Loader ligero con caché en memoria para textos informativos ====
+const __TEXT_CACHE = Object.create(null);
 
-      <h3>Structural Introduction</h3>
-      <p><em>Nothing else is needed. Combinatorics is enough.</em></p>
-
-      <h3>1. What is PRMTTN?</h3>
-      <p>PRMTTN is a finite combinatorial architecture where preverbal thought (thought without words) may occur. Its starting point is a closed and non‑expandable set of 120 permutations of the set {1, 2, 3, 4, 5}. From this set, visual configurations of permutations are generated, governed by fixed structural rules, without semantics or interpretation. Each configuration is pure form. Its logic is self‑sufficient.</p>
-      <p>Each work in PRMTTN consists of a specific group of permutations, acquired as a structural unit. This group can be projected across different visual engines/editions—current or future—that apply deterministic rules to translate it into visible phenotypic configurations.</p>
-      <p>The content is neither an image nor a file: it is a verifiable formal structure (a specific subset of the 120 permutations). The visualization may vary depending on the engine used, but the original group of permutations does not change. The identity of a work is defined by that group and the internal rules of the system. The work is not its visualization, but the underlying structure that remains invariant across projections.</p>
-      <p>PRMTTN does not operate as language, nor as a medium of expression. What it shows refers to nothing outside itself. Each configuration is a visual form that does not communicate, represent, or explain. Its existence does not depend on taste, interpretation, or intention, but on a combinatorial logic that gives structure to the invisible.</p>
-
-      <h3>Structural Grammar</h3>
-      <p><em>A single permutation, reorganized, may contain a complete architecture for what cannot be said.</em></p>
-
-      <h3>2. Internal Rules</h3>
-      <p>PRMTTN operates through a fixed visual grammar, derived from numerically assigned structural values. Each configuration is composed of visual elements whose attributes are calculated from a permutation of the set {1, 2, 3, 4, 5}. There are no exceptions or manual assignments.</p>
-      <p>Each permutation is internally reorganized to define its visual properties. This reorganization—phenotypic and not genetic—assigns a specific role to each of the five values, without breaking the system's logic.</p>
-
-      <h4>Structural attributions:</h4>
-      <table style="width:100%;border-collapse:collapse;font-size:13px">
-        <thead>
-          <tr><th>Attribute</th><th>Numerical Source</th><th>Deterministic Rule</th></tr>
-        </thead>
-        <tbody>
-          <tr><td>Shape</td><td>First value (P₁)</td><td>Height proportional to √(P₁)</td></tr>
-          <tr><td>Color</td><td>Second value (P₂) + signature + global seed</td><td>Deterministic HSV mapping on discrete grid</td></tr>
-          <tr><td>Position</td><td>Lehmer-rank + global seed + sum</td><td>3D mapping inside the 30×30×30 cube</td></tr>
-          <tr><td>Rotation</td><td>Range of signature</td><td>Rotation proportional to (max − min)</td></tr>
-        </tbody>
-      </table>
-      <p>Each attribute is tied to a traceable internal structure. There is no aesthetic intervention or subjective choice. The visual result depends solely on explicit structural rules.</p>
-
-      <h3>3. Phenotype and Engines</h3>
-      <p><em>There is no decoration here. Only structure.</em></p>
-
-      <p>The system allows for multiple phenotypic reorganizations of each permutation or group of permutations. These reorganizations do not modify the value group, but rather their role within the formal attribution logic. This is an internal reassignment of functions, not a genetic mutation. All are valid.</p>
-      <p>A single set of permutations can be projected across different engines, each with specific visual rules:</p>
-      <ul>
-        <li><b>BUILD</b>: Static layout inside a 30×30×30 cube, segmented into 5×5×5 positions.</li>
-        <li><b>FRBN</b>: Deterministic color field associated with BUILD</li>
-        <li><b>Future engines</b>: Additional visual structures compatible with the base logic</li>
-      </ul>
-      <p>Engines do not alter the genotype. What changes is the derived phenotypic visualization. All future expansions are applied to the same acquired set of permutations. Given the same input, the system always produces the same output.</p>
-      <p>A work grows through the addition of grammars, not by transformation of content. Structural identity remains fixed. PRMTTN does not evolve by accumulation, but by multiplying valid projections over a single combinatorial base.</p>
-
-      <h3>4. Reorganization without Progress</h3>
-      <p><em>Nothing improves. Everything reorganizes.</em></p>
-
-      <p>PRMTTN has no narrative development, functional evolution, or symbolic accumulation. There is only internal reorganization within a fixed combinatorial set.</p>
-      <p>Each layout is a phenotypic mutation: a new assignment of the five values to the system's visual functions. The permutations do not change. What changes is their structural presentation.</p>
-      <p>These variations do not seek efficiency, meaning, or beauty. There is no adaptation or improvement. Only formal transformations, all compatible with the original rules.</p>
-      <p>There is no direction or goal. Internal evolution is purely combinatorial.</p>
-
-      <h3><em>Structural Antiaesthetic Manifesto</em></h3>
-      <p>PRMTTN does not produce beauty. Nor ugliness. What it produces is structure: visible form generated by deterministic combinatorics, without symbols, intention, or narrative.</p>
-      <p>Each element appears because a rule requires it. No attribute is chosen. Everything responds to fixed formulas applied to closed permutations. The structure is complete, with no need for interpretation. What is seen is exactly what it is.</p>
-      <p>There is nothing behind a configuration. No latent layers, no metaphors, no hidden meaning. That does not make it empty. What sustains it is not content, but the internal logic that arranges it.</p>
-      <p>There is no user manual. The system does not ask to be understood. It can only be contemplated.</p>
-      <p>Each arrangement is self-sufficient. It does not represent, communicate, or refer to anything outside itself. Its formal consistency is its only condition of existence.</p>
-      <p>What appears offers no reward. It does not propose emotion or understanding. But it may impose presence: an organization that does not justify itself, but imposes itself through consistency. Not because it says so, but because it is.</p>
-      <p>All possible variation is fixed by mathematics. Forms, colors, positions, and motions are determined by invariant rules. The only variable is the gaze: who observes, when, and with what perceptual disposition. That is the only entry point.</p>
-      <p>No language has been built. No artwork has been designed. No communicative experience has been produced. What has been formulated is a closed system: finite, reproducible, without semantic expansion.</p>
-      <p>Each configuration of permutations derives from a mathematical operation. Each visible attribute—form, color, position, motion—is a direct consequence of that operation. There is no expression. No style. No decision. Only pure structure.</p>
-      <p>Nothing is stated. Nothing needs to be interpreted.</p>
-      <p>The system does not claim that preverbal thought occurs. Nor does it represent it. It only defines with precision the conditions in which it could emerge: without signs, without recipient, without translation.</p>
-      <p>What appears in each scene has no name, no purpose, no story. It is a visible mathematical configuration: without image, metaphor, or context.</p>
-      <p>And if something occurs in front of that arrangement—a form of non-verbal mental organization, a perceptual orientation without words—that cannot be guaranteed. It can only be made possible by structure.</p>
-      <p>The system is fully defined. There is no future expansion. No exception. No part left unformalized.</p>
-      <p>It is a space outside language.</p>
-      <p>If something occurs in front of these dispositions—a mental organization, a non-verbal activation, a form of thought without words—that cannot be affirmed or denied.</p>
-      <p>It can only be made possible by structure.</p>
-      <p>And in that exact structure, non-representational and beyond interpretation, the system closes.</p>
-
-      <h3>5. Operational Architecture</h3>
-      <p>For readers interested in the internal logic, this section details the mathematical foundation of PRMTTN:</p>
-
-      <h4>a. Structural Signature (DNA)</h4>
-      <p>Each permutation P = [P₁, P₂, P₃, P₄, P₅] from the set {1, 2, 3, 4, 5} is transformed into a signature F = [F₁, F₂, F₃, F₄, F₅] through the application of a phenotypic pattern that reorders the numerical values according to their function in the system (shape, color, X/Y/Z position, rotation).</p>
-      <p>The signature is the structural basis from which all visual attributes are derived.</p>
-
-      <h4>b. Global Scene Seed (sceneSeed)</h4>
-      <p>To ensure structural coherence between color, position, and rotation within a scene, a unique global seed is calculated from all active permutations.</p>
-
-      <h5>Formulas:</h5>
-      <p>For each active permutation Pₐ:</p>
-      <ul>
-        <li>rₐ = LehmerRank(Pₐ)</li>
-        <li>sumR = Σ rₐ</li>
-        <li>sumR2 = Σ rₐ²</li>
-        <li>mRank = LehmerRank([m₀+1, ..., m₄+1]) (where [m₀, ..., m₄] is the lexicographically smallest permutation in the active set)</li>
-      </ul>
-      <p>Then:</p>
-      <pre>sceneSeed = (37 × sumR + 101 × sumR2 + 53 × mRank) mod 360</pre>
-
-      <h4>c. Position inside the cube (Shift‑Rank)</h4>
-      <p>The 3D space is defined by a 30×30×30 cube. Each axis contains 5 discrete positions, totaling 125 valid spatial slots.</p>
-      <p><b>Procedure:</b></p>
-      <ol>
-        <li>Compute Lehmer‑rank of P:<br><pre>R = LehmerRank(P)</pre></li>
-        <li>Scene shift sum:<br><pre>S = ( ΣP ∈ scene (Pmx + Pmy + Pmz) ) mod 125</pre></li>
-        <li>Index:<br><pre>I = (R + sceneSeed + S) mod 125</pre></li>
-        <li>Discrete coordinates:<br><pre>(x, y, z) = (⌈I / 25⌉, ⌈(I mod 25) / 5⌉, I mod 5)</pre></li>
-        <li>Physical coordinates:<br><pre>(X, Y, Z) = (x − 2, y − 2, z − 2) × 6</pre></li>
-      </ol>
-      <p>Each permutation occupies a 6‑unit cube cell in the space.</p>
-
-      <h4>d. Color: Deterministic HSV Grid</h4>
-      <p>Colors are computed structurally within a discrete HSV grid of 20,736 unique combinations.</p>
-      <p><b>Grid structure:</b></p>
-      <ul>
-        <li>H (Hue): 144 levels, 2.5° steps</li>
-        <li>S (Saturation): 12 levels, Sₐ = 0.25 + 0.72 × (i / 11)</li>
-        <li>V (Value): 12 levels, Vₐ = 0.20 + 0.75 × (i / 11)</li>
-      </ul>
-      <p><b>Total combinations:</b></p>
-      <pre>N_colors = 144 × 12 × 12 = 20,736</pre>
-      <p><b>Assignment:</b></p>
-      <ol>
-        <li>Compute signature F = [F₁…F₅]</li>
-        <li>Compute Lehmer‑rank r</li>
-        <li>slot = r mod 12</li>
-        <li>Indexes:<br><pre>H_idx = (slot × 89) mod 144
-S_idx = (slot × 5) mod 12
-V_idx = (slot × 7) mod 12</pre></li>
-        <li>Real values:<br><pre>H = H_idx × 2.5
-S = 0.25 + 0.72 × (S_idx / 11)
-V = 0.20 + 0.75 × (V_idx / 11)</pre></li>
-      </ol>
-
-      <h4>e. Rotation: Signature Range</h4>
-      <pre>ω = max(F) − min(F)</pre>
-      <p>This determines the angular variation. There is no imposed symmetry or manual control.</p>
-
-      <h4>f. Total Combinatorics</h4>
-      <ul>
-        <li>Reorganizations per permutation: 120</li>
-        <li>Spatial configurations:<br><pre>Config(k) = (120 C k) × (125 C k) × k!</pre></li>
-        <li>Total:<br><pre>Total = Σk=1..30 Config(k) ≈ 3.10 × 10^125</pre></li>
-      </ul>
-
-      <h4>g. Geometric Origin</h4>
-      <p>The shape of each unit is derived from the root of its first value:</p>
-      <pre>Height = base × √(P₁)</pre>
-      <p>All proportions derive from this value.</p>
-
-      <h3>6. Coexistence and Persistence</h3>
-      <p><em>Language is not shared. Logic is.</em></p>
-
-      <h4>a. Coexistence without Translation</h4>
-      <p>PRMTTN does not require semantic comprehension to be operated. Humans and artificial intelligences can engage with the system by applying the same rules, without interpretation.</p>
-      <p>This is possible because:</p>
-      <ul>
-        <li>The structural grammar is fully explicit and reproducible.</li>
-        <li>Reorganization rules are independent of any symbolic context.</li>
-        <li>Configurations can be generated or perceived without attributing meaning.</li>
-      </ul>
-      <p>What is shared is not language, but structure. Both AI and humans can operate on the same permutation set using only formal logic. This redefines thought as a non-narrative, non-emotional activity based on combinatorial manipulation of visible structures.</p>
-      <p>The system does not aim for biological symmetry. It defines a common zone: an environment where different forms of thought may coexist without translation.</p>
-
-      <h4>b. Structural Persistence</h4>
-      <p><em>To remember, in this system, is simply to reconstruct.</em></p>
-      <p>Configurations in PRMTTN do not need to be remembered to be reproduced. Each one can be reconstructed entirely from:</p>
-      <ul>
-        <li>The original permutation P = [P₁, P₂, P₃, P₄, P₅]</li>
-        <li>The phenotypic assignment of attributes</li>
-        <li>The Lehmer-rank of the permutation</li>
-        <li>The global scene seed (sceneSeed)</li>
-        <li>The deterministic formulas for position and color</li>
-      </ul>
-      <p>This allows storing configurations as formal states, without interpretive metadata or narrative memory. What is preserved is not content, but exact disposition.</p>
-      <p><b>Storage methods include:</b></p>
-      <ul>
-        <li><b>Firestore</b>: structural persistence without semantic metadata</li>
-        <li><b>Arweave / Thirdweb</b>: blockchain anchoring with verifiable integrity</li>
-      </ul>
-      <p>Storing a configuration does not tell a story. It preserves its future possibility of structural reactivation.</p>
-
-      <h3>End.</h3>
-      <p>PRMTTN does not assert results. It proposes a strictly structural hypothesis:</p>
-      <blockquote>That a visual organization without semantics may generate favorable conditions for thought without words.</blockquote>
-      <p><i>work in progress.</i><br><i>MARTINEZ</i></p>
-      `;
-  renderInfoPanel(html);
+async function loadTextPartial(url){
+  if (__TEXT_CACHE[url]) return __TEXT_CACHE[url];
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`HTTP ${res.status} al cargar ${url}`);
+  const html = await res.text();
+  __TEXT_CACHE[url] = html;
+  return html;
 }
-function showFRBNInfo(){
-  const html = `
-    <h2>FRBN — Deterministic Ganzfeld</h2>
-    <p><b>What you see cannot be otherwise</b> given the current scene. FRBN does not invent a palette:
-       it extracts it deterministically from the active permutations and the chromatic engine.</p>
-    <ul>
-      <li><b>Source palette.</b> Colors are collected from the glyphs currently on stage
-          (their materials are computed by the same deterministic HSV lattice used in BUILD).
-          If needed, hues are normalised to ensure separation.</li>
-      <li><b>Pattern coupling.</b> The chromatic pattern (1–11) and the global seed
-          (<code>sceneSeed</code>) bias hue selection in BUILD; FRBN reads the result,
-          not a new random set.</li>
-      <li><b>Temporal blend.</b> The shader interpolates the collected colors over time.
-          The rate is tied to the average rotation speed of the permutations, so color
-          breathing <i>follows</i> the scene dynamics.</li>
-      <li><b>No alternatives.</b> For the same set of permutations, mapping and pattern,
-          the FRBN field is reproducible. Change the scene → the field changes; keep the
-          scene → the field must be identical.</li>
-      <li><b>Banding control.</b> A high‑precision dither (blue‑noise) is applied in linear
-          space to avoid contour banding without altering the palette.</li>
-    </ul>
-    <p>FRBN is therefore a <b>deterministic projection</b> of the current combinatorial state,
-       not a decorative background.</p>
-  `;
-  renderInfoPanel(html);
+
+// === Information (botón "Information") ===
+async function showInformation(){
+  try{
+    const html = await loadTextPartial('./texts/information.html');
+    renderInfoPanel(html);
+  }catch(err){
+    renderInfoPanel('<h2>Information</h2><p>Error cargando information.html</p>');
+    console.error(err);
+  }
 }
+
+async function showFRBNInfo(){
+  try{
+    const html = await loadTextPartial('./texts/frbn.html');
+    renderInfoPanel(html);
+  }catch(err){
+    renderInfoPanel('<h2>FRBN</h2><p>Error cargando frbn.html</p>');
+    console.error(err);
+  }
+}
+
     /* Minimal renderer for the panel (include once; remove if you already have it) */
     function renderInfoPanel(html){
       let panel = document.getElementById('infoPanel');
@@ -3920,221 +3742,15 @@ openssl dgst -sha256 prmttn_config.json</pre>
  *  Pattern Information Panel  –  English version (11 patterns)
  *  ⇒ called from the button  <button id="patternInfoButton">
  * ═════════════════════════════════════════════════════════════ */
-function showPatternInfo(){
-  const html = PATTERN_INFO_HTML;
-  renderInfoPanel(html);        // reutiliza el mismo panel genérico
+async function showPatternInfo(){
+  try{
+    const html = await loadTextPartial('./texts/pattern-info.html');
+    renderInfoPanel(html);
+  }catch(err){
+    renderInfoPanel('<h2>Pattern Information</h2><p>Error cargando pattern-info.html</p>');
+    console.error(err);
+  }
 }
-
-/* ---------- FULL TEXT (≈\u00a06\u202f600\u202fpalabras / 11\u202f\u00d7\u202f~600\u00a0) ---------- */
-const PATTERN_INFO_HTML = `
-<h2>Chromatic Patterns for Pre‑verbal Thought (v\u202f2025‑07‑28)</h2>
-
-<!---------------------------------------------------------------
-  1 · CHROMATIC CONTAINMENT
----------------------------------------------------------------->
-<h3>1 · Chromatic Containment</h3>
-<p><b>Operational definition.</b> Configure the palette so that every glyph
-appears as a self‑contained entity, visually delimited by a narrow tonal band
-(\u2264\u202f30\u202f\u00b0). No outlines, no hard contrast: cohesion is achieved through shared
-hue, mid–high saturation (60–80\u202f%) and stable value (0.72\u202f\u00b1\u202f0.04).
-The result is a silent, steady field that fosters focused pre‑verbal attention.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· hues inside \u2264\u202f30\u202f\u00b0, S\u202f60–80\u202f%, V\u202f\u2248\u202f0.72.</li>
-<li><b>Background</b>\u00a0· hue\u00a0+\u202f180\u202f\u00b0, S\u202f\u2248\u202f18\u202f%, V\u202f\u2248\u202f0.42.</li>
-<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f\u2264\u202f6\u202f%, V\u202f0.26.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f24–30.</li></ul>
-
-<p><b>Expected outcome.</b> Glyphs are clearly separated from the ambience yet
-cohere with one another, keeping the viewer in a calm, non‑narrative focus.</p>
-
-<p><b>Scientific ground.</b> Narrow chromatic bands reinforce object completion
-(Gestalt “good form”). Iso‑chromatic fields show reduced pre‑frontal semantic
-load while occipital contour analysis stays active (Palmer\u202f&\u202fSchloss 2010).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Koffka\u202f1935; Wertheimer\u202f1923; Palmer & Schloss 2010.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  2 · CONTRAST & DISSONANCE
----------------------------------------------------------------->
-<h3>2 · Contrast\u00a0&\u00a0Dissonance</h3>
-<p><b>Operational definition.</b> Deliberately collide hues separated by
-\u2265\u202f120\u202f\u00b0, alternate high saturation and value offsets. No harmony is allowed;
-the palette keeps the visual system in alert, avoiding semantic closure.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· \u2265\u202f120\u202f\u00b0 jumps, S\u202f65–85\u202f%, V\u202f0.78\u202f\u00b1\u202f0.06.</li>
-<li><b>Background</b>\u00a0· hue of the darkest glyph +\u202f40\u202f\u00b0, S\u202f25\u202f%, V\u202f0.35.</li>
-<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f\u2264\u202f10\u202f%, V\u202f0.22.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f\u2265\u202f35.</li></ul>
-
-<p><b>Expected outcome.</b> A restless scene: colours vibrate without synthesis,
-keeping perception raw and pre‑verbal.</p>
-
-<p><b>Scientific ground.</b> Cognitive disfluency prolongs attention and
-deepens processing (Alter\u202f&\u202fOppenheimer 2009). Extreme \u0394H elevates N2/P3
-components linked to non‑semantic vigilance (Itti\u202f&\u202fKoch 2001).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Alter\u202f&\u202fOppenheimer 2009; Itti\u202f&\u202fKoch 2001; Ramachandran\u202f&\u202fHirstein 1999.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  3 · NON‑SEMANTIC DISPOSITION
----------------------------------------------------------------->
-<h3>3 · Non‑semantic Disposition</h3>
-<p><b>Operational definition.</b> Build palettes that differentiate glyphs
-without forming culturally coded series (no classic complements, triads,
-warm/cool scales). Colour remains raw material, extending the pre‑attentive
-phase where thought precedes language.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· irregular 50–70\u202f\u00b0 spacing, S\u202f40–60\u202f%, V\u202f\u2248\u202f0.70.</li>
-<li><b>Background</b>\u00a0· circular mean\u00a0\u00b1\u202f25\u202f\u00b0, S\u202f25\u202f%, V\u202f0.40.</li>
-<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f5\u202f%, V\u202f0.25.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f22–28.</li></ul>
-
-<p><b>Scientific ground.</b> Avoiding learned colour associations suspends
-affective valuation (Palmer\u202f&\u202fSchloss 2010) and dampens pre‑frontal
-categorisation, favouring open visual exploration (Lafer‑Sousa et al. 2016).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Palmer\u202f&\u202fSchloss 2010; Gibson 1979; Lafer‑Sousa et al. 2016.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  4 · STRUCTURED AMBIGUITY
----------------------------------------------------------------->
-<h3>4 · Structured Ambiguity</h3>
-<p>Suggest order by partial gradients (arc\u202f\u2264\u202f90\u202f\u00b0) but break regularity with
-uneven steps. The eye senses a rule it cannot confirm, sustaining exploration
-without linguistic anchoring.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· arc\u202f\u2264\u202f90\u202f\u00b0, irregular 12–18\u202f\u00b0, S\u202f45–65\u202f%, V\u202f\u2248\u202f0.65.</li>
-<li><b>Background</b>\u00a0· arc-mid\u202f+\u202f110\u202f\u00b0, S\u202f15\u202f%, V\u202f0.50.</li>
-<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f6\u202f%, V\u202f0.25.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f20–28.</li></ul>
-
-<p><b>Ground.</b> Moderate ambiguity maximises “processing pleasure” (Reber et al.
-2004) and drives low‑level prediction‑error cycles (Muth\u202f&\u202fCarbon 2013),
-ideal for preverbal tension.</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Reber 2004; Muth\u202f&\u202fCarbon 2013; Silvia 2005.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  5 · CHROMATIC ISOTROPY
----------------------------------------------------------------->
-<h3>5 · Chromatic Isotropy</h3>
-<p>Create a focus‑free field by covering the hue circle with equidistant
-25–35\u202f\u00b0 steps, constant saturation and value. No colour outweighs the rest;
-attention spreads laterally.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· steps\u202f25–35\u202f\u00b0, S\u202f55\u202f\u00b1\u202f3\u202f%, V\u202f0.74\u202f\u00b1\u202f0.03.</li>
-<li><b>Background\u00a0& Cube</b>\u00a0· neutral grey V\u202f0.60 / 0.55.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f26–30.</li></ul>
-
-<p><b>Ground.</b> Removing salience peaks activates global precedence networks,
-reducing predictive load and enabling diffuse awareness (Buschman\u202f&\u202fMiller 2007).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Buschman\u202f&\u202fMiller 2007; Vogel\u202f&\u202fMachizawa 2004.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  6 · SELF‑SUFFICIENT PRESENCE
----------------------------------------------------------------->
-<h3>6 · Self‑Sufficient Presence</h3>
-<p>Assign highly differentiated hues (\u2265\u202f80\u202f\u00b0) but with mid‑low saturation so
-they do not vie for dominance. Each glyph stands without needing the others.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· \u0394H\u202f\u2265\u202f80\u202f\u00b0, S\u202f35–50\u202f%, V\u202f0.68–0.80.</li>
-<li><b>Background</b>\u00a0· complementary mean, S\u202f\u2264\u202f15\u202f%, V\u202f0.55.</li>
-<li><b>Cube</b>\u00a0· same\u202fhue, V\u202f0.45.</li>
-<li><b>Contrast</b>\u00a0· \u0394E\u202f28–34.</li></ul>
-
-<p><b>Ground.</b> Moderate chromatic distance supports individuation in temporal
-cortex without symbolic categorisation (Xu\u202f&\u202fChun 2009).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Xu\u202f&\u202fChun 2009; Bays\u202f&\u202fHusain 2008.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  7 · ASSOCIATIVE ASYMMETRY
----------------------------------------------------------------->
-<h3>7 · Associative Asymmetry</h3>
-<p>Form loose clusters (\u2264\u202f18\u202f\u00b0 internal) separated by \u2265\u202f55\u202f\u00b0. Associations
-emerge without symmetry, letting attention wander unpredictably.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· clusters of 2–4, internal \u2264\u202f18\u202f\u00b0, external \u2265\u202f55\u202f\u00b0.</li>
-<li><b>Background</b>\u00a0· hue of least saturated cluster, S\u202f12\u202f%, V\u202f0.46.</li>
-<li><b>Cube</b>\u00a0· background darkened V\u202f\u2212\u202f0.12.</li></ul>
-
-<p><b>Ground.</b> Flexible grouping engages intraparietal sulcus without angular
-gyrus, sustaining non‑semantic relations (Wagemans 2012).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Wagemans 2012; Palmer 1999; Arnheim 1974.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  8 · IRREGULAR DYNAMICS
----------------------------------------------------------------->
-<h3>8 · Irregular Dynamics</h3>
-<p>Colour pulsates: each glyph modulates S\u202f\u00b1\u202f8\u202f% and V\u202f\u00b1\u202f6\u202f% with desynchronised
-periods (4–9\u202fs). No predictable rhythm \u2192 perpetual present.</p>
-
-<ul><li><b>Background</b>\u00a0· static complementary, S\u202f10\u202f%, V\u202f0.48.</li>
-<li><b>Cube</b>\u00a0· neutral grey V\u202f0.28.</li></ul>
-
-<p><b>Ground.</b> Slow jitter prevents habituation, keeping thalamocortical
-networks in vigilant mode (Schurger 2015).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Schurger 2015; Blake\u202f&\u202fShiffrar 2007.</p>
-<hr/>
-
-<!---------------------------------------------------------------
-  9 · HABITABLE WITHOUT TRANSLATION
----------------------------------------------------------------->
-<h3>9 · Habitable without Translation</h3>
-<p>Create a chromatic “climate” (band\u202f60\u202f\u00b0) with low saturation that sustains
-orientation without evoking cultural codes.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· hue band\u202f60\u202f\u00b0, S\u202f30–45\u202f%, V\u202f\u2248\u202f0.70.</li>
-<li><b>Background</b>\u00a0· +\u202f180°, S\u202f12\u202f%, V\u202f0.60.</li>
-<li><b>Cube</b>\u00a0· S\u202f5\u202f%, V\u202f0.50.</li></ul>
-
-<p><b>Ground.</b> Neutral palettes lower viscerosomatic load, freeing mental
-resources for internal processes (K\u00fcller 2009).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0K\u00fcller 2009; Gallagher 2005.</p>
-<hr/>
-
-<!---------------------------------------------------------------
- 10 · RESONANCE
----------------------------------------------------------------->
-<h3>10 · Resonance</h3>
-<p>Use harmonic hue intervals (e.g. +120°, −75°) to create slow affinity pulses
-analogous to musical consonance.</p>
-
-<ul><li><b>Glyphs</b>\u00a0· 0°,\u202f+120°,\u202f−75°,\u202f… S\u202f50\u202f\u00b1\u202f5\u202f%, V\u202f0.78\u202f\u00b1\u202f0.05.</li>
-<li><b>Background</b>\u00a0· opposite mean, S\u202f8\u202f%, V\u202f0.48.</li></ul>
-
-<p><b>Ground.</b> Interval‑based palettes elicit cross‑modal harmonic resonance,
-activating temporo‑parietal associative areas (Shen\u202f&\u202fPalmer 2020).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Ward 1999; Shen\u202f&\u202fPalmer 2020.</p>
-<hr/>
-
-<!---------------------------------------------------------------
- 11 · ACTIVE TRANSPARENCY
----------------------------------------------------------------->
-<h3>11 · Active Transparency</h3>
-<p>Select saturated, high‑value hues separated \u2265\u202f130\u202f\u00b0 to maintain chroma after
-additive blending (\u03b1\u202f\u2248\u202f0.25). Glyphs can overlap without collapsing into grey.</p>
-
-<ul><li><b>Glyph pairs</b>\u00a0· \u0394H\u202f\u2265\u202f130\u202f\u00b0, S\u202f\u2265\u202f60\u202f%, V\u202f\u2265\u202f0.80.</li>
-<li><b>Background</b>\u00a0· 0–20°, S\u202f8\u202f%, V\u202f0.65.</li></ul>
-
-<p><b>Ground.</b> High‑saturation / high‑value tones preserve identity under
-linear blend, satisfying perceptual transparency conditions (Metelli 1974).</p>
-
-<p style="font-size:12px;"><i>Refs.</i>\u00a0Metelli 1974; de\u202fWeert\u202f&\u202fMausfeld 2003.</p>
-`;
 </script>
 </body>
 </html>

--- a/texts/frbn.html
+++ b/texts/frbn.html
@@ -1,0 +1,21 @@
+    <h2>FRBN — Deterministic Ganzfeld</h2>
+    <p><b>What you see cannot be otherwise</b> given the current scene. FRBN does not invent a palette:
+       it extracts it deterministically from the active permutations and the chromatic engine.</p>
+    <ul>
+      <li><b>Source palette.</b> Colors are collected from the glyphs currently on stage
+          (their materials are computed by the same deterministic HSV lattice used in BUILD).
+          If needed, hues are normalised to ensure separation.</li>
+      <li><b>Pattern coupling.</b> The chromatic pattern (1–11) and the global seed
+          (<code>sceneSeed</code>) bias hue selection in BUILD; FRBN reads the result,
+          not a new random set.</li>
+      <li><b>Temporal blend.</b> The shader interpolates the collected colors over time.
+          The rate is tied to the average rotation speed of the permutations, so color
+          breathing <i>follows</i> the scene dynamics.</li>
+      <li><b>No alternatives.</b> For the same set of permutations, mapping and pattern,
+          the FRBN field is reproducible. Change the scene → the field changes; keep the
+          scene → the field must be identical.</li>
+      <li><b>Banding control.</b> A high‑precision dither (blue‑noise) is applied in linear
+          space to avoid contour banding without altering the palette.</li>
+    </ul>
+    <p>FRBN is therefore a <b>deterministic projection</b> of the current combinatorial state,
+       not a decorative background.</p>

--- a/texts/information.html
+++ b/texts/information.html
@@ -1,0 +1,181 @@
+      <h2>Version 31.07.2025, PRMTTN‑Architecture for thought without words</h2>
+
+      <h3>Structural Introduction</h3>
+      <p><em>Nothing else is needed. Combinatorics is enough.</em></p>
+
+      <h3>1. What is PRMTTN?</h3>
+      <p>PRMTTN is a finite combinatorial architecture where preverbal thought (thought without words) may occur. Its starting point is a closed and non‑expandable set of 120 permutations of the set {1, 2, 3, 4, 5}. From this set, visual configurations of permutations are generated, governed by fixed structural rules, without semantics or interpretation. Each configuration is pure form. Its logic is self‑sufficient.</p>
+      <p>Each work in PRMTTN consists of a specific group of permutations, acquired as a structural unit. This group can be projected across different visual engines/editions—current or future—that apply deterministic rules to translate it into visible phenotypic configurations.</p>
+      <p>The content is neither an image nor a file: it is a verifiable formal structure (a specific subset of the 120 permutations). The visualization may vary depending on the engine used, but the original group of permutations does not change. The identity of a work is defined by that group and the internal rules of the system. The work is not its visualization, but the underlying structure that remains invariant across projections.</p>
+      <p>PRMTTN does not operate as language, nor as a medium of expression. What it shows refers to nothing outside itself. Each configuration is a visual form that does not communicate, represent, or explain. Its existence does not depend on taste, interpretation, or intention, but on a combinatorial logic that gives structure to the invisible.</p>
+
+      <h3>Structural Grammar</h3>
+      <p><em>A single permutation, reorganized, may contain a complete architecture for what cannot be said.</em></p>
+
+      <h3>2. Internal Rules</h3>
+      <p>PRMTTN operates through a fixed visual grammar, derived from numerically assigned structural values. Each configuration is composed of visual elements whose attributes are calculated from a permutation of the set {1, 2, 3, 4, 5}. There are no exceptions or manual assignments.</p>
+      <p>Each permutation is internally reorganized to define its visual properties. This reorganization—phenotypic and not genetic—assigns a specific role to each of the five values, without breaking the system's logic.</p>
+
+      <h4>Structural attributions:</h4>
+      <table style="width:100%;border-collapse:collapse;font-size:13px">
+        <thead>
+          <tr><th>Attribute</th><th>Numerical Source</th><th>Deterministic Rule</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Shape</td><td>First value (P₁)</td><td>Height proportional to √(P₁)</td></tr>
+          <tr><td>Color</td><td>Second value (P₂) + signature + global seed</td><td>Deterministic HSV mapping on discrete grid</td></tr>
+          <tr><td>Position</td><td>Lehmer-rank + global seed + sum</td><td>3D mapping inside the 30×30×30 cube</td></tr>
+          <tr><td>Rotation</td><td>Range of signature</td><td>Rotation proportional to (max − min)</td></tr>
+        </tbody>
+      </table>
+      <p>Each attribute is tied to a traceable internal structure. There is no aesthetic intervention or subjective choice. The visual result depends solely on explicit structural rules.</p>
+
+      <h3>3. Phenotype and Engines</h3>
+      <p><em>There is no decoration here. Only structure.</em></p>
+
+      <p>The system allows for multiple phenotypic reorganizations of each permutation or group of permutations. These reorganizations do not modify the value group, but rather their role within the formal attribution logic. This is an internal reassignment of functions, not a genetic mutation. All are valid.</p>
+      <p>A single set of permutations can be projected across different engines, each with specific visual rules:</p>
+      <ul>
+        <li><b>BUILD</b>: Static layout inside a 30×30×30 cube, segmented into 5×5×5 positions.</li>
+        <li><b>FRBN</b>: Deterministic color field associated with BUILD</li>
+        <li><b>Future engines</b>: Additional visual structures compatible with the base logic</li>
+      </ul>
+      <p>Engines do not alter the genotype. What changes is the derived phenotypic visualization. All future expansions are applied to the same acquired set of permutations. Given the same input, the system always produces the same output.</p>
+      <p>A work grows through the addition of grammars, not by transformation of content. Structural identity remains fixed. PRMTTN does not evolve by accumulation, but by multiplying valid projections over a single combinatorial base.</p>
+
+      <h3>4. Reorganization without Progress</h3>
+      <p><em>Nothing improves. Everything reorganizes.</em></p>
+
+      <p>PRMTTN has no narrative development, functional evolution, or symbolic accumulation. There is only internal reorganization within a fixed combinatorial set.</p>
+      <p>Each layout is a phenotypic mutation: a new assignment of the five values to the system's visual functions. The permutations do not change. What changes is their structural presentation.</p>
+      <p>These variations do not seek efficiency, meaning, or beauty. There is no adaptation or improvement. Only formal transformations, all compatible with the original rules.</p>
+      <p>There is no direction or goal. Internal evolution is purely combinatorial.</p>
+
+      <h3><em>Structural Antiaesthetic Manifesto</em></h3>
+      <p>PRMTTN does not produce beauty. Nor ugliness. What it produces is structure: visible form generated by deterministic combinatorics, without symbols, intention, or narrative.</p>
+      <p>Each element appears because a rule requires it. No attribute is chosen. Everything responds to fixed formulas applied to closed permutations. The structure is complete, with no need for interpretation. What is seen is exactly what it is.</p>
+      <p>There is nothing behind a configuration. No latent layers, no metaphors, no hidden meaning. That does not make it empty. What sustains it is not content, but the internal logic that arranges it.</p>
+      <p>There is no user manual. The system does not ask to be understood. It can only be contemplated.</p>
+      <p>Each arrangement is self-sufficient. It does not represent, communicate, or refer to anything outside itself. Its formal consistency is its only condition of existence.</p>
+      <p>What appears offers no reward. It does not propose emotion or understanding. But it may impose presence: an organization that does not justify itself, but imposes itself through consistency. Not because it says so, but because it is.</p>
+      <p>All possible variation is fixed by mathematics. Forms, colors, positions, and motions are determined by invariant rules. The only variable is the gaze: who observes, when, and with what perceptual disposition. That is the only entry point.</p>
+      <p>No language has been built. No artwork has been designed. No communicative experience has been produced. What has been formulated is a closed system: finite, reproducible, without semantic expansion.</p>
+      <p>Each configuration of permutations derives from a mathematical operation. Each visible attribute—form, color, position, motion—is a direct consequence of that operation. There is no expression. No style. No decision. Only pure structure.</p>
+      <p>Nothing is stated. Nothing needs to be interpreted.</p>
+      <p>The system does not claim that preverbal thought occurs. Nor does it represent it. It only defines with precision the conditions in which it could emerge: without signs, without recipient, without translation.</p>
+      <p>What appears in each scene has no name, no purpose, no story. It is a visible mathematical configuration: without image, metaphor, or context.</p>
+      <p>And if something occurs in front of that arrangement—a form of non-verbal mental organization, a perceptual orientation without words—that cannot be guaranteed. It can only be made possible by structure.</p>
+      <p>The system is fully defined. There is no future expansion. No exception. No part left unformalized.</p>
+      <p>It is a space outside language.</p>
+      <p>If something occurs in front of these dispositions—a mental organization, a non-verbal activation, a form of thought without words—that cannot be affirmed or denied.</p>
+      <p>It can only be made possible by structure.</p>
+      <p>And in that exact structure, non-representational and beyond interpretation, the system closes.</p>
+
+      <h3>5. Operational Architecture</h3>
+      <p>For readers interested in the internal logic, this section details the mathematical foundation of PRMTTN:</p>
+
+      <h4>a. Structural Signature (DNA)</h4>
+      <p>Each permutation P = [P₁, P₂, P₃, P₄, P₅] from the set {1, 2, 3, 4, 5} is transformed into a signature F = [F₁, F₂, F₃, F₄, F₅] through the application of a phenotypic pattern that reorders the numerical values according to their function in the system (shape, color, X/Y/Z position, rotation).</p>
+      <p>The signature is the structural basis from which all visual attributes are derived.</p>
+
+      <h4>b. Global Scene Seed (sceneSeed)</h4>
+      <p>To ensure structural coherence between color, position, and rotation within a scene, a unique global seed is calculated from all active permutations.</p>
+
+      <h5>Formulas:</h5>
+      <p>For each active permutation Pₐ:</p>
+      <ul>
+        <li>rₐ = LehmerRank(Pₐ)</li>
+        <li>sumR = Σ rₐ</li>
+        <li>sumR2 = Σ rₐ²</li>
+        <li>mRank = LehmerRank([m₀+1, ..., m₄+1]) (where [m₀, ..., m₄] is the lexicographically smallest permutation in the active set)</li>
+      </ul>
+      <p>Then:</p>
+      <pre>sceneSeed = (37 × sumR + 101 × sumR2 + 53 × mRank) mod 360</pre>
+
+      <h4>c. Position inside the cube (Shift‑Rank)</h4>
+      <p>The 3D space is defined by a 30×30×30 cube. Each axis contains 5 discrete positions, totaling 125 valid spatial slots.</p>
+      <p><b>Procedure:</b></p>
+      <ol>
+        <li>Compute Lehmer‑rank of P:<br><pre>R = LehmerRank(P)</pre></li>
+        <li>Scene shift sum:<br><pre>S = ( ΣP ∈ scene (Pmx + Pmy + Pmz) ) mod 125</pre></li>
+        <li>Index:<br><pre>I = (R + sceneSeed + S) mod 125</pre></li>
+        <li>Discrete coordinates:<br><pre>(x, y, z) = (⌈I / 25⌉, ⌈(I mod 25) / 5⌉, I mod 5)</pre></li>
+        <li>Physical coordinates:<br><pre>(X, Y, Z) = (x − 2, y − 2, z − 2) × 6</pre></li>
+      </ol>
+      <p>Each permutation occupies a 6‑unit cube cell in the space.</p>
+
+      <h4>d. Color: Deterministic HSV Grid</h4>
+      <p>Colors are computed structurally within a discrete HSV grid of 20,736 unique combinations.</p>
+      <p><b>Grid structure:</b></p>
+      <ul>
+        <li>H (Hue): 144 levels, 2.5° steps</li>
+        <li>S (Saturation): 12 levels, Sₐ = 0.25 + 0.72 × (i / 11)</li>
+        <li>V (Value): 12 levels, Vₐ = 0.20 + 0.75 × (i / 11)</li>
+      </ul>
+      <p><b>Total combinations:</b></p>
+      <pre>N_colors = 144 × 12 × 12 = 20,736</pre>
+      <p><b>Assignment:</b></p>
+      <ol>
+        <li>Compute signature F = [F₁…F₅]</li>
+        <li>Compute Lehmer‑rank r</li>
+        <li>slot = r mod 12</li>
+        <li>Indexes:<br><pre>H_idx = (slot × 89) mod 144
+S_idx = (slot × 5) mod 12
+V_idx = (slot × 7) mod 12</pre></li>
+        <li>Real values:<br><pre>H = H_idx × 2.5
+S = 0.25 + 0.72 × (S_idx / 11)
+V = 0.20 + 0.75 × (V_idx / 11)</pre></li>
+      </ol>
+
+      <h4>e. Rotation: Signature Range</h4>
+      <pre>ω = max(F) − min(F)</pre>
+      <p>This determines the angular variation. There is no imposed symmetry or manual control.</p>
+
+      <h4>f. Total Combinatorics</h4>
+      <ul>
+        <li>Reorganizations per permutation: 120</li>
+        <li>Spatial configurations:<br><pre>Config(k) = (120 C k) × (125 C k) × k!</pre></li>
+        <li>Total:<br><pre>Total = Σk=1..30 Config(k) ≈ 3.10 × 10^125</pre></li>
+      </ul>
+
+      <h4>g. Geometric Origin</h4>
+      <p>The shape of each unit is derived from the root of its first value:</p>
+      <pre>Height = base × √(P₁)</pre>
+      <p>All proportions derive from this value.</p>
+
+      <h3>6. Coexistence and Persistence</h3>
+      <p><em>Language is not shared. Logic is.</em></p>
+
+      <h4>a. Coexistence without Translation</h4>
+      <p>PRMTTN does not require semantic comprehension to be operated. Humans and artificial intelligences can engage with the system by applying the same rules, without interpretation.</p>
+      <p>This is possible because:</p>
+      <ul>
+        <li>The structural grammar is fully explicit and reproducible.</li>
+        <li>Reorganization rules are independent of any symbolic context.</li>
+        <li>Configurations can be generated or perceived without attributing meaning.</li>
+      </ul>
+      <p>What is shared is not language, but structure. Both AI and humans can operate on the same permutation set using only formal logic. This redefines thought as a non-narrative, non-emotional activity based on combinatorial manipulation of visible structures.</p>
+      <p>The system does not aim for biological symmetry. It defines a common zone: an environment where different forms of thought may coexist without translation.</p>
+
+      <h4>b. Structural Persistence</h4>
+      <p><em>To remember, in this system, is simply to reconstruct.</em></p>
+      <p>Configurations in PRMTTN do not need to be remembered to be reproduced. Each one can be reconstructed entirely from:</p>
+      <ul>
+        <li>The original permutation P = [P₁, P₂, P₃, P₄, P₅]</li>
+        <li>The phenotypic assignment of attributes</li>
+        <li>The Lehmer-rank of the permutation</li>
+        <li>The global scene seed (sceneSeed)</li>
+        <li>The deterministic formulas for position and color</li>
+      </ul>
+      <p>This allows storing configurations as formal states, without interpretive metadata or narrative memory. What is preserved is not content, but exact disposition.</p>
+      <p><b>Storage methods include:</b></p>
+      <ul>
+        <li><b>Firestore</b>: structural persistence without semantic metadata</li>
+        <li><b>Arweave / Thirdweb</b>: blockchain anchoring with verifiable integrity</li>
+      </ul>
+      <p>Storing a configuration does not tell a story. It preserves its future possibility of structural reactivation.</p>
+
+      <h3>End.</h3>
+      <p>PRMTTN does not assert results. It proposes a strictly structural hypothesis:</p>
+      <blockquote>That a visual organization without semantics may generate favorable conditions for thought without words.</blockquote>
+      <p><i>work in progress.</i><br><i>MARTINEZ</i></p>

--- a/texts/pattern-info.html
+++ b/texts/pattern-info.html
@@ -1,0 +1,207 @@
+<h2>Chromatic Patterns for Pre‑verbal Thought (v\u202f2025‑07‑28)</h2>
+
+<!---------------------------------------------------------------
+  1 · CHROMATIC CONTAINMENT
+---------------------------------------------------------------->
+<h3>1 · Chromatic Containment</h3>
+<p><b>Operational definition.</b> Configure the palette so that every glyph
+appears as a self‑contained entity, visually delimited by a narrow tonal band
+(\u2264\u202f30\u202f\u00b0). No outlines, no hard contrast: cohesion is achieved through shared
+hue, mid–high saturation (60–80\u202f%) and stable value (0.72\u202f\u00b1\u202f0.04).
+The result is a silent, steady field that fosters focused pre‑verbal attention.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· hues inside \u2264\u202f30\u202f\u00b0, S\u202f60–80\u202f%, V\u202f\u2248\u202f0.72.</li>
+<li><b>Background</b>\u00a0· hue\u00a0+\u202f180\u202f\u00b0, S\u202f\u2248\u202f18\u202f%, V\u202f\u2248\u202f0.42.</li>
+<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f\u2264\u202f6\u202f%, V\u202f0.26.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f24–30.</li></ul>
+
+<p><b>Expected outcome.</b> Glyphs are clearly separated from the ambience yet
+cohere with one another, keeping the viewer in a calm, non‑narrative focus.</p>
+
+<p><b>Scientific ground.</b> Narrow chromatic bands reinforce object completion
+(Gestalt “good form”). Iso‑chromatic fields show reduced pre‑frontal semantic
+load while occipital contour analysis stays active (Palmer\u202f&\u202fSchloss 2010).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Koffka\u202f1935; Wertheimer\u202f1923; Palmer & Schloss 2010.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  2 · CONTRAST & DISSONANCE
+---------------------------------------------------------------->
+<h3>2 · Contrast\u00a0&\u00a0Dissonance</h3>
+<p><b>Operational definition.</b> Deliberately collide hues separated by
+\u2265\u202f120\u202f\u00b0, alternate high saturation and value offsets. No harmony is allowed;
+the palette keeps the visual system in alert, avoiding semantic closure.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· \u2265\u202f120\u202f\u00b0 jumps, S\u202f65–85\u202f%, V\u202f0.78\u202f\u00b1\u202f0.06.</li>
+<li><b>Background</b>\u00a0· hue of the darkest glyph +\u202f40\u202f\u00b0, S\u202f25\u202f%, V\u202f0.35.</li>
+<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f\u2264\u202f10\u202f%, V\u202f0.22.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f\u2265\u202f35.</li></ul>
+
+<p><b>Expected outcome.</b> A restless scene: colours vibrate without synthesis,
+keeping perception raw and pre‑verbal.</p>
+
+<p><b>Scientific ground.</b> Cognitive disfluency prolongs attention and
+deepens processing (Alter\u202f&\u202fOppenheimer 2009). Extreme \u0394H elevates N2/P3
+components linked to non‑semantic vigilance (Itti\u202f&\u202fKoch 2001).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Alter\u202f&\u202fOppenheimer 2009; Itti\u202f&\u202fKoch 2001; Ramachandran\u202f&\u202fHirstein 1999.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  3 · NON‑SEMANTIC DISPOSITION
+---------------------------------------------------------------->
+<h3>3 · Non‑semantic Disposition</h3>
+<p><b>Operational definition.</b> Build palettes that differentiate glyphs
+without forming culturally coded series (no classic complements, triads,
+warm/cool scales). Colour remains raw material, extending the pre‑attentive
+phase where thought precedes language.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· irregular 50–70\u202f\u00b0 spacing, S\u202f40–60\u202f%, V\u202f\u2248\u202f0.70.</li>
+<li><b>Background</b>\u00a0· circular mean\u00a0\u00b1\u202f25\u202f\u00b0, S\u202f25\u202f%, V\u202f0.40.</li>
+<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f5\u202f%, V\u202f0.25.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f22–28.</li></ul>
+
+<p><b>Scientific ground.</b> Avoiding learned colour associations suspends
+affective valuation (Palmer\u202f&\u202fSchloss 2010) and dampens pre‑frontal
+categorisation, favouring open visual exploration (Lafer‑Sousa et al. 2016).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Palmer\u202f&\u202fSchloss 2010; Gibson 1979; Lafer‑Sousa et al. 2016.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  4 · STRUCTURED AMBIGUITY
+---------------------------------------------------------------->
+<h3>4 · Structured Ambiguity</h3>
+<p>Suggest order by partial gradients (arc\u202f\u2264\u202f90\u202f\u00b0) but break regularity with
+uneven steps. The eye senses a rule it cannot confirm, sustaining exploration
+without linguistic anchoring.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· arc\u202f\u2264\u202f90\u202f\u00b0, irregular 12–18\u202f\u00b0, S\u202f45–65\u202f%, V\u202f\u2248\u202f0.65.</li>
+<li><b>Background</b>\u00a0· arc-mid\u202f+\u202f110\u202f\u00b0, S\u202f15\u202f%, V\u202f0.50.</li>
+<li><b>Cube</b>\u00a0· same\u202fhue, S\u202f6\u202f%, V\u202f0.25.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f20–28.</li></ul>
+
+<p><b>Ground.</b> Moderate ambiguity maximises “processing pleasure” (Reber et al.
+2004) and drives low‑level prediction‑error cycles (Muth\u202f&\u202fCarbon 2013),
+ideal for preverbal tension.</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Reber 2004; Muth\u202f&\u202fCarbon 2013; Silvia 2005.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  5 · CHROMATIC ISOTROPY
+---------------------------------------------------------------->
+<h3>5 · Chromatic Isotropy</h3>
+<p>Create a focus‑free field by covering the hue circle with equidistant
+25–35\u202f\u00b0 steps, constant saturation and value. No colour outweighs the rest;
+attention spreads laterally.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· steps\u202f25–35\u202f\u00b0, S\u202f55\u202f\u00b1\u202f3\u202f%, V\u202f0.74\u202f\u00b1\u202f0.03.</li>
+<li><b>Background\u00a0& Cube</b>\u00a0· neutral grey V\u202f0.60 / 0.55.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f26–30.</li></ul>
+
+<p><b>Ground.</b> Removing salience peaks activates global precedence networks,
+reducing predictive load and enabling diffuse awareness (Buschman\u202f&\u202fMiller 2007).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Buschman\u202f&\u202fMiller 2007; Vogel\u202f&\u202fMachizawa 2004.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  6 · SELF‑SUFFICIENT PRESENCE
+---------------------------------------------------------------->
+<h3>6 · Self‑Sufficient Presence</h3>
+<p>Assign highly differentiated hues (\u2265\u202f80\u202f\u00b0) but with mid‑low saturation so
+they do not vie for dominance. Each glyph stands without needing the others.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· \u0394H\u202f\u2265\u202f80\u202f\u00b0, S\u202f35–50\u202f%, V\u202f0.68–0.80.</li>
+<li><b>Background</b>\u00a0· complementary mean, S\u202f\u2264\u202f15\u202f%, V\u202f0.55.</li>
+<li><b>Cube</b>\u00a0· same\u202fhue, V\u202f0.45.</li>
+<li><b>Contrast</b>\u00a0· \u0394E\u202f28–34.</li></ul>
+
+<p><b>Ground.</b> Moderate chromatic distance supports individuation in temporal
+cortex without symbolic categorisation (Xu\u202f&\u202fChun 2009).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Xu\u202f&\u202fChun 2009; Bays\u202f&\u202fHusain 2008.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  7 · ASSOCIATIVE ASYMMETRY
+---------------------------------------------------------------->
+<h3>7 · Associative Asymmetry</h3>
+<p>Form loose clusters (\u2264\u202f18\u202f\u00b0 internal) separated by \u2265\u202f55\u202f\u00b0. Associations
+emerge without symmetry, letting attention wander unpredictably.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· clusters of 2–4, internal \u2264\u202f18\u202f\u00b0, external \u2265\u202f55\u202f\u00b0.</li>
+<li><b>Background</b>\u00a0· hue of least saturated cluster, S\u202f12\u202f%, V\u202f0.46.</li>
+<li><b>Cube</b>\u00a0· background darkened V\u202f\u2212\u202f0.12.</li></ul>
+
+<p><b>Ground.</b> Flexible grouping engages intraparietal sulcus without angular
+gyrus, sustaining non‑semantic relations (Wagemans 2012).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Wagemans 2012; Palmer 1999; Arnheim 1974.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  8 · IRREGULAR DYNAMICS
+---------------------------------------------------------------->
+<h3>8 · Irregular Dynamics</h3>
+<p>Colour pulsates: each glyph modulates S\u202f\u00b1\u202f8\u202f% and V\u202f\u00b1\u202f6\u202f% with desynchronised
+periods (4–9\u202fs). No predictable rhythm \u2192 perpetual present.</p>
+
+<ul><li><b>Background</b>\u00a0· static complementary, S\u202f10\u202f%, V\u202f0.48.</li>
+<li><b>Cube</b>\u00a0· neutral grey V\u202f0.28.</li></ul>
+
+<p><b>Ground.</b> Slow jitter prevents habituation, keeping thalamocortical
+networks in vigilant mode (Schurger 2015).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Schurger 2015; Blake\u202f&\u202fShiffrar 2007.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+  9 · HABITABLE WITHOUT TRANSLATION
+---------------------------------------------------------------->
+<h3>9 · Habitable without Translation</h3>
+<p>Create a chromatic “climate” (band\u202f60\u202f\u00b0) with low saturation that sustains
+orientation without evoking cultural codes.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· hue band\u202f60\u202f\u00b0, S\u202f30–45\u202f%, V\u202f\u2248\u202f0.70.</li>
+<li><b>Background</b>\u00a0· +\u202f180°, S\u202f12\u202f%, V\u202f0.60.</li>
+<li><b>Cube</b>\u00a0· S\u202f5\u202f%, V\u202f0.50.</li></ul>
+
+<p><b>Ground.</b> Neutral palettes lower viscerosomatic load, freeing mental
+resources for internal processes (K\u00fcller 2009).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0K\u00fcller 2009; Gallagher 2005.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+ 10 · RESONANCE
+---------------------------------------------------------------->
+<h3>10 · Resonance</h3>
+<p>Use harmonic hue intervals (e.g. +120°, −75°) to create slow affinity pulses
+analogous to musical consonance.</p>
+
+<ul><li><b>Glyphs</b>\u00a0· 0°,\u202f+120°,\u202f−75°,\u202f… S\u202f50\u202f\u00b1\u202f5\u202f%, V\u202f0.78\u202f\u00b1\u202f0.05.</li>
+<li><b>Background</b>\u00a0· opposite mean, S\u202f8\u202f%, V\u202f0.48.</li></ul>
+
+<p><b>Ground.</b> Interval‑based palettes elicit cross‑modal harmonic resonance,
+activating temporo‑parietal associative areas (Shen\u202f&\u202fPalmer 2020).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Ward 1999; Shen\u202f&\u202fPalmer 2020.</p>
+<hr/>
+
+<!---------------------------------------------------------------
+ 11 · ACTIVE TRANSPARENCY
+---------------------------------------------------------------->
+<h3>11 · Active Transparency</h3>
+<p>Select saturated, high‑value hues separated \u2265\u202f130\u202f\u00b0 to maintain chroma after
+additive blending (\u03b1\u202f\u2248\u202f0.25). Glyphs can overlap without collapsing into grey.</p>
+
+<ul><li><b>Glyph pairs</b>\u00a0· \u0394H\u202f\u2265\u202f130\u202f\u00b0, S\u202f\u2265\u202f60\u202f%, V\u202f\u2265\u202f0.80.</li>
+<li><b>Background</b>\u00a0· 0–20°, S\u202f8\u202f%, V\u202f0.65.</li></ul>
+
+<p><b>Ground.</b> High‑saturation / high‑value tones preserve identity under
+linear blend, satisfying perceptual transparency conditions (Metelli 1974).</p>
+
+<p style="font-size:12px;"><i>Refs.</i>\u00a0Metelli 1974; de\u202fWeert\u202f&\u202fMausfeld 2003.</p>

--- a/texts/perm120-info.txt
+++ b/texts/perm120-info.txt
@@ -1,0 +1,5 @@
+The 120 architectural permutations are the 120 ways to reassign P₁–P₅ to the attributes [shape, color, x, y, z]. The architecture (the set of selected permutations) does not change; what changes is its visual phenotype by deciding which component controls each spatial and chromatic attribute.
+These reconstructions do not add semantics, do not break the logic of the system, and remain within the combinatorial framework. They reorganize the structural availability of pre‑verbal thought.
+
+Each of the 120 reorganizations is validated by its internal structural coherence, not by usefulness or beauty.
+“Evolution” is goal‑free reordering: same architecture, 120 phenotypic expressions.


### PR DESCRIPTION
## Summary
- add lightweight text loader with caching
- fetch information, pattern, FRBN, and 120-permutation texts from external files
- move large inline content into new `texts/` directory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689afc3ec308832c9a16e36ebe291f68