### PR TITLE
R5NOVA: marco visible y borde perimetral ajustado

### DIFF
--- a/index.html
+++ b/index.html
@@ -4639,7 +4639,16 @@ void main(){
 
     // ——— R5NOVA · ensamblado BSP con ratios 0.42–0.58 y recorte determinista ———
     function r5novaAssembleRects(){
-      const bbox = { x: -R5_W/2, y: -R5_H/2, w: R5_W, h: R5_H };
+      // Borde perimetral para que la separación contra paredes/techo/piso
+      // sea IGUAL al gap entre volúmenes:
+      //  - reducimos el bbox del tiler en R5_GAP/2 por lado
+      const BORDER = R5_GAP / 2;
+      const bbox = {
+        x: -R5_W/2 + BORDER,
+        y: -R5_H/2 + BORDER,
+        w: R5_W - 2 * BORDER,
+        h: R5_H - 2 * BORDER
+      };
       const seed = computeLayoutSeed();  // ya existe en el código
 
       const rects = window.Tilers.assemble(bbox, null, {
@@ -4750,9 +4759,9 @@ void main(){
         mesh.position.set(cx, cy, zBackEdge + R5_DEPTH/2); // pegado al canto posterior
         groupR5NOVA.add(mesh);
 
-        // === Rahmen (marco) INTERNO y de color único/determinista ===
+        // === Rahmen (marco) INTERNO con pequeño "pull" hacia la cámara ===
         // grosor base ≈ 2× gap, con límites para no cerrar el hueco interior
-        const FRAME_Z_EPS = 0.03; // pequeño offset hacia ADENTRO para evitar z-fighting
+        const FRAME_Z_PULL = 0.06; // mueve el marco mínimamente hacia el frente (evita z-fighting)
         const tRaw = Math.min(R5_GAP * 2, Math.min(w, h) * 0.20);
         const t    = Math.max(0.001, Math.min(tRaw, w / 3, h / 3)); // asegura w-2t y h-2t positivos
 
@@ -4760,10 +4769,9 @@ void main(){
         const wIn = Math.max(0.001, w - 2 * t);
         const hIn = Math.max(0.001, h - 2 * t);
 
-        // color del marco: distinto al del cuerpo y todos distintos entre sí (determinista)
-        // usamos el mismo 'pa' del volumen, pero con un offset de ranura que rota en el círculo de 12
-        //  - offs  : offset del cuerpo (según tag)
-        //  - offsF : offset adicional (ciclo de paso 5, coprimo con 12) + 6 (opuesto) → muy distinto
+        // color del marco: distinto al del cuerpo y determinista
+        // offs  : offset del cuerpo (según tag)
+        // offsF : offset adicional (ciclo de paso 5, coprimo con 12) + 6 (opuesto) → muy distinto
         const offsF = (offs + 6 + (5 * i) % 12) % 12;
         const colF  = colorR5NFor(pa, offsF);
 
@@ -4771,10 +4779,10 @@ void main(){
         matF.emissive = colF.clone();
         matF.emissiveIntensity = 0.12;
 
-        // colocamos el marco un pelín HACIA ADENTRO del volumen (no hacia afuera)
-        const zFrame = zBackEdge + R5_DEPTH/2 - FRAME_Z_EPS;
+        // Posición Z del marco: un pelín por DELANTE del volumen
+        const zFrame = mesh.position.z + FRAME_Z_PULL;
 
-        // 4 barras internas: arriba/abajo/izq/der
+        // 4 barras internas: arriba/abajo/izq/der (misma profundidad que el volumen)
         const topGeo = new THREE.BoxGeometry(wIn, t, R5_DEPTH);
         const botGeo = new THREE.BoxGeometry(wIn, t, R5_DEPTH);
         const lefGeo = new THREE.BoxGeometry(t, hIn, R5_DEPTH);


### PR DESCRIPTION
## Summary
- Añade marco interno con ligero desplazamiento hacia la cámara para evitar z-fighting y hacerlo visible
- Reduce el área de ensamblado de rectángulos para igualar la separación perimetral con el gap interno

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a395f7b8fc832c80d0b218069e1f66