### PR TITLE
chore: tweak R5NOVA dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -4473,9 +4473,9 @@ void main(){
     }
 
     /* Parámetros geométricos (idénticos a RAUM) */
-    const R5_W = 60, R5_H = 30, R5_D = 30, R5_G = 2;  // ancho, alto, fondo, grosor pared
+    const R5_W = 30, R5_H = 30, R5_D = 30, R5_G = 2;  // ancho, alto, fondo, grosor pared (pared de fondo 30×30)
     const R5_DEPTH = 1.50;       // espesor de los volúmenes (extrusión hacia la cámara)
-    const R5_GAP   = 0.06;       // ← separación mínima entre volúmenes (pedida)
+    const R5_GAP   = 0.12;       // ← separación mínima (x2)
 
     /* Construye la escena R5NOVA:
        - Pared izquierda, derecha, piso y techo (como RAUM, deterministas)


### PR DESCRIPTION
## Summary
- reduce R5NOVA width to 30 and keep back wall 30x30
- double minimal gap between R5NOVA volumes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed8e62a4832cb21b567c670e9c78