### PR TITLE
Refine engine cycle to avoid TMSL double toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5105,25 +5105,26 @@ void main(){
 
     /* === Rueda de motores del botón “4” (sincroniza el menú) === */
     function cycleEngine(){
-      if (isFRBN){  toggleFRBN(); toggleLCHT(); updateEngineSelectUI(); return; }   // FRBN → LCHT
-      if (isLCHT){  ensureOnlyOFFNNG();        updateEngineSelectUI(); return; }   // LCHT → OFFNNG
-      if (isOFFNNG){ensureOnlyTMSL();          updateEngineSelectUI(); return; }   // OFFNNG → TMSL
-
-      // --- FIX: no quedarse “clavado” en TMSL ---
-      if (isTMSL){
-        try{ if (!isRAUM) toggleRAUM(); }catch(_){ }
-        try{ if (isTMSL)  toggleTMSL(); }catch(_){ }
+      const syncUI = () => {
         updateEngineSelectUI();
-        return;                                                                      // TMSL → RAUM
-      }
+        setTimeout(updateEngineSelectUI, 0);
+        requestAnimationFrame(updateEngineSelectUI);
+      };
 
-      if (isRAUM){  ensureOnly13245();         updateEngineSelectUI(); return; }   // RAUM  → 13245
-      if (is13245){ ensureOnlyR5NOVA();        updateEngineSelectUI(); return; }   // 13245 → R5NOVA
-      if (isR5NOVA){ switchToBuild();          updateEngineSelectUI(); return; }   // R5NOVA → BUILD
+      if (isFRBN){   ensureOnlyLCHT();   syncUI(); return; }   // FRBN  → LCHT
+      if (isLCHT){   ensureOnlyOFFNNG(); syncUI(); return; }   // LCHT  → OFFNNG
+      if (isOFFNNG){ ensureOnlyTMSL();   syncUI(); return; }   // OFFNNG→ TMSL
+
+      // FIX: TMSL no hace doble toggle
+      if (isTMSL){   ensureOnlyRAUM();   syncUI(); return; }   // TMSL → RAUM
+
+      if (isRAUM){   ensureOnly13245();  syncUI(); return; }   // RAUM  → 13245
+      if (is13245){  ensureOnlyR5NOVA(); syncUI(); return; }   // 13245 → R5NOVA
+      if (isR5NOVA){ switchToBuild();    syncUI(); return; }   // R5NOVA→ BUILD
 
       // BUILD → FRBN
-      toggleFRBN();
-      updateEngineSelectUI();
+      if (typeof ensureOnlyFRBN === 'function') ensureOnlyFRBN(); else toggleFRBN();
+      syncUI();
     }
 
     init();


### PR DESCRIPTION
## Summary
- Replace `cycleEngine` with bounce-resistant implementation
- Ensure TMSL transitions directly to RAUM without double toggle
- Reinforce engine select UI updates across frames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5455596f8832ca53d9c16aceb504e