### PR TITLE
feat: extend tilers with r4 and update R5X10

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,198 +9,203 @@
   <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
   <!-- === tilers.js embebido (JS puro) — crea window.Tilers === -->
     <script type="module">
-    /* ───────── tilers (JS puro) — núcleo de ensambles multi-familia ───────── */
-    const PHI   = (1 + Math.sqrt(5)) / 2;
-    const ROOT2 = Math.SQRT2;
-    const ROOT3 = Math.sqrt(3);
-    const ROOT5 = Math.sqrt(5);
-    const EPS   = 1e-6;
+/* ───────── tilers (JS puro) — núcleo de ensambles multi-familia ───────── */
+const PHI   = (1 + Math.sqrt(5)) / 2;
+const ROOT2 = Math.SQRT2;
+const ROOT3 = Math.sqrt(3);
+const ROOT4 = Math.sqrt(4);   // = 2   ← NUEVO
+const ROOT5 = Math.sqrt(5);
+const EPS   = 1e-6;
 
-    /* util mínimo */
-    function near(a,b,eps=EPS){ return Math.abs(a-b) <= eps; }
+/* util mínimo */
+function near(a,b,eps=EPS){ return Math.abs(a-b) <= eps; }
 
-    /* Catálogo de familias + alias proporcionales útiles para matching */
-    const families = [
-      { id:'phi', r:PHI,   aliases:[1/PHI, 1-PHI**-1, PHI**2-PHI] },          // .618, .382, 1
-      { id:'r2',  r:ROOT2, aliases:[1/ROOT2, 2-ROOT2] },                      // .7071, .5858
-      { id:'r3',  r:ROOT3, aliases:[ROOT3-1, 1-(ROOT3-1)] },                  // .732, .268
-      { id:'r5',  r:ROOT5, aliases:[1/ROOT5, (ROOT5-2)] }                     // .4472, .236
-    ];
+/* Catálogo de familias + alias proporcionales útiles para matching */
+const families = [
+  { id:'phi', r:PHI,   aliases:[1/PHI, 1-PHI**-1, PHI**2-PHI] },         // .618, .382, 1
+  { id:'r2',  r:ROOT2, aliases:[1/ROOT2, 2-ROOT2] },                     // .7071, .5858
+  { id:'r3',  r:ROOT3, aliases:[1/ROOT3, ROOT3-1, 1-(ROOT3-1)] },        // .577, .732, .268
+  { id:'r4',  r:ROOT4, aliases:[1/ROOT4, 1] },                           // .50, 1   ← NUEVO
+  { id:'r5',  r:ROOT5, aliases:[1/ROOT5, (ROOT5-2)] }                    // .4472, .236
+];
 
-    /* identifica familia por proximidad (tolerancia holgada para ratios derivados) */
-    function whichFamily(r, eps=1e-3){
-      let best = null;
-      for (const f of families){
-        for (const c of [f.r, ...f.aliases]){
-          const d = Math.abs(r - c);
-          if (!best || d < best.d) best = { f:f.id, d };
-        }
-      }
-      return (best && best.d <= 5e-3) ? best.f : null;
+/* identifica familia por proximidad (tolerancia holgada para ratios derivados) */
+function whichFamily(r, eps=2e-2){                 // ← tolerancia más realista
+  let best = null;
+  for (const f of families){
+    for (const c of [f.r, ...f.aliases]){
+      const d = Math.abs(r - c);
+      if (!best || d < best.d) best = { f:f.id, d };
     }
+  }
+  return (best && best.d <= eps) ? best.f : null;
+}
 
-    /* familia dominante por “área” en el inventario; fallback φ */
-    function dominantFamily(inv){
-      const acc = {phi:0,r2:0,r3:0,r5:0};
-      (inv?.ratios||[]).forEach(it=>{
-        const fam = whichFamily(it.r) ?? 'phi';
-        acc[fam] += it.area || 0;
-      });
-      return ['phi','r2','r3','r5'].reduce((best,f)=> acc[f]>acc[best]?f:best,'phi');
+/* familia dominante por “área” en el inventario; fallback φ */
+function dominantFamily(inv){
+  const acc = {phi:0,r2:0,r3:0,r4:0,r5:0};        // ← incluye r4
+  (inv?.ratios||[]).forEach(it=>{
+    const fam = whichFamily(it.r) ?? 'phi';
+    acc[fam] += it.area || 0;
+  });
+  return Object.keys(acc).reduce((best,f)=> acc[f]>acc[best]?f:best,'phi');
+}
+
+/* ---------- 1) Euclid / Continued Fraction → mosaico de cuadrados ---------- */
+function tilesEuclid(b, r, tag='euclid'){
+  const out=[];
+  let x=b.x, y=b.y, w=b.w, h=b.h;
+
+  const orient = (w>=h) ? 1 : -1;     // 1 vertical; -1 horizontal
+  if (orient<0){ [w,h] = [h,w]; }
+
+  let W=w, H=h;
+  let baseX=0, baseY=0;
+  while (W > EPS && H > EPS){
+    const q = Math.floor(W / H + EPS);
+    for (let i=0;i<q;i++){
+      const rect = orient>0
+        ? { x: b.x + baseX + i*H, y: b.y + baseY, w: H, h: H, tag }
+        : { x: b.x + baseY,       y: b.y + baseX + i*H, w: H, h: H, tag };
+      out.push(rect);
     }
+    const rem = W - q*H;
+    if (rem <= EPS) break;
+    if (orient>0){ baseX += q*H; } else { baseY += q*H; }
+    W = H; H = rem;
+  }
+  return out;
+}
 
-    /* ---------- 1) Euclid / Continued Fraction → mosaico de cuadrados ---------- */
-    function tilesEuclid(b, r, tag='euclid'){
-      const out=[];
-      let x=b.x, y=b.y, w=b.w, h=b.h;
+/* ---------- 2) Beatty / Sturmian (dos tamaños L/S) ---------- */
+function beattyPairFor(f){
+  if (f==='phi'){ return [PHI*PHI, (PHI*PHI)/(PHI*PHI-1)]; }
+  if (f==='r2'){  const a=1+ROOT2; return [a, a/(a-1)]; }
+  if (f==='r3'){  const a=1+ROOT3; return [a, a/(a-1)]; }
+  if (f==='r4'){  const a=1+ROOT4; return [a, a/(a-1)]; }   // ← NUEVO
+  const a=1+ROOT5; return [a, a/(a-1)];                     // r5
+}
+function tilesBeatty(b, f, majorFirst=true, tag='beatty'){
+  const [alpha] = beattyPairFor(f);
+  const N = Math.max(2, Math.round(b.w / (b.h*0.25)));
+  const seq = [];
+  for (let k=1;k<=N;k++){
+    const LA = Math.floor(k*alpha) - Math.floor((k-1)*alpha);
+    seq.push(LA===2); // true=L, false=S
+  }
 
-      const orient = (w>=h) ? 1 : -1;     // 1 vertical; -1 horizontal
-      if (orient<0){ [w,h] = [h,w]; }
+  // alturas L/S generalizadas (sin “0.618” fijo)
+  const rVal = (f==='phi'?PHI : f==='r2'?ROOT2 : f==='r3'?ROOT3 : f==='r4'?ROOT4 : ROOT5);
+  const L =  majorFirst ? b.h           : b.h / rVal;
+  const S =  majorFirst ? b.h / rVal    : b.h;
 
-      let W=w, H=h;
-      let baseX=0, baseY=0;
-      while (W > EPS && H > EPS){
-        const q = Math.floor(W / H + EPS);
-        for (let i=0;i<q;i++){
-          const rect = orient>0
-            ? { x: b.x + baseX + i*H, y: b.y + baseY, w: H, h: H, tag }
-            : { x: b.x + baseY,       y: b.y + baseX + i*H, w: H, h: H, tag };
-          out.push(rect);
-        }
-        const rem = W - q*H;
-        if (rem <= EPS) break;
-        if (orient>0){ baseX += q*H; } else { baseY += q*H; }
-        W = H; H = rem;
-      }
-      return out;
+  const wL = 1.0, wS = 1/(alpha-1);      // anchos relativos
+  const widths = seq.map(s => s ? wL : wS);
+  const sum = widths.reduce((a,c)=>a+c,0);
+  const kscale = b.w / sum;
+
+  let x = b.x;
+  const out = [];
+  for (let i=0;i<widths.length;i++){
+    const cw = widths[i]*kscale;
+    const ch = seq[i] ? L : S;
+    out.push({x, y:b.y, w:cw, h:ch, tag});
+    if (ch < b.h - EPS){
+      out.push({x, y:b.y+ch, w:cw, h:b.h-ch, tag});
     }
+    x += cw;
+    if (x > b.x + b.w - EPS) break;
+  }
+  return out;
+}
 
-    /* ---------- 2) Beatty / Sturmian (dos tamaños L/S) ---------- */
-    function beattyPairFor(f){
-      if (f==='phi'){ const a = PHI*PHI; return [a, a/(a-1)]; }
-      if (f==='r2'){  const a = 1+ROOT2; return [a, a/(a-1)]; }
-      if (f==='r3'){  const a = 1+ROOT3; return [a, a/(a-1)]; }
-      const a = 1+ROOT5; return [a, a/(a-1)];
+/* ---------- 3) Sustitución inflacionaria (Fibo/Pell/√3) ---------- */
+function substRules(f){
+  if (f==='phi') return ['LS','L'];      // Fibonacci
+  if (f==='r2')  return ['LSS','L'];     // tipo Pell
+  if (f==='r3')  return ['LLS','L'];     // √3
+  return null;                           // r4/r5 → sin reglas específicas (fallback)
+}
+function tilesSubstitution(b, f, iters=6, tag='subst'){
+  const rules = substRules(f);
+  if (!rules){
+    // Hasta definir reglas de sustitución para r4/r5, usar Beatty (misma familia)
+    return tilesBeatty(b, f, true, 'beatty');
+  }
+  let word = 'L';
+  const [RL,RS] = rules;
+  for (let i=0;i<iters;i++){
+    let next=''; for (const ch of word) next += (ch==='L'?RL:RS);
+    word = next;
+  }
+  const rVal = (f==='phi'?PHI : f==='r2'?ROOT2 : ROOT3);
+  const wL = 1, wS = 1 / rVal;           // ← corrección: S = 1/√n (o 1/φ)
+  const widths = [...word].map(ch => ch==='L'?wL:wS);
+  const sum = widths.reduce((a,c)=>a+c,0);
+  const kscale = b.w / sum;
+  let x = b.x;
+  const out = [];
+  for (const ch of word){
+    const cw = (ch==='L'?wL:wS)*kscale;
+    out.push({x, y:b.y, w:cw, h:b.h, tag});
+    x += cw;
+    if (x > b.x + b.w - EPS) break;
+  }
+  return out;
+}
+
+/* ---------- 4) Orquestador con alternancia de estrategias ---------- */
+function fillByStrategy(rect, fam, strategy){
+  if (strategy==='beatty') return tilesBeatty(rect, fam, true, 'beatty');
+  if (strategy==='subst')  return tilesSubstitution(rect, fam, 7, 'subst'); // r4/r5 → Beatty
+  // 'euclid' (o cualquier otro) → cuadrícula euclidiana dentro de la banda
+  return tilesEuclid(rect, rect.w/rect.h, 'euclid-in-band');
+}
+
+function assemble(b, inv, opt={}){
+  const fam = (opt.familyId && ['phi','r2','r3','r4','r5'].includes(opt.familyId))
+    ? opt.familyId
+    : dominantFamily(inv || {ratios:[]});
+
+  const rBox = Math.max(b.w,b.h) / Math.min(b.w,b.h);
+  const ratios = inv?.ratios || [];
+  const famOf  = r => whichFamily(r) ?? 'phi';
+
+  const singleSize = ratios.length<=1 || ratios.every(x=>famOf(x.r)===fam);
+  const twoSizesSameFamily = ratios.length===2 && ratios.every(x=>famOf(x.r)===fam);
+
+  // Modo espiral “global”
+  if (opt.wantSpiral) return tilesSubstitution(b, fam, 7, 'subst');
+
+  // Alternancia explícita (por bandas euclidianas)
+  if (Array.isArray(opt.strategyCycle) && opt.strategyCycle.length){
+    const bands = tilesEuclid(b, rBox, 'euclid-band');
+    const cycle = opt.strategyCycle;
+    const out   = [];
+    for (let i=0;i<bands.length;i++){
+      const strat = cycle[i % cycle.length];
+      out.push(...fillByStrategy(bands[i], fam, strat));
     }
-    function tilesBeatty(b, f, majorFirst=true, tag='beatty'){
-      const [alpha] = beattyPairFor(f);
-      const N = Math.max(2, Math.round(b.w / (b.h*0.25)));
-      const seq = [];
-      for (let k=1;k<=N;k++){
-        const LA = Math.floor(k*alpha) - Math.floor((k-1)*alpha);
-        seq.push(LA===2); // true=L, false=S
-      }
-      const L = majorFirst ? b.h : b.h*0.618;
-      const S = majorFirst ? b.h*0.618 : b.h;
+    return out;
+  }
 
-      const wL = 1.0, wS = 1/(alpha-1);
-      const widths = seq.map(s => s ? wL : wS);
-      const sum = widths.reduce((a,c)=>a+c,0);
-      const kscale = b.w / sum;
+  // Heurística por inventario (retro-compatible)
+  if (twoSizesSameFamily) return tilesBeatty(b, fam, true, 'beatty');
+  if (singleSize)         return tilesEuclid(b, rBox, 'euclid');
 
-      let x = b.x;
-      const out = [];
-      for (let i=0;i<widths.length;i++){
-        const cw = widths[i]*kscale;
-        const ch = seq[i] ? L : S;
-        out.push({x, y:b.y, w:cw, h:ch, tag});
-        if (ch < b.h - EPS){
-          out.push({x, y:b.y+ch, w:cw, h:b.h-ch, tag});
-        }
-        x += cw;
-        if (x > b.x + b.w - EPS) break;
-      }
-      return out;
-    }
+  // Híbrido: bandas euclidianas + Beatty dentro de cada una
+  const bands = tilesEuclid(b, rBox, 'euclid-band');
+  const out   = [];
+  for (const band of bands){
+    out.push(...tilesBeatty(
+      { x:band.x, y:band.y, w:band.w, h:band.h }, fam, true, 'beatty-in-band'
+    ));
+  }
+  return out;
+}
 
-    /* ---------- 3) Sustitución inflacionaria (Fibo/Pell/√3) ---------- */
-    function substRules(f){
-      if (f==='phi') return ['LS','L'];   // Fibonacci
-      if (f==='r2')  return ['LSS','L'];  // tipo Pell
-      return ['LLS','L'];                 // √3 genérica
-    }
-    function tilesSubstitution(b, f, iters=6, tag='subst'){
-      let word = 'L';
-      const [RL,RS] = substRules(f);
-      for (let i=0;i<iters;i++){
-        let next=''; for (const ch of word) next += (ch==='L'?RL:RS);
-        word = next;
-      }
-      const wL = 1, wS = 1/(f==='phi'?PHI: (f==='r2'?(1+ROOT2-1):(ROOT3-1)) );
-      const widths = [...word].map(ch => ch==='L'?wL:wS);
-      const sum = widths.reduce((a,c)=>a+c,0);
-      const kscale = b.w / sum;
-      let x = b.x;
-      const out = [];
-      for (const ch of word){
-        const cw = (ch==='L'?wL:wS)*kscale;
-        out.push({x, y:b.y, w:cw, h:b.h, tag});
-        x += cw;
-        if (x > b.x + b.w - EPS) break;
-      }
-      return out;
-    }
-
-    /* ---------- 4) Orquestador con alternancia de estrategias ---------- */
-    /*
-       assemble(bbox, inv, opt)
-       opt = {
-         familyId: 'phi'|'r2'|'r3'|'r5'   // fuerza familia (si se omite, usa dominante)
-         wantSpiral: boolean               // si true → Sustitución en espiral (toda la caja)
-         strategyCycle: ['beatty','euclid','subst'] // alterna por “bandas” euclidianas
-       }
-    */
-    function fillByStrategy(rect, fam, strategy){
-      if (strategy==='beatty') return tilesBeatty(rect, fam, true, 'beatty');
-      if (strategy==='subst')  return tilesSubstitution(rect, fam, 7, 'subst');
-      // 'euclid' (o cualquier otro) → cuadrícula euclidiana dentro de la banda
-      return tilesEuclid(rect, rect.w/rect.h, 'euclid-in-band');
-    }
-
-    function assemble(b, inv, opt={}){
-      const fam = (opt.familyId && ['phi','r2','r3','r5'].includes(opt.familyId))
-        ? opt.familyId
-        : dominantFamily(inv || {ratios:[]});
-
-      const rBox = Math.max(b.w,b.h) / Math.min(b.w,b.h);
-      const ratios = inv?.ratios || [];
-      const famOf  = r => whichFamily(r) ?? 'phi';
-
-      const singleSize = ratios.length<=1 || ratios.every(x=>famOf(x.r)===fam);
-      const twoSizesSameFamily = ratios.length===2 && ratios.every(x=>famOf(x.r)===fam);
-
-      // Modo espiral “global”
-      if (opt.wantSpiral) return tilesSubstitution(b, fam, 7, 'subst');
-
-      // Alternancia explícita (por bandas euclidianas)
-      if (Array.isArray(opt.strategyCycle) && opt.strategyCycle.length){
-        const bands = tilesEuclid(b, rBox, 'euclid-band');
-        const cycle = opt.strategyCycle;
-        const out   = [];
-        for (let i=0;i<bands.length;i++){
-          const strat = cycle[i % cycle.length];
-          out.push(...fillByStrategy(bands[i], fam, strat));
-        }
-        return out;
-      }
-
-      // Heurística por inventario (retro-compatible)
-      if (twoSizesSameFamily) return tilesBeatty(b, fam, true, 'beatty');
-      if (singleSize)         return tilesEuclid(b, rBox, 'euclid');
-
-      // Híbrido: bandas euclidianas + Beatty dentro de cada una
-      const bands = tilesEuclid(b, rBox, 'euclid-band');
-      const out   = [];
-      for (const band of bands){
-        out.push(...tilesBeatty(
-          { x:band.x, y:band.y, w:band.w, h:band.h }, fam, true, 'beatty-in-band'
-        ));
-      }
-      return out;
-    }
-
-    /* exporta en global */
-    window.Tilers = { PHI, ROOT2, ROOT3, ROOT5, families, whichFamily, assemble };
+/* exporta en global */
+window.Tilers = { PHI, ROOT2, ROOT3, ROOT4, ROOT5, families, whichFamily, assemble };
     </script>
   <style>
   body {
@@ -4302,27 +4307,30 @@ void main(){
         // 1) BBox en unidades del cubo 30×30 (origen arriba-izquierda del plano frontal)
         const bbox = { x:0, y:0, w:cubeSize, h:cubeSize };
 
-        // 2) Familia determinista (φ, √2, √3) a partir de invariantes globales
-        const fams = ['phi','r2','r3'];
+        // 2) Familia determinista: ahora φ, √2, √3, √4, √5
+        const fams = ['phi','r2','r3','r4','r5'];                         // ← ampliado
         const fam  = fams[(sceneSeed + S_global + (getSelectedPerms().length||1)) % fams.length];
 
-        // 3) Inventario: dos tamaños de la MISMA familia para habilitar Beatty cuando toque
-        // (los ratios se expresan con las constantes del tiler; las áreas sólo sesgan la elección dominante)
+        // 3) Inventario: dos tamaños de la MISMA familia (rho y 1/rho)
+        const T = window.Tilers;
+        function rhoOf(f){
+          return f==='phi'?T.PHI : f==='r2'?T.ROOT2 : f==='r3'?T.ROOT3 : f==='r4'?T.ROOT4 : T.ROOT5;
+        }
+        const rho = rhoOf(fam);
         let inv;
         if (fam==='phi'){
-          inv = { ratios:[ { r: window.Tilers.PHI,    area: 0.618 },
-                           { r: 1/window.Tilers.PHI,  area: 0.382 } ] };
+          inv = { ratios:[ { r:  rho,   area: 0.618 },
+                           { r: 1/rho, area: 0.382 } ] };
         } else if (fam==='r2'){
-          inv = { ratios:[ { r: window.Tilers.ROOT2,  area: 0.60  },
-                           { r: 1/window.Tilers.ROOT2,area: 0.40  } ] };
-        } else { // 'r3'
-          inv = { ratios:[ { r: window.Tilers.ROOT3,               area: 0.66  },
-                           { r: (window.Tilers.ROOT3-1),           area: 0.34  } ] };
+          inv = { ratios:[ { r:  rho,   area: 0.60  },
+                           { r: 1/rho, area: 0.40  } ] };
+        } else {
+          inv = { ratios:[ { r:  rho,   area: 0.66  },                // r3, r4, r5
+                           { r: 1/rho, area: 0.34  } ] };
         }
 
         // 4) Ensamble con alternancia de estrategias por “bandas” euclidianas
-        //    – ciclo fijo y determinista; se puede rotar con sceneSeed si deseas variar el arranque
-        const stratCycle = ['beatty','euclid','subst'];
+        const stratCycle = ['beatty','euclid','subst']; // ‘subst’ hará fallback a Beatty en r4/r5
         const rawRects = window.Tilers.assemble(bbox, inv, {
           familyId: fam,
           strategyCycle: stratCycle,
@@ -4353,7 +4361,7 @@ void main(){
           const cy = halfCube - (r.y + r.h/2);
           const cz = 0.0;
 
-          // offset cromático (conserva tu lógica previa)
+          // offset cromático (mantenemos tu lógica)
           let off = 0;
           if (r.tag === 'beatty' || r.tag === 'beatty-in-band') off = 1;
           if (r.tag === 'subst') off = 2;


### PR DESCRIPTION
## Summary
- add √4 family to tilers, broaden matching tolerance, and allow Beatty/substitution fallbacks
- expand R5×10 engine to handle φ, √2, √3, √4, √5 families with balanced inventories

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ad5c1bf4832c8a93cc31fd20b16c