### PR TITLE
feat: enable front view zoom controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2255,24 +2255,56 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
     }
 
     function applyStandardView(){
+      const target = new THREE.Vector3(0,0,0);
+
+      // RAUM: siempre frontal fija pero con zoom permitido
       if (isRAUM){
         camera.position.set(0, 0, RAUM_CAMERA_ZOOMED);
-        camera.lookAt(new THREE.Vector3(0,0,0));
+        camera.lookAt(target);
+
+        controls.enabled      = true;
+        controls.enableRotate = false;
+        controls.enablePan    = false;
+        controls.enableZoom   = true;
+        controls.minDistance  = 25;
+        controls.maxDistance  = 140;
+
         controls.update();
         return;
       }
-      const view=document.getElementById('standardView').value,
-            pos=new THREE.Vector3();
+
+      const view = document.getElementById('standardView').value;
+      const pos = new THREE.Vector3();
       switch(view){
         case "isometric": pos.set(50,50,50); break;
         case "top":       pos.set(0,80,0);   break;
-        case "front":     pos.set(0,0,40);   break;  // antes 50
+        case "front":     pos.set(0,0,40);   break;  // frontal fija
         case "side":      pos.set(50,0,0);   break;
-        case "diagonal":  pos.set(-50,50,-50);break;
+        case "diagonal":  pos.set(-50,50,-50); break;
         default:          pos.set(0,0,50);
       }
+
       camera.position.copy(pos);
-      camera.lookAt(new THREE.Vector3(0,0,0));
+      camera.lookAt(target);
+
+      if (view === "front"){
+        // Vista frontal fija: solo zoom
+        controls.enabled      = true;
+        controls.enableRotate = false;
+        controls.enablePan    = false;
+        controls.enableZoom   = true;
+        controls.minDistance  = 25;
+        controls.maxDistance  = 140;
+      } else {
+        // Otras vistas: libre
+        controls.enabled      = true;
+        controls.enableRotate = true;
+        controls.enablePan    = true;
+        controls.enableZoom   = true;
+        controls.minDistance  = 10;
+        controls.maxDistance  = 200;
+      }
+
       controls.update();
     }
 
@@ -3234,12 +3266,10 @@ void main(){
     let isTMSL = false;
     let tmslGroup = null;
     let tmslPrevBg = null;
-    let tmslPrevControls = true;
 
     /* ───────────────  RAUM  ·  fixed room 60×30×30  ─────────────── */
     let isRAUM = false;
     let raumGroup = null;
-    let raumPrevControls = true;
     const RAUM_W = 60, RAUM_H = 30, RAUM_D = 30, RAUM_G = 1;
     const RAUM_CAMERA_Z = 80;   // vista frontal fija cómoda para 60 de ancho
 
@@ -3284,9 +3314,9 @@ void main(){
       scene.add(tmslGroup);
     }
 
-    function toggleTMSL(){           /* se usa sólo internamente */
-      if (!isTMSL){                  /* — ENTRAR — */
-        leaveBuildRenderBoost();          // ← desactiva boost de BUILD
+    function toggleTMSL(){
+      if (!isTMSL){ // ENTRAR
+        leaveBuildRenderBoost();
         if (isFRBN)  toggleFRBN();
         if (isLCHT)  toggleLCHT();
         if (isOFFNNG)toggleOFFNNG();
@@ -3297,21 +3327,35 @@ void main(){
         permutationGroup.visible = false;
         if (lichtGroup) lichtGroup.visible = false;
 
-        tmslPrevBg        = scene.background ? scene.background.clone() : null;
-        scene.background  = new THREE.Color(0x000000);   // neutro absoluto
-        tmslPrevControls  = controls.enabled;
-        controls.enabled  = false;                       // cámara fija
-        applyStandardView();                             // vista “front”
+        tmslPrevBg = scene.background ? scene.background.clone() : null;
+        scene.background = new THREE.Color(0x000000);
+
+        // Vista frontal fija con zoom
+        controls.enabled      = true;
+        controls.enableRotate = false;
+        controls.enablePan    = false;
+        controls.enableZoom   = true;
+        controls.minDistance  = 25;
+        controls.maxDistance  = 140;
+
+        document.getElementById('standardView').value = 'front';
+        applyStandardView();
+
         isTMSL = true;
 
-      } else {                      /* — SALIR — (lo hace BUILD) */
+      } else { // SALIR
         if (tmslGroup){
           tmslGroup.traverse(o=>{ if(o.isMesh){o.geometry.dispose();o.material.dispose();}});
           scene.remove(tmslGroup);
           tmslGroup = null;
         }
         if (tmslPrevBg) scene.background = tmslPrevBg;
-        controls.enabled = tmslPrevControls;
+
+        // Controles “normales”
+        controls.enabled      = true;
+        controls.enableRotate = true;
+        controls.enablePan    = true;
+        controls.enableZoom   = true;
 
         cubeUniverse.visible     = true;
         permutationGroup.visible = true;
@@ -3385,18 +3429,30 @@ void main(){
       // ====== APERTURA en PARED DEL FONDO (marco en 4 piezas; sin dependencias extra) ======
       const { sumR, sumR2, mRank } = raumStats();
 
-      const breite = 10 + ((sumR  + 7*mRank + sceneSeed)  % 16); // 10..25
-      const hoehe  = 10 + ((sumR2 + 11*mRank + 3*sceneSeed) % 16); // 10..25
+      // dimensiones base (10..25), luego garantizamos ≥ 1/3 de área visible
+      let breite = 10 + ((sumR  + 7*mRank + sceneSeed)  % 16);      // 10..25
+      let hoehe  = 10 + ((sumR2 + 11*mRank + 3*sceneSeed) % 16);    // 10..25
+
+      const minArea = (Wi * Hi) / 3;  // al menos un tercio del rectángulo visible
+      let area = breite * hoehe;
+      if (area < minArea){
+        const s = Math.min(Math.sqrt(minArea / area), Wi / breite, Hi / hoehe);
+        breite = Math.floor(breite * s);
+        hoehe  = Math.floor(hoehe  * s);
+      }
+      breite = Math.max(2, Math.min(breite, Wi));
+      hoehe  = Math.max(2, Math.min(hoehe,  Hi));
 
       const xmin = -Wi/2 + breite/2, xmax = Wi/2 - breite/2;
       const ymin = -Hi/2 + hoehe/2,  ymax = Hi/2 - hoehe/2;
+
+      // centro determinista
       const ux   = ((37*sumR + 13*mRank + S_global) % 997) / 997;
       const uy   = ((53*sumR2 + 17*mRank + sceneSeed) % 991) / 991;
       const xC   = xmin + (xmax - xmin) * ux;
       const yC   = ymin + (ymax - ymin) * uy;
 
-      // Para construir la pared del fondo con hueco, usamos 4 rectángulos (top/bot/left/right)
-      // todos con grosor g en Z.
+      // pared del fondo con hueco (4 rectángulos)
       const zBack = -D/2 + g/2;
 
       // Bandas superior e inferior
@@ -3412,6 +3468,7 @@ void main(){
         bot.position.set(0, yC - hoehe/2 - hBot/2, zBack);
         raumGroup.add(bot);
       }
+
       // Bandas izquierda y derecha
       const wLeft = (xC - breite/2) - (-Wi/2);
       if (wLeft > 0.0001){
@@ -3436,7 +3493,7 @@ void main(){
       const xA  = xAmin + (xAmax - xAmin) * uAx;
       const zA  = zAmin + (zAmax - zAmin) * uAz;
 
-      const wallA = new THREE.Mesh(new THREE.BoxGeometry(g, H, LA), lambert(colA, 0.8)); // 20% transparencia
+      const wallA = new THREE.Mesh(new THREE.BoxGeometry(g, H, LA), lambert(colA)); // opaco
       wallA.position.set(xA, 0, zA);
       raumGroup.add(wallA);
 
@@ -3450,7 +3507,7 @@ void main(){
       const xB  = xBmin + (xBmax - xBmin) * uBx;
       const zB  = zBmin + (zBmax - zBmin) * uBz;
 
-      const wallB = new THREE.Mesh(new THREE.BoxGeometry(LB, H, g), lambert(colB, 0.8)); // 20% transparencia
+      const wallB = new THREE.Mesh(new THREE.BoxGeometry(LB, H, g), lambert(colB)); // opaco
       wallB.position.set(xB, 0, zB);
       raumGroup.add(wallB);
 
@@ -3461,28 +3518,37 @@ void main(){
       isRAUM = !isRAUM;
 
       if (isRAUM){
-        // exclusividad con otros motores
         if (isFRBN)  toggleFRBN();
         if (isLCHT)  toggleLCHT();
         if (isOFFNNG)toggleOFFNNG();
         if (isTMSL)  toggleTMSL();
 
-        // cámara frontal fija
-        raumPrevControls = controls.enabled;
-        controls.enabled = false;
+        // Frontal fija con zoom
+        controls.enabled      = true;
+        controls.enableRotate = false;
+        controls.enablePan    = false;
+        controls.enableZoom   = true;
+        controls.minDistance  = 25;
+        controls.maxDistance  = 140;
+
         camera.position.set(0, 0, RAUM_CAMERA_ZOOMED);
         camera.lookAt(0,0,0);
         controls.update();
 
         buildRAUM();
-        // ocultar resto
+
         cubeUniverse.visible     = false;
         permutationGroup.visible = false;
         if (lichtGroup) lichtGroup.visible = false;
 
       } else {
         clearGroup(raumGroup); raumGroup = null;
-        controls.enabled = raumPrevControls;
+
+        // Restaurar comportamiento libre
+        controls.enabled      = true;
+        controls.enableRotate = true;
+        controls.enablePan    = true;
+        controls.enableZoom   = true;
 
         cubeUniverse.visible     = true;
         permutationGroup.visible = true;


### PR DESCRIPTION
## Summary
- allow standard views to lock front view rotation while permitting zoom, including in RAUM and TMSL modes
- ensure RAUM back-wall opening spans at least one third of visible area
- render RAUM internal walls opaque

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b8a07fd3c832cb6cbd2b6907435c3