### PR TITLE
Refine 13245 grid and level camera

### DIFF
--- a/index.html
+++ b/index.html
@@ -2295,14 +2295,24 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
         return;
       }
 
-      // 13245: Orbit completo (como BUILD)
+      // 13245: cámara nivelada (verticales “gerade”)
       if (is13245){
-        controls.enabled      = true;
-        controls.enableRotate = true;
-        controls.enablePan    = true;
-        controls.enableZoom   = true;
-        controls.minDistance  = 10;
-        controls.maxDistance  = 200;
+        const eyeY = 0;                    // misma Y para cámara y target
+        camera.up.set(0,1,0);
+        camera.position.set(camera.position.x, eyeY, camera.position.z);
+        controls.target.set(0, eyeY, 0);
+
+        controls.enabled            = true;
+        controls.enableRotate       = true;  // yaw
+        controls.enablePan          = true;
+        controls.enableZoom         = true;
+        controls.minDistance        = 10;
+        controls.maxDistance        = 200;
+        controls.screenSpacePanning = true;
+
+        controls.minPolarAngle = Math.PI / 2;
+        controls.maxPolarAngle = Math.PI / 2;
+
         controls.update();
         return;
       }
@@ -3782,60 +3792,32 @@ void main(){
       floor.position.set(0, 0, 0);
       group13245.add(floor);
 
-      // — Muro exterior: anillo continuo (ExtrudeGeometry)
-      {
-        const R_OUT = R_OUT132;
-        const R_IN  = R_OUT132 - WALL_THICK132;
+      // — Muro exterior (anillo) ELIMINADO — dejamos solo el piso
 
-        const shape = new THREE.Shape();
-        shape.absarc(0, 0, R_OUT, 0, Math.PI * 2, false);
-
-        const hole  = new THREE.Path();
-        hole.absarc(0, 0, R_IN, 0, Math.PI * 2, true);
-        shape.holes.push(hole);
-
-        const extr = new THREE.ExtrudeGeometry(shape, {
-          depth: WALL_H132,
-          bevelEnabled: false,
-          curveSegments: 128,
-          steps: 1
-        });
-
-        // El extruido sale a lo largo de +Z → lo rotamos para que la altura sea Y
-        extr.rotateX(Math.PI / 2);
-        extr.translate(0, WALL_H132 / 2, 0);
-
-        const wallMat = new THREE.MeshLambertMaterial({
-          color: 0xffffff,
-          dithering: true,
-          side: THREE.DoubleSide
-        });
-
-        const ring = new THREE.Mesh(extr, wallMat);
-        group13245.add(ring);
-      }
-
-      // — Intersecciones de la grilla 10×10 (11×11 puntos) dentro del anillo
+      // — Centros de la grilla: más densa para que queden más juntos
+      //   (antes 10×10 dentro del anillo; ahora cuadrícula 14×14 en todo el piso)
       const centers = [];
       {
         const half   = FLOOR132 * 0.5;
-        const step   = CELL132;
-        const R_IN   = R_OUT132 - WALL_THICK132;
-        const margin = CROSS132 * 0.60;    // separa de la pared
+        const GRID_N = 14;                 // ← grilla más densa (sube a 16/18 si quieres aún más)
+        const step   = FLOOR132 / GRID_N;  // separación menor
+        const margin = CROSS132 * 0.35;    // pequeño margen en bordes
 
-        for (let gz = 0; gz <= 10; gz++){
-          for (let gx = 0; gx <= 10; gx++){
+        for (let gz = 0; gz <= GRID_N; gz++){
+          for (let gx = 0; gx <= GRID_N; gx++){
             const x = -half + step * gx;
             const z = -half + step * gz;
-            if (Math.hypot(x, z) <= (R_IN - margin)) centers.push([x, z]);
+            if (Math.abs(x) <= half - margin && Math.abs(z) <= half - margin){
+              centers.push([x, z]);
+            }
           }
         }
       }
 
       // — Colocación determinista (open addressing con salto coprimo 37)
-      const occ = Array(centers.length).fill(false);
-      const perms = getSelectedPerms();                      // seleccionadas en UI
-      const baseGeo = new THREE.BoxGeometry(CROSS132, 1, CROSS132);
+      const occ      = Array(centers.length).fill(false);
+      const perms    = getSelectedPerms();                      // seleccionadas en UI
+      const baseGeo  = new THREE.BoxGeometry(CROSS132, 1, CROSS132);
 
       perms.forEach(pa => {
         const r = lehmerRank(pa);
@@ -3844,10 +3826,11 @@ void main(){
         occ[idx] = true;
 
         const [x, z] = centers[idx];
+
         const [hBot, hMid, hTop] = heightsFor(pa);
         const cols = [0,1,2].map(k => color132For(pa, k));
 
-        const sep = 0.20;  // separación visible entre volúmenes
+        const sep = 0.20;  // separación visible entre tramos
         let y = 0.0;
 
         // tramo inferior
@@ -3860,7 +3843,7 @@ void main(){
         m1.material.emissive = cols[1].clone(); m1.material.emissiveIntensity = 0.06;
         m1.scale.y = hMid; m1.position.set(x, y + hMid/2, z); y += hMid + sep; group13245.add(m1);
 
-        // tramo superior (se omite si hTop = 0)
+        // tramo superior (omitido si hTop=0)
         if (hTop > 0.0001){
           const m2 = new THREE.Mesh(baseGeo, new THREE.MeshLambertMaterial({ color: cols[2], dithering:true }));
           m2.material.emissive = cols[2].clone(); m2.material.emissiveIntensity = 0.06;
@@ -3888,24 +3871,31 @@ void main(){
 
         leaveBuildRenderBoost();
         enterRaumRenderBoost();
-
         build13245();
 
-        // Vista inicial: dentro del anillo, con Orbit activo y target al centro
-        {
-          const R_IN = R_OUT132 - WALL_THICK132;
-          camera.position.set(0, WALL_H132 * 0.60, Math.min(R_IN * 0.80, 12));
-          controls.target.set(0, WALL_H132 * 0.40, 0);
+        // — Cámara nivelada: verticales siempre rectas (sin tilt)
+        const R_IN = R_OUT132 - WALL_THICK132;
+        const eyeY = 0;                 // misma altura para cámara y target
+        camera.up.set(0,1,0);
+        camera.fov = 55;                // FOV moderado para evitar sensación de inclinación
+        camera.updateProjectionMatrix();
 
-          controls.enabled      = true;
-          controls.enableRotate = true;
-          controls.enablePan    = true;
-          controls.enableZoom   = true;
-          controls.minDistance  = 10;
-          controls.maxDistance  = 200;
+        camera.position.set(0, eyeY, Math.min(R_IN * 0.90, 18));
+        controls.target.set(0, eyeY, 0);
 
-          controls.update();
-        }
+        controls.enabled            = true;
+        controls.enableRotate       = true;   // solo yaw
+        controls.enablePan          = true;
+        controls.enableZoom         = true;
+        controls.minDistance        = 10;
+        controls.maxDistance        = 200;
+        controls.screenSpacePanning = true;
+
+        // Bloquea el ángulo polar en el horizonte (sin cabeceo)
+        controls.minPolarAngle = Math.PI / 2;
+        controls.maxPolarAngle = Math.PI / 2;
+
+        controls.update();
 
         cubeUniverse.visible     = false;
         permutationGroup.visible = false;
@@ -3915,6 +3905,13 @@ void main(){
         leaveRaumRenderBoost();
         disposeGroup(group13245);
         group13245 = null;
+
+        // Restaurar ajustes por defecto
+        camera.fov = 75;
+        camera.updateProjectionMatrix();
+        controls.minPolarAngle      = 0;
+        controls.maxPolarAngle      = Math.PI;
+        controls.screenSpacePanning = false;
 
         cubeUniverse.visible     = true;
         permutationGroup.visible = true;


### PR DESCRIPTION
## Summary
- Remove exterior wall from 13245 build and densify grid to 14×14 across floor
- Constrain camera in 13245 to level horizon with moderate FOV and restore defaults on exit
- Keep camera leveled when applying standard views within 13245

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d120d00832c978a4b567b92e711