### PR TITLE
feat: add R5NOVA post build adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,6 +816,13 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let scene, camera, renderer, controls, raycaster, mouse;
     let cubeUniverse, permutationGroup;
     const cubeSize = 30, segment = cubeSize/5, halfCube = cubeSize/2;
+
+    // === Ajustes específicos de R5NOVA (solo aplican cuando R5NOVA está activo) ===
+    const R5NOVA_BACK_DEPTH   = 0.12;  // grosor (en escala) de los volúmenes de la pared del fondo → “casi sin profundidad”
+    const R5NOVA_MIN_VOLUMES  = 4;     // mínimo de volúmenes visibles en pared del fondo
+    const R5NOVA_MAX_VOLUMES  = 10;    // máximo de volúmenes visibles en pared del fondo
+    const R5NOVA_DISABLE_CEILING = true; // apagar volumen de techo (no borrar → visible=false)
+
     const EPS = 1e-6;
     let isPaused = false, currentMode = "manual", userRating = null, textsVisible = true;
     let attributeMapping = [0,1,2,3,4, 0,1];   // forma,color,x,y,z,bg,wall
@@ -2366,20 +2373,87 @@ function makePalette(){
     function updateColorPickersFromScene(){
       // memoriza el primer glifo encontrado para cada índice P2 (1-5)
       const seen = {};
-      permutationGroup.children.forEach(o=>{
-        const pa  = o.userData.permStr.split(',').map(Number);
-        const idx = pa[attributeMapping[1]];           // 1-5
-        if(!seen[idx]){
-          const c = o.material.color;                     // THREE.Color
-          const hex = '#'+c.getHexString();
-          const inp = document.getElementById('color'+idx);
-          if(inp) inp.value = hex;
-          seen[idx]=true;
-        }
-      });
-    }
+        permutationGroup.children.forEach(o=>{
+          const pa  = o.userData.permStr.split(',').map(Number);
+          const idx = pa[attributeMapping[1]];           // 1-5
+          if(!seen[idx]){
+            const c = o.material.color;                     // THREE.Color
+            const hex = '#'+c.getHexString();
+            const inp = document.getElementById('color'+idx);
+            if(inp) inp.value = hex;
+            seen[idx]=true;
+          }
+        });
+      }
 
-    function refreshAll(opts = {rebuild:false}){
+      /* ──────────────────────────────────────────────────────────────
+       *  R5NOVA · post-ajustes no invasivos
+       *  – Reduce espesor de volúmenes de la pared del fondo
+       *  – Limita el nº de volúmenes en pared del fondo (min 4, máx 10)
+       *  – Apaga (visible=false) el/los volúmenes del techo
+       *  Nota: sólo actúa si isR5NOVA === true. No interfiere con otros motores.
+       * ────────────────────────────────────────────────────────────── */
+      function __near(v, t, eps){ return Math.abs(v - t) <= (eps ?? 0.75); }
+
+      function adjustR5NovaAfterBuild(){
+        if (typeof isR5NOVA === 'undefined' || !isR5NOVA) return;
+
+        // Intentamos usar el grupo propio si existe; si no, escaneamos la escena.
+        const root = (typeof r5novaGroup !== 'undefined' && r5novaGroup) ? r5novaGroup : scene;
+
+        const backZ = -halfCube;   // fondo del cubo 30×30×30 (z ≈ -15)
+        const ceilY = +halfCube;   // techo (y ≈ +15)
+
+        // 1) Detectar volúmenes pegados a la pared del fondo y reducir su “profundidad” (eje Z).
+        const backVolumes = [];
+        root.traverse(o=>{
+          if (!o.isMesh) return;
+          if (o === cubeUniverse) return;
+
+          const wp = new THREE.Vector3();
+          o.getWorldPosition(wp);
+
+          // candidato “en el fondo”: centro cercano a z ≈ -15 (tolerancia 2 u)
+          if (__near(wp.z, backZ, 2.0)) {
+            o.scale.z = Math.max(0.001, R5NOVA_BACK_DEPTH); // “casi plano”
+            backVolumes.push(o);
+          }
+        });
+
+        // 2) Límite de cantidad en pared del fondo → [R5NOVA_MIN_VOLUMES … R5NOVA_MAX_VOLUMES]
+        //    Si hay más, se ocultan los extra; si hay menos, se clona alguno con un jitter mínimo.
+        backVolumes.sort((a,b)=> a.uuid.localeCompare(b.uuid));
+
+        for (let i = R5NOVA_MAX_VOLUMES; i < backVolumes.length; i++){
+          backVolumes[i].visible = false;
+        }
+
+        if (backVolumes.length < R5NOVA_MIN_VOLUMES && backVolumes.length > 0){
+          const need = R5NOVA_MIN_VOLUMES - backVolumes.length;
+          for (let k = 0; k < need; k++){
+            const src = backVolumes[ backVolumes.length - 1 - (k % backVolumes.length) ];
+            const clone = src.clone();
+            // micro-desplazamiento para evitar z-fighting
+            clone.position.x += (k+1) * 0.15;
+            clone.position.y += (k % 2 ? -1 : 1) * 0.15;
+            clone.visible = true;
+            (src.parent || root).add(clone);
+          }
+        }
+
+        // 3) Apagar volumen/es de techo (y ≈ +15). No se borran, solo visible=false.
+        if (R5NOVA_DISABLE_CEILING){
+          root.traverse(o=>{
+            if (!o.isMesh) return;
+            const wp = new THREE.Vector3();
+            o.getWorldPosition(wp);
+            // techo: y≈+15; z libre (puede estar delante o atrás)
+            if (__near(wp.y, ceilY, 1.5)) o.visible = false;
+          });
+        }
+      }
+
+      function refreshAll(opts = {rebuild:false}){
       if(!opts.keepManual){            // por defecto se limpian colores manuales
         manualOverride = {};
       }
@@ -2398,10 +2472,16 @@ function makePalette(){
       if (isFRBN && skySphere) buildGanzfeld();   // FRBN sincronizado
       rebuildLCHTIfActive();                      // LCHT sincronizado
       if (isOFFNNG) syncOFFNNGFromScene();
-      rebuildRAUMIfActive();
-      rebuild13245IfActive();                     // ← NUEVO
-      rebuildR5NOVAIfActive();                // ← NUEVO
-    }
+        rebuildRAUMIfActive();
+        rebuild13245IfActive();                     // ← NUEVO
+        rebuildR5NOVAIfActive();                    // ← NUEVO
+        // Post-ajustes específicos de R5NOVA (espesor fondo, 4–10 volúmenes, techo OFF)
+        if (typeof isR5NOVA !== 'undefined' && isR5NOVA){
+          // cede un frame para asegurar que el build terminó y hay world matrices
+          setTimeout(adjustR5NovaAfterBuild, 0);
+          requestAnimationFrame(adjustR5NovaAfterBuild);
+        }
+      }
     function onColourPick(idx,hex){
       manualOverride[idx]=hex;
       refreshAll({keepManual:true});


### PR DESCRIPTION
## Summary
- add configuration constants for R5NOVA engine
- implement adjustR5NovaAfterBuild to tweak back-wall volumes and ceiling
- invoke adjustR5NovaAfterBuild after rebuilding R5NOVA

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1833f8088832cbf96fbb22c8861e6