### PR TITLE
refactor: isolate R5NOVA config and rebuild

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,11 +817,28 @@ document.getElementById('json-upload').addEventListener('change', function(event
     let cubeUniverse, permutationGroup;
     const cubeSize = 30, segment = cubeSize/5, halfCube = cubeSize/2;
 
-    // === R5NOVA — constantes SOLO para este motor ===
-    // Grosor real (en unidades de mundo) que deben tener las piezas de la fila del fondo
-    const R5NOVA_MIN_BACK_THICKNESS = 0.0012;   // estable y muy fino
-    // Banda alrededor del z_min para capturar TODA la fila del fondo (permanece igual)
-    const R5NOVA_BACK_BAND           = 1.6;    // ≈ una “rebanada” de 1.6u detrás
+    // === R5NOVA — configuración AISLADA (sin depender de otros motores) ===
+    // Todo lo de R5NOVA toma estos valores y NADA más.
+    const R5NOVA_CFG = {
+      // Selección de “fila del fondo”: usamos minZ del AABB en mundo
+      BACK_BAND     : 1.8,          // ancho de la rebanada desde zMin (en unidades de mundo)
+
+      // Grosor objetivo de TODAS las piezas de esa fila (en unidades de mundo, no relativas)
+      BACK_THICKNESS: 0.18,         // pon 0.10–0.40 para probar cambios visibles
+
+      // Material ‘flat’ por defecto (sin luces) para aislar color de la iluminación global
+      MATERIAL      : 'basic',      // 'basic' (flat) o 'lambert' si prefieres difuso
+
+      // “Secuencia dorada” 100% determinista para evitar repeticiones de tono
+      HUE_BASE      : 0.0,                             // grados
+      HUE_STEP      : 137.50776405003785,              // ángulo áureo (evita ciclos cortos)
+      SAT           : 0.86,                            // 0..1
+      VAL           : 0.92,                            // 0..1
+      MIN_HUE_DIFF  : 12,                               // separación mínima entre tonos (grados)
+
+      // Mantener legibilidad frente al fondo (puedes poner false si no lo quieres)
+      ENSURE_CONTRAST: true
+    };
 
     const EPS = 1e-6;
     let isPaused = false, currentMode = "manual", userRating = null, textsVisible = true;
@@ -2386,137 +2403,114 @@ function makePalette(){
         });
       }
 
-            /* ──────────────────────────────────────────────────────────────
- *  R5NOVA · pasada final
- *    • ancla la fila del fondo al plano z_min (grosor fijo en mundo)
- *    • colores deterministas con "golden angle" para unicidad
- *    • contraste mínimo ΔE≥22 con el fondo + vibrance BUILD
- *  SOLO se aplica cuando isR5NOVA === true
- * ────────────────────────────────────────────────────────────── */
+/* ──────────────────────────────────────────────────────────────────────
+ *  R5NOVA · pasada final (AISLADA)
+ *    • Selección por AABB.min.z (más robusto)
+ *    • Grosor fijo BACK_THICKNESS para toda la fila del fondo
+ *    • Color propio por pieza usando secuencia dorada (sin PATTERNS/sceneSeed)
+ *    • Material propio (clonado) para no ser sobreescrito por otros motores
+ * ──────────────────────────────────────────────────────────────────── */
 function adjustR5NovaAfterBuild(){
   if (typeof isR5NOVA === 'undefined' || !isR5NOVA) return;
   if (!permutationGroup) return;
 
-  const root = permutationGroup;
-  const wp   = new THREE.Vector3();
+  const root   = permutationGroup;
+  const tmpBox = new THREE.Box3();
 
-  // 1) z mínimo (mundo)
+  // 1) zMin global = mínimo de minZ (AABB en mundo) entre todas las piezas
   let zMin = +Infinity;
   root.traverse(o=>{
     if (!o.isMesh || o === cubeUniverse) return;
-    o.updateWorldMatrix(true, false);
-    o.getWorldPosition(wp);
-    if (wp.z < zMin) zMin = wp.z;
+    tmpBox.setFromObject(o);
+    if (tmpBox.min.z < zMin) zMin = tmpBox.min.z;
   });
   if (!isFinite(zMin)) return;
 
-  const bandMax = zMin + R5NOVA_BACK_BAND;
+  const bandMax = zMin + R5NOVA_CFG.BACK_BAND;
 
-  // 2) recopila SOLO la fila del fondo (con orden determinista)
+  // 2) Tomamos SOLO piezas cuyo minZ entra en la banda [zMin .. zMin+BACK_BAND]
+  //    y orden estable (Y asc, luego X asc, luego minZ asc) para indexar colores
   const backRow = [];
   root.traverse(o=>{
     if (!o.isMesh || o === cubeUniverse) return;
-    o.updateWorldMatrix(true, false);
-    o.getWorldPosition(wp);
-    if (wp.z <= bandMax + 1e-6){
+    tmpBox.setFromObject(o);
+    if (tmpBox.min.z <= bandMax + 1e-6){
       backRow.push({
         mesh: o,
-        // orden estable: primero Y asc, luego X asc (ambos en mundo)
-        x: wp.x,
-        y: wp.y,
-        z: wp.z
+        x   : o.position.x,
+        y   : o.position.y,
+        z0  : tmpBox.min.z
       });
     }
   });
+  backRow.sort((a,b)=> (a.y - b.y) || (a.x - b.x) || (a.z0 - b.z0));
 
-  backRow.sort((a,b)=> (a.y-b.y) || (a.x-b.x) || (a.z-b.z));
+  // util hue: diferencia circular mínima en grados
+  const hueDelta = (a, b) => {
+    let d = Math.abs(a - b) % 360;
+    return d > 180 ? 360 - d : d;
+  };
 
-  // 3) base de color (hue) ligada a escena pero espaciada por ángulo áureo
-  //    hue_i = (sceneSeed + i * GOLD) % 360 — “unicidad” sin ciclos cortos
-  const baseHue = (sceneSeed % 360 + 360) % 360;
+  const usedH = []; // h usados (para imponer MIN_HUE_DIFF)
 
-  // util local: AABB en mundo
-  const tmpBox = new THREE.Box3();
-  const tmpV3  = new THREE.Vector3();
-
-  // helper: garantiza material propio (no compartido)
-  function ensureOwnMaterial(mesh){
-    if (!mesh.material) return;
-    if (mesh.userData._r5novaOwnMat) return;
-    mesh.material = mesh.material.clone();
-    mesh.material.dithering = true;
-    mesh.userData._r5novaOwnMat = true;
-  }
-
-  // 4) procesa fila del fondo
+  // 3) Procesar cada pieza del fondo: detener giro, fijar grosor, color flat único
   backRow.forEach((item, idx)=>{
     const o = item.mesh;
 
-    // a) Detener y fijar orientación (para escalado coherente sobre Z local)
+    // a) Detener animación y resets para que el escalado en Z sea coherente
     o.userData.rotationSpeed = 0;
     o.rotation.set(0,0,0);
     o.updateWorldMatrix(true, false);
 
-    // b) Calcular espesor actual en mundo y escalar SOLO Z para lograr grosor fijo
+    // b) Calcular grosor actual en mundo y escalar SOLO Z a BACK_THICKNESS
     tmpBox.setFromObject(o);
-    const thick0 = Math.max(1e-6, tmpBox.max.z - tmpBox.min.z);
-    const s      = R5NOVA_MIN_BACK_THICKNESS / thick0;
-    o.scale.z *= s;
+    const thickNow = Math.max(1e-6, tmpBox.max.z - tmpBox.min.z);
+    const sZ = R5NOVA_CFG.BACK_THICKNESS / thickNow;
+    o.scale.z *= sZ;
     o.updateWorldMatrix(true, false);
 
-    // c) Re-anclar al plano de fondo: minZ → zMin
+    // c) Re-anclar al plano de fondo: minZ → zMin exacto
     tmpBox.setFromObject(o);
-    const minZ1 = tmpBox.min.z;
-    const dz    = zMin - minZ1;
-    o.position.z += dz;              // desplaza en Z local
+    const dz = zMin - tmpBox.min.z;
+    o.position.z += dz;
     o.updateWorldMatrix(true, false);
 
-    // d) Color propio + contraste + vibrance
-    ensureOwnMaterial(o);
-
-    // Firma/slot determinista por si lo quieres como semilla secundaria
-    let sig = [0,0,0,0,0], r = 0;
-    if (o.userData && typeof o.userData.permStr === 'string'){
-      const arr = o.userData.permStr.split(',').map(Number);
-      if (Array.isArray(arr) && arr.length === 5){
-        sig = computeSignature(arr);
-        r   = lehmerRank(arr);
+    // d) Material PROPIO (no compartido) y preferentemente plano (sin luces)
+    if (!o.userData._r5novaOwnMat){
+      let mat;
+      if (R5NOVA_CFG.MATERIAL === 'basic'){
+        mat = new THREE.MeshBasicMaterial({ color: 0xffffff, dithering: true });
+      } else {
+        mat = new THREE.MeshLambertMaterial({ color: 0xffffff, dithering: true });
       }
+      if (o.material && o.material.transparent){
+        mat.transparent = true;
+        mat.opacity     = o.material.opacity;
+      }
+      o.material = mat;
+      o.userData._r5novaOwnMat = true;
     }
 
-    // — modo "golden": h_i bien espaciados y reproducibles
-    const hGolden = (baseHue + idx * GOLD) % 360;
+    // e) Color 100% desacoplado: H(i) = H0 + i·φ  (con separación mínima entre tonos)
+    let h = (R5NOVA_CFG.HUE_BASE + idx * R5NOVA_CFG.HUE_STEP) % 360;
+    let guard = 0;
+    while (usedH.some(u => hueDelta(h, u) < R5NOVA_CFG.MIN_HUE_DIFF) && guard < 36){
+      h = (h + 7) % 360; // micro-desplazamiento determinista si cae muy cerca
+      guard++;
+    }
+    usedH.push(h);
 
-    // S,V: derivadas de patrón, pero con dispersión coprima (PHI_S/PHI_V)
-    const slot  = (r + sceneSeed + idx) % 12;
-    let [hI,sI,vI] = PATTERNS[activePatternId](sig, sceneSeed, slot);
-    sI = (sI * PHI_S) % 12;
-    vI = (vI * PHI_V) % 12;
+    let rgb = hsvToRgb(h, R5NOVA_CFG.SAT, R5NOVA_CFG.VAL);
+    if (R5NOVA_CFG.ENSURE_CONTRAST) rgb = ensureContrastRGB(rgb);
 
-    const sv    = idxToHSV(0, sI, vI);  // usamos S,V de cuadrícula
-    let  rgb    = hsvToRgb(hGolden, sv.s, sv.v);
+    o.material.color.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
 
-    // contraste mínimo contra el fondo actual
-    rgb = ensureContrastRGB(rgb);
+    // Emisión suave (si el material lo soporta) — no depende de vibrance/FRBN/etc.
+    if ('emissive' in o.material){
+      o.material.emissive = new THREE.Color(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+      o.material.emissiveIntensity = 0.08;
+    }
 
-    // Vibrance BUILD coherente (en función de frontalidad relativa)
-    let [h0,s0,v0] = rgbToHsv(rgb[0], rgb[1], rgb[2]);
-    // zNorm usa posición local; tras el re-anclaje, la cara trasera está en zMin.
-    // Para mantener el “gesto” de vibrance, usamos la Z del centro del AABB:
-    tmpBox.setFromObject(o);
-    const zCenter = 0.5*(tmpBox.min.z + tmpBox.max.z);
-    const zNorm   = (zCenter + halfCube) / cubeSize;   // 0..1 relativo al cubo
-    const vib     = 0.22 + 0.10 * zNorm;
-    const s1      = Math.min(1, s0 + vib * (1 - s0));
-    const v1      = Math.min(0.93, v0 * (1.02 + 0.06 * zNorm));
-    const rgb2    = hsvToRgb(h0, s1, v1);
-
-    o.material.color.setRGB(rgb2[0]/255, rgb2[1]/255, rgb2[2]/255);
-
-    // energía suave (sin “quemados”)
-    if (!o.material.emissive) o.material.emissive = new THREE.Color();
-    o.material.emissive.setRGB(rgb2[0]/255, rgb2[1]/255, rgb2[2]/255);
-    o.material.emissiveIntensity = 0.03 + 0.12 * zNorm;
     o.material.needsUpdate = true;
   });
 }


### PR DESCRIPTION
## Summary
- encapsulate R5NOVA parameters in isolated `R5NOVA_CFG` object
- reimplement `adjustR5NovaAfterBuild` to use fixed thickness, golden-angle colors and dedicated materials

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a211de7584832c9fe2850966722fa8