### PR TITLE
Add 13245 engine and integrate across build cycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -910,12 +910,13 @@ function buildLCHT() {
 
     /* Cambia al motor BUILD sin generar una nueva configuración */
     function switchToBuild(){
-      if (isOFFNNG) toggleOFFNNG();   // ← NUEVO: asegura exclusividad
-      if (isFRBN)  toggleFRBN();   // apaga FRBN si estaba activo
-      if (isLCHT)  toggleLCHT();   // apaga LCHT si estaba activo
-      if (isTMSL)  toggleTMSL();   // apaga TMSL si estaba activo
-      if (isRAUM)  toggleRAUM();  // apaga RAUM si estaba activo
-      enterBuildRenderBoost();   // ← aplica PR 2.5 + exposure 0.90 SOLO en BUILD
+      if (isOFFNNG) toggleOFFNNG();   // exclusividad
+      if (isFRBN)  toggleFRBN();
+      if (isLCHT)  toggleLCHT();
+      if (isTMSL)  toggleTMSL();
+      if (isRAUM)  toggleRAUM();
+      if (is13245) toggle13245();     // ← NUEVO
+      enterBuildRenderBoost();        // PR/exposure para BUILD
       /* Nada más: la escena existente permanece tal cual */
     }
 
@@ -1964,17 +1965,17 @@ function makePalette(){
       makePalette();
       applyPalette();
 
-      /* Mientras LCHT está activo, NO toques el fondo ni las paredes
-         (evita que los patrones cromáticos los re-coloreen).        */
+      // Mientras LCHT está activo, NO tocar fondo/pareces automáticos
       if (!isLCHT){
-        updateBackground(false);   // ← automático
-        updateCubeColor(false);    // ← automático
+        updateBackground(false);   // automático
+        updateCubeColor(false);    // automático
       }
 
-      if (isFRBN && skySphere) buildGanzfeld();   // mantiene FRBN sincronizado
-      rebuildLCHTIfActive();                      // mantiene LCHT sincronizado
+      if (isFRBN && skySphere) buildGanzfeld();   // FRBN sincronizado
+      rebuildLCHTIfActive();                      // LCHT sincronizado
       if (isOFFNNG) syncOFFNNGFromScene();
       rebuildRAUMIfActive();
+      rebuild13245IfActive();                     // ← NUEVO
     }
     function onColourPick(idx,hex){
       manualOverride[idx]=hex;
@@ -2278,8 +2279,8 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
     function applyStandardView(){
       const target = new THREE.Vector3(0,0,0);
 
-      // RAUM: siempre frontal fija pero con zoom permitido
-      if (isRAUM){
+      // RAUM y 13245: frontal fija con zoom permitido
+      if (isRAUM || is13245){
         camera.position.set(0, 0, RAUM_CAMERA_ZOOMED);
         camera.lookAt(target);
 
@@ -2294,12 +2295,13 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
         return;
       }
 
+      // Otros modos
       const view = document.getElementById('standardView').value;
       const pos = new THREE.Vector3();
       switch(view){
         case "isometric": pos.set(50,50,50); break;
         case "top":       pos.set(0,80,0);   break;
-        case "front":     pos.set(0,0,40);   break;  // frontal fija
+        case "front":     pos.set(0,0,40);   break;
         case "side":      pos.set(50,0,0);   break;
         case "diagonal":  pos.set(-50,50,-50); break;
         default:          pos.set(0,0,50);
@@ -2309,7 +2311,6 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       camera.lookAt(target);
 
       if (view === "front"){
-        // Vista frontal fija: solo zoom
         controls.enabled      = true;
         controls.enableRotate = false;
         controls.enablePan    = false;
@@ -2317,7 +2318,6 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
         controls.minDistance  = 25;
         controls.maxDistance  = 140;
       } else {
-        // Otras vistas: libre
         controls.enabled      = true;
         controls.enableRotate = true;
         controls.enablePan    = true;
@@ -3680,13 +3680,212 @@ void main(){
     function ensureOnlyRAUM(){ if (!isRAUM) toggleRAUM(); }
     function rebuildRAUMIfActive(){ if (isRAUM) buildRAUM(); }
 
+    // ──────────────────────────────
+    // 13245 · motor (grid 10×10)
+    // ──────────────────────────────
+    let is13245 = false;
+    let group13245 = null;
+
+    /* Escala acoplada a RAUM:
+     *   - piso 179.98 → ~60
+     *   - anillo Ø183.98 → ~61.33 (espesor ~0.667, h ~16.67)
+     */
+    const K132           = 60 / 179.98;
+    const FLOOR132       = 179.98 * K132;           // ~60
+    const R_OUT132       = (183.98 * 0.5) * K132;   // ~30.666
+    const WALL_THICK132  = 2.0 * K132;              // ~0.6667
+    const WALL_H132      = 50.0 * K132;             // ~16.667
+    const CELL132        = FLOOR132 / 10;           // ~6
+    const CROSS132       = 2.25 * K132;             // ~0.75
+    const STEP_OPEN_ADDR = 37;                      // coprimo con 100
+
+    function disposeGroup(g){
+      if (!g) return;
+      g.traverse(o => {
+        if (o.isMesh) {
+          o.geometry?.dispose?.();
+          o.material?.dispose?.();
+        }
+      });
+      scene.remove(g);
+    }
+
+    /* Color RAUM → aplica “vibrance BUILD” y ∆E≥22 contra el fondo */
+    function lambertRaumColor(cTHREE, emissiveIntensity = 0.06, doubleSide = false){
+      const c = applyBuildVibranceToColor(cTHREE);
+      const m = new THREE.MeshLambertMaterial({
+        color: c,
+        dithering: true,
+        side: doubleSide ? THREE.DoubleSide : THREE.FrontSide
+      });
+      m.emissive = c.clone();
+      m.emissiveIntensity = emissiveIntensity;
+      return m;
+    }
+
+    /* Color determinista para el tramo k (k=0..2) de una permutación */
+    function color132For(pa, k){
+      const sig  = computeSignature(pa);
+      const r    = lehmerRank(pa);
+      const slot = (r % 12) + k;     // offsets k=0,1,2
+
+      let [hI,sI,vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
+      sI = (sI * PHI_S) % 12;
+      vI = (vI * PHI_V) % 12;
+
+      const {h,s,v} = idxToHSV(hI, sI, vI);
+      let rgb = hsvToRgb(h,s,v);
+      rgb = ensureContrastRGB(rgb);
+
+      const col = new THREE.Color(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+      return applyBuildVibranceToColor(col);
+    }
+
+    /* Alturas de los 3 tramos (abajo, medio, arriba) con el caso P1=5≈ε */
+    function heightsFor(pa){
+      // rango suave 1.6…4.0 por tramo; el superior se acorta y si P1=5 → ε
+      const f = v => 1.6 + 2.4 * ((v - 1) / 4);     // 1..5 → 1.6..4.0
+      const hBot = f(pa[2]);
+      const hMid = f(pa[1]);
+      const hTop = (pa[0] === 5) ? 0.12 : (1.2 + 1.8 * ((pa[0] - 1) / 4));
+      return [hBot, hMid, hTop];
+    }
+
+    /* Construye/rehace toda la escena 13245 */
+    function build13245(){
+      // limpia versión previa
+      disposeGroup(group13245);
+      group13245 = new THREE.Group();
+
+      // Fondo acoplado a BUILD (sin intervención manual)
+      updateBackground(false);
+
+      // — Piso: plano XZ del tamaño exacto (color RAUM #2)
+      const floorCol = raumColorFor(2);
+      const floor = new THREE.Mesh(
+        new THREE.PlaneGeometry(FLOOR132, FLOOR132),
+        lambertRaumColor(floorCol, 0.04, true)
+      );
+      floor.rotation.x = -Math.PI / 2;
+      floor.position.set(0, 0, 0);
+      group13245.add(floor);
+
+      // — Muro exterior: anillo aproximado con N paneles
+      const N = 64;
+      const Rmid = R_OUT132 - WALL_THICK132 * 0.5;
+      const arcLen = 2 * Math.PI * Rmid / N;
+      const segGeo = new THREE.BoxGeometry(WALL_THICK132, WALL_H132, arcLen * 1.02);
+      const wallMat = new THREE.MeshLambertMaterial({
+        color: 0xffffff,
+        side: THREE.DoubleSide,
+        dithering: true
+      });
+      for (let i = 0; i < N; i++){
+        const am = (i + 0.5) * 2 * Math.PI / N;
+        const seg = new THREE.Mesh(segGeo, wallMat);
+        seg.position.set(Rmid * Math.cos(am), WALL_H132/2, Rmid * Math.sin(am));
+        seg.rotation.y = am;
+        group13245.add(seg);
+      }
+
+      // — Centros de la grilla 10×10 (en el cuadrado del piso)
+      const centers = [];
+      const half = FLOOR132 * 0.5, step = CELL132;
+      for (let gz = 0; gz < 10; gz++){
+        for (let gx = 0; gx < 10; gx++){
+          const x = -half + step*gx + step*0.5;
+          const z = -half + step*gz + step*0.5;
+          centers.push([x, z]);
+        }
+      }
+
+      // — Colocación determinista (open addressing con salto coprimo 37)
+      const occ = Array(centers.length).fill(false);
+      const perms = getSelectedPerms();                      // seleccionadas en UI
+      const baseGeo = new THREE.BoxGeometry(CROSS132, 1, CROSS132);
+
+      perms.forEach(pa => {
+        const r = lehmerRank(pa);
+        let idx = (r + sceneSeed + S_global) % centers.length;
+        while (occ[idx]) idx = (idx + STEP_OPEN_ADDR) % centers.length;
+        occ[idx] = true;
+
+        const [x, z] = centers[idx];
+        const [hBot, hMid, hTop] = heightsFor(pa);
+        const cols = [0,1,2].map(k => color132For(pa, k));
+
+        const sep = 0.06;
+        let y = 0.0;
+
+        // tramo inferior
+        const m0 = new THREE.Mesh(baseGeo, new THREE.MeshLambertMaterial({ color: cols[0], dithering:true }));
+        m0.material.emissive = cols[0].clone(); m0.material.emissiveIntensity = 0.06;
+        m0.scale.y = hBot; m0.position.set(x, y + hBot/2, z); y += hBot + sep; group13245.add(m0);
+
+        // tramo medio
+        const m1 = new THREE.Mesh(baseGeo, new THREE.MeshLambertMaterial({ color: cols[1], dithering:true }));
+        m1.material.emissive = cols[1].clone(); m1.material.emissiveIntensity = 0.06;
+        m1.scale.y = hMid; m1.position.set(x, y + hMid/2, z); y += hMid + sep; group13245.add(m1);
+
+        // tramo superior (puede ser ε≈0.12)
+        const m2 = new THREE.Mesh(baseGeo, new THREE.MeshLambertMaterial({ color: cols[2], dithering:true }));
+        m2.material.emissive = cols[2].clone(); m2.material.emissiveIntensity = 0.06;
+        m2.scale.y = hTop; m2.position.set(x, y + hTop/2, z); group13245.add(m2);
+      });
+
+      scene.add(group13245);
+    }
+
+    /* rebuild si hay cambios de escena */
+    function rebuild13245IfActive(){ if (is13245) build13245(); }
+
+    /* Exclusivo (como RAUM). Usa el “crispness boost” de RAUM y vista frontal fija con zoom. */
+    function toggle13245(){
+      is13245 = !is13245;
+
+      if (is13245){
+        // exclusividad
+        if (isFRBN)  toggleFRBN();
+        if (isLCHT)  toggleLCHT();
+        if (isOFFNNG)toggleOFFNNG();
+        if (isTMSL)  toggleTMSL();
+        if (isRAUM)  toggleRAUM();
+
+        leaveBuildRenderBoost();
+        enterRaumRenderBoost();
+
+        build13245();
+
+        cubeUniverse.visible     = false;
+        permutationGroup.visible = false;
+        if (lichtGroup) lichtGroup.visible = false;
+
+        // vista frontal con zoom permitido (igual a RAUM)
+        document.getElementById('standardView').value = 'front';
+        applyStandardView();
+
+      } else {
+        leaveRaumRenderBoost();
+        disposeGroup(group13245);
+        group13245 = null;
+
+        cubeUniverse.visible     = true;
+        permutationGroup.visible = true;
+        if (lichtGroup && isLCHT) lichtGroup.visible = true;
+      }
+    }
+
+    /* botón selector – sólo enciende, nunca apaga */
+    function ensureOnly13245(){ if (!is13245) toggle13245(); }
+
     /* rueda de motores del botón “4” */
     function cycleEngine(){
       if (isFRBN){ toggleFRBN(); toggleLCHT(); return; }   // FRBN → LCHT
       if (isLCHT){ ensureOnlyOFFNNG(); return; }           // LCHT → OFFNNG
       if (isOFFNNG){ ensureOnlyTMSL(); return; }           // OFFNNG → TMSL
       if (isTMSL){ ensureOnlyRAUM(); return; }             // TMSL  → RAUM
-      if (isRAUM){ switchToBuild(); return; }              // RAUM  → BUILD
+      if (isRAUM){ ensureOnly13245(); return; }            // RAUM  → 13245
+      if (is13245){ switchToBuild(); return; }             // 13245 → BUILD
       toggleFRBN();                                        // BUILD → FRBN
     }
 


### PR DESCRIPTION
## Summary
- add new `13245` engine with grid-based scene and exclusive toggle
- extend engine cycle, view handling, and build switching to include `13245`
- refresh scene rebuild flow to support `13245`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d1a26527c832c9f10d97027175fe3