### PR TITLE
Refine vivid look tuning for OFFNNG

### DIFF
--- a/index.html
+++ b/index.html
@@ -3095,19 +3095,19 @@ void main(){
     const meanSig = selPerms.length ? (sumSig / (selPerms.length * 5)) : 6; // ~3..9
     const sigN = Math.max(0, Math.min(1, (meanSig - 3) / 6)); // 0..1
 
-    // —— LOOK base "Strong" (anti-rim OFFNNG) ——
-    U.uSMin.value      = 0.60;
-    U.uVMin.value      = 0.84;
-    U.uSatGain.value   = 1.22;
-    U.uValGain.value   = 1.30;
-    U.uGammaV.value    = 0.58;
-    U.uExposure.value  = 1.90;
+    // —— LOOK base "Vivid" (más saturación y brillo controlados) ——
+    U.uSMin.value      = 0.64;   // antes 0.60
+    U.uVMin.value      = 0.87;   // antes 0.84
+    U.uSatGain.value   = 1.30;   // antes 1.22
+    U.uValGain.value   = 1.34;   // antes 1.30
+    U.uGammaV.value    = 0.56;   // antes 0.58 (levanta medios sin quemar)
+    U.uExposure.value  = 2.00;   // antes 1.90 (clipea en 1.0 en el shader)
     U.uDensity.value   = 0.70 - 0.05 * nr;
 
-    // Borde: no atenuar y con tinte claro mínimo
-    U.uEdgeBase.value  = 1.00;   // ← clave: elimina el “marco” oscuro
-    U.uEdgeTintV.value = 0.84;   // cara cercana nunca cae de V≈0.84
-    U.uEdgePow.value   = 1.2;    // transición más plana (sin hundir perímetro)
+    // Borde: sin atenuar + tinte más claro (resalta color)
+    U.uEdgeBase.value  = 1.00;   // mantiene anti-rim
+    U.uEdgeTintV.value = 0.90;   // antes 0.84
+    U.uEdgePow.value   = 1.2;
 
     // —— Bias por patrón (±10–15 %) + mezcla de ejes ≤ 0.3 ——
     const B = OFFNNG_PATTERN_BIAS[activePatternId] || OFFNNG_PATTERN_BIAS[1];


### PR DESCRIPTION
## Summary
- Adjust OFFNNG sync parameters for vivid base look and brighter edge tint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b36bfea0c832ca10e6affd6db6131