### PR TITLE
feat: actualizar parámetros y postprocesado R5NOVA

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,12 +817,9 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let cubeUniverse, permutationGroup;
     const cubeSize = 30, segment = cubeSize/5, halfCube = cubeSize/2;
 
-    // === Ajustes específicos de R5NOVA (solo aplican cuando R5NOVA está activo) ===
-    const R5NOVA_BACK_DEPTH   = 0.12;   // espesor mínimo en Z (factor de escala). Con BoxGeometry depth=0.5 → ~0.06u visibles
-    const R5NOVA_BACK_EPS_Z   = 0.0005; // micro-separación anti z-fighting
-    const R5NOVA_MIN_VOLUMES  = 4;      // garantiza al menos 4 volúmenes en el fondo (si hay menos, clona)
-    const R5NOVA_MAX_VOLUMES  = 10;     // opcional: oculta el resto para que no “sature” el fondo
-    const R5NOVA_DISABLE_CEILING = true; // apaga el techo (queda en escena, solo invisible)
+    // === R5NOVA — parámetros de raíz (sin parches) ===
+    const R5NOVA_MIN_WORLD_THICKNESS = 0.18; // grosor deseado (unidades de MUNDO) para la fila del fondo
+    const R5NOVA_BACK_BAND           = 1.6;  // banda alrededor de z_min para capturar la fila del fondo (step=6)
 
     const EPS = 1e-6;
     let isPaused = false, currentMode = "manual", userRating = null, textsVisible = true;
@@ -2388,158 +2385,87 @@ function makePalette(){
       }
 
             /* ──────────────────────────────────────────────────────────────
-       *  R5NOVA · post-ajustes no invasivos (versión final)
-       * ────────────────────────────────────────────────────────────── */
-      function adjustR5NovaAfterBuild(){
+ *  R5NOVA · pasada final (fondo por minZ, grosor mundo, colores únicos)
+ * ────────────────────────────────────────────────────────────── */
+function adjustR5NovaAfterBuild(){
   if (typeof isR5NOVA === 'undefined' || !isR5NOVA) return;
 
-  // Preferimos trabajar SOLO sobre las permutaciones
-  const root =
-    (typeof permutationGroup !== 'undefined' && permutationGroup) ? permutationGroup :
-    (typeof r5novaGroup !== 'undefined' && r5novaGroup)          ? r5novaGroup :
-    scene;
+  // Trabajamos sobre el grupo de permutaciones (no tocamos el cubo contenedor)
+  const root = (typeof permutationGroup !== 'undefined' && permutationGroup) ? permutationGroup : scene;
+  const wp   = new THREE.Vector3();
 
-  const backZ = -halfCube;   // z = -15
-  const ceilY = +halfCube;   // y = +15
-  const wp    = new THREE.Vector3();
+  // 1) z mínimo real en mundo (fila del fondo)
+  let zMin = Infinity;
+  root.traverse(o=>{
+    if (!o.isMesh || o === cubeUniverse) return;
+    o.getWorldPosition(wp);
+    if (wp.z < zMin) zMin = wp.z;
+  });
+  if (!isFinite(zMin)) return;
 
-  const backVolumes = [];
+  const bandMax = zMin + R5NOVA_BACK_BAND;
 
-  // Helper: cada mesh DEBE tener su propio material (sin compartir)
+  // Helper: cada mesh con su propio material (no compartido)
   function ensureOwnMaterial(mesh){
     if (!mesh.material) return;
-    // Si ya lo hicimos, salimos
     if (mesh.userData._r5novaOwnMat) return;
-
     mesh.material = mesh.material.clone();
     mesh.material.dithering = true;
-
-    // Empújalo un pelín “hacia delante” del BackSide del cubo
-    mesh.material.polygonOffset       = true;
-    mesh.material.polygonOffsetFactor = -2;  // negativo → más cercano a cámara
-    mesh.material.polygonOffsetUnits  = -2;
-
-    // Asegurar que renderiza después de las paredes del cubo
-    mesh.renderOrder = 10;
-
     mesh.userData._r5novaOwnMat = true;
   }
 
-  // 1) Detectar volúmenes en el fondo, **achatar**, **pegar** y **fijar** orientación
+  // 2) Fila del fondo = objetos con z ≤ zMin + banda
   root.traverse(o=>{
     if (!o.isMesh || o === cubeUniverse) return;
-
     o.getWorldPosition(wp);
-    // Cerca del plano trasero (tolerancia estricta)
-    if (Math.abs(wp.z - backZ) <= 1.2){
-      // Material independiente + bias de profundidad
-      ensureOwnMaterial(o);
+    if (wp.z <= bandMax + 1e-6){
 
-      // Detener animación de giro y resetear rotación para que NO “recupere” grosor
+      // a) Fijar orientación y detener giro
       o.userData.rotationSpeed = 0;
       o.rotation.set(0,0,0);
 
-      // Achatar Z (profundidad real = depthParam * scale.z)
-      const depthParam = (o.geometry && o.geometry.parameters && o.geometry.parameters.depth)
+      // b) Grosor mínimo en unidades de mundo (escala sobre depth del BoxGeometry)
+      const depthParam = (o.geometry && o.geometry.parameters && typeof o.geometry.parameters.depth === 'number')
         ? o.geometry.parameters.depth : 0.5;
-      o.scale.z = Math.max(0.0002, R5NOVA_BACK_DEPTH);
+      const targetScaleZ = Math.max(0.0002, R5NOVA_MIN_WORLD_THICKNESS / Math.max(1e-6, depthParam));
+      o.scale.z = targetScaleZ;
 
-      // Colocar el **plano trasero** exactamente en z = backZ + EPS
-      const d = depthParam * o.scale.z;                // grosor final en mundo
-      o.position.z = backZ + (d*0.5) + R5NOVA_BACK_EPS_Z;
+      // c) Material propio + color único con contraste ΔE ≥ 22
+      ensureOwnMaterial(o);
 
-      // Asegurar matrices actualizadas
-      o.updateMatrix();
-      o.updateMatrixWorld(true);
-
-      backVolumes.push(o);
-    }
-  });
-
-  // 2) Límite de cantidad (mantener determinismo del orden)
-  backVolumes.sort((a,b)=>
-    (a.position.x - b.position.x) ||
-    (a.position.y - b.position.y) ||
-    a.id - b.id
-  );
-
-  for (let i = R5NOVA_MAX_VOLUMES; i < backVolumes.length; i++){
-    backVolumes[i].visible = false;
-  }
-
-  // 3) Si faltan, clonar desde los últimos y darles material propio
-  if (backVolumes.length && backVolumes.length < R5NOVA_MIN_VOLUMES){
-    const need = R5NOVA_MIN_VOLUMES - backVolumes.length;
-    for (let k = 0; k < need; k++){
-      const src   = backVolumes[ backVolumes.length - 1 - (k % backVolumes.length) ];
-      const clone = src.clone();
-      // Material **independiente** también en el clon
-      ensureOwnMaterial(clone);
-
-      // Micro-offset para no coplanear clones entre sí
-      clone.position.x += (k+1) * 0.12;
-      clone.position.y += (k % 2 ? -1 : 1) * 0.12;
-
-      clone.userData.rotationSpeed = 0;
-      clone.rotation.set(0,0,0);
-      clone.visible = true;
-
-      (src.parent || root).add(clone);
-      clone.updateMatrixWorld(true);
-      backVolumes.push(clone);
-    }
-  }
-
-  // 4) Apagar techo si está activo
-  if (R5NOVA_DISABLE_CEILING){
-    root.traverse(o=>{
-      if (!o.isMesh) return;
-      o.getWorldPosition(wp);
-      if (Math.abs(wp.y - ceilY) <= 1.5) o.visible = false;
-    });
-  }
-
-  // 5) Colores **únicos** (deterministas, sin compartir material)
-  backVolumes.forEach((o, idx)=>{
-    // Base determinista (si viene de una permutación)
-    let sig = [idx,idx,idx,idx,idx], r = idx;
-    if (o.userData && typeof o.userData.permStr === 'string'){
-      const arr = o.userData.permStr.split(',').map(Number);
-      if (Array.isArray(arr) && arr.length === 5){
-        sig = computeSignature(arr);
-        r   = lehmerRank(arr);
+      // Base determinista (si proviene de una permutación)
+      let sig = [0,0,0,0,0], r = 0;
+      if (o.userData && typeof o.userData.permStr === 'string'){
+        const arr = o.userData.permStr.split(',').map(Number);
+        if (Array.isArray(arr) && arr.length === 5){
+          sig = computeSignature(arr);
+          r   = lehmerRank(arr);
+        }
       }
+      const slot = (r + sceneSeed) % 12;
+
+      let [hI,sI,vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
+      sI = (sI * PHI_S) % 12;
+      vI = (vI * PHI_V) % 12;
+
+      const {h,s,v} = idxToHSV(hI, sI, vI);
+      let  rgb      = hsvToRgb(h, s, v);
+      rgb = ensureContrastRGB(rgb);
+
+      // “Vibrance BUILD” coherente con el resto
+      let [h0,s0,v0] = rgbToHsv(rgb[0], rgb[1], rgb[2]);
+      const zNorm    = (o.position.z + halfCube) / cubeSize;
+      const vib      = 0.22 + 0.10 * zNorm;
+      const s1       = Math.min(1, s0 + vib * (1 - s0));
+      const v1       = Math.min(0.93, v0 * (1.02 + 0.06 * zNorm));
+      const rgbBoost = hsvToRgb(h0, s1, v1);
+
+      if (!o.material.emissive) o.material.emissive = new THREE.Color();
+      o.material.color.setRGB(rgbBoost[0]/255, rgbBoost[1]/255, rgbBoost[2]/255);
+      o.material.emissive.setRGB(rgbBoost[0]/255, rgbBoost[1]/255, rgbBoost[2]/255);
+      o.material.emissiveIntensity = 0.03 + 0.12 * zNorm;
+      o.material.needsUpdate = true;
     }
-
-    // Slot único estable por pieza del fondo
-    const slot = (r + sceneSeed + idx) % 12;
-
-    let [hI,sI,vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
-    sI = (sI * PHI_S) % 12;
-    vI = (vI * PHI_V) % 12;
-
-    const {h,s,v} = idxToHSV(hI, sI, vI);
-    let  rgb      = hsvToRgb(h, s, v);
-    rgb = ensureContrastRGB(rgb); // ΔE fondo ≥ 22
-
-    // “Vibrance BUILD” coherente con el resto
-    let [h0, s0, v0] = rgbToHsv(rgb[0], rgb[1], rgb[2]);
-    const zNorm      = (o.position.z + halfCube) / cubeSize;
-    const vib        = 0.22 + 0.10 * zNorm;
-    const s1         = Math.min(1, s0 + vib * (1 - s0));
-    const v1         = Math.min(0.93, v0 * (1.02 + 0.06 * zNorm));
-    const rgbBoost   = hsvToRgb(h0, s1, v1);
-
-    // Color final
-    ensureOwnMaterial(o); // (por si entra aquí sin pasar antes)
-    o.material.color.setRGB(rgbBoost[0]/255, rgbBoost[1]/255, rgbBoost[2]/255);
-
-    // Emisivo suave (igual que BUILD)
-    if (!o.material.emissive) o.material.emissive = new THREE.Color();
-    o.material.emissive.setRGB(rgbBoost[0]/255, rgbBoost[1]/255, rgbBoost[2]/255);
-    o.material.emissiveIntensity = 0.03 + 0.12 * zNorm;
-
-    o.material.needsUpdate = true;
   });
 }
 
@@ -2566,7 +2492,7 @@ function makePalette(){
         rebuildRAUMIfActive();
         rebuild13245IfActive();                     // ← NUEVO
         rebuildR5NOVAIfActive();                    // ← NUEVO
-        // Post-ajustes específicos de R5NOVA (espesor fondo, 4–10 volúmenes, techo OFF)
+        // Post-ajustes específicos de R5NOVA (grosor y color del fondo)
         if (typeof isR5NOVA !== 'undefined' && isR5NOVA){
           // cede un frame para asegurar que el build terminó y hay world matrices
           setTimeout(adjustR5NovaAfterBuild, 0);


### PR DESCRIPTION
## Summary
- sustituye constantes R5NOVA por parámetros de grosor mínimo y banda de captura
- reescribe `adjustR5NovaAfterBuild` para usar z mínimo real, fijar grosor mundial y colores únicos
- simplifica post‑ajuste R5NOVA eliminando clonados y techo

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e757cc10832ca13c8af7368aed8d