### PR TITLE
Clamp TMSL halo to cube and enforce black matte background

### DIFF
--- a/index.html
+++ b/index.html
@@ -3937,6 +3937,7 @@ void main(){
     // ── TMSL · Tomasello/Staudt — estado + textura halo ────────────────
     let tmslHaloTex   = null;
     let tmslHaloGroup = null;
+    let tmslClampGroup = null;   // anillo/“marco” que oculta halo fuera del perímetro
     let tmslCellsGroup = null;   // ← NUEVO: contenedor único de volúmenes+marcos
 
     function makeHaloTexture(size = 256, inner = 0.30, outer = 0.98, gamma = 1.6){
@@ -4058,6 +4059,53 @@ void main(){
       scene.add(tmslGroup);
     }
 
+    // Ocultador del halo fuera del área útil (perímetro = cuadrado del cubo 30×30)
+    function buildTMSLHaloClamp(wallFrontZ){
+      try{
+        // limpia versión previa
+        if (tmslClampGroup){
+          tmslClampGroup.traverse(o=>{ if(o.isMesh){ o.geometry.dispose?.(); o.material.dispose?.(); }});
+          if (tmslGroup) tmslGroup.remove(tmslClampGroup);
+          tmslClampGroup = null;
+        }
+        if (!tmslGroup) return;
+
+        const clampZ = wallFrontZ + 0.006;           // un pelo delante del halo (halo ≈ +0.005)
+        const BIG    = cubeSize * 10;                 // tamaño amplio para cubrir “hasta infinito”
+        const minX   = -halfCube, maxX = halfCube;    // perímetro: el cuadrado 30×30
+        const minY   = -halfCube, maxY = halfCube;
+        const W      = (maxX - minX);
+        const H      = (maxY - minY);
+
+        const mat = new THREE.MeshBasicMaterial({
+          color: 0x000000,
+          side: THREE.DoubleSide,
+          depthWrite: true,
+          depthTest: true,
+          transparent: false
+        });
+
+        tmslClampGroup = new THREE.Group();
+
+        // Bandas superior e inferior
+        const top    = new THREE.Mesh(new THREE.PlaneGeometry(W, BIG), mat.clone());
+        top.position.set((minX+maxX)/2, maxY + BIG/2, clampZ);
+
+        const bottom = new THREE.Mesh(new THREE.PlaneGeometry(W, BIG), mat.clone());
+        bottom.position.set((minX+maxX)/2, minY - BIG/2, clampZ);
+
+        // Bandas izquierda y derecha
+        const left   = new THREE.Mesh(new THREE.PlaneGeometry(BIG, H + 2*BIG), mat.clone());
+        left.position.set(minX - BIG/2, (minY+maxY)/2, clampZ);
+
+        const right  = new THREE.Mesh(new THREE.PlaneGeometry(BIG, H + 2*BIG), mat.clone());
+        right.position.set(maxX + BIG/2, (minY+maxY)/2, clampZ);
+
+        tmslClampGroup.add(top, bottom, left, right);
+        tmslGroup.add(tmslClampGroup);
+      }catch(e){ console.warn('[TMSL] halo clamp error:', e); }
+    }
+
     function buildTMSL_TomaselloStaudt(){
       if (!tmslGroup) return;
 
@@ -4076,6 +4124,12 @@ void main(){
         tmslGroup.remove(tmslHaloGroup);
         tmslHaloGroup = null;
       }
+      // limpia clamp previo
+      if (tmslClampGroup){
+        tmslClampGroup.traverse(o=>{ if(o.isMesh){ o.geometry.dispose?.(); o.material.dispose?.(); }});
+        tmslGroup.remove(tmslClampGroup);
+        tmslClampGroup = null;
+      }
       if (!tmslHaloTex) tmslHaloTex = makeHaloTexture(512);
       tmslHaloGroup = new THREE.Group();
       tmslGroup.add(tmslHaloGroup);
@@ -4093,7 +4147,7 @@ void main(){
 
       // medidas base (igual que venías usando)
       const MOD_W = 1.60;     // ancho
-      const DEP   = 0.80;     // profundidad (salida)
+      const DEP   = 0.40;     // profundidad (salida)
       const HALO_SCALE_X = 4.0;
       const HALO_SCALE_Y = 4.0;
 
@@ -4200,6 +4254,8 @@ void main(){
           tmslHaloGroup.add(halo);
         }
       }
+      // … tras terminar de crear todos los halos y volúmenes …
+      buildTMSLHaloClamp(wallFrontZ);
     }
 
     function updateTMSLHalos(t){
@@ -5711,12 +5767,12 @@ async function showPatternInfo(){
     try{
       if (on){
         if (!window.__tmslAmbient){
-          const amb = new THREE.AmbientLight(0xffffff, 0.12); // antes 0.55
+          const amb = new THREE.AmbientLight(0xffffff, 0.55);
           amb.name = '__tmslAmbient';
           scene.add(amb);
           window.__tmslAmbient = amb;
         } else {
-          window.__tmslAmbient.intensity = 0.12;
+          window.__tmslAmbient.intensity = 0.55;
         }
       } else {
         if (window.__tmslAmbient){
@@ -5749,15 +5805,25 @@ async function showPatternInfo(){
 
   // Base mínima visible + FONDO NEGRO MATE para TMSL
   window.ensureBaseVisibilityForTMSL = function(){
-    try{
-      scene.background = new THREE.Color(TMSL_BG_HEX);
-      if (renderer && renderer.setClearColor) renderer.setClearColor(TMSL_BG_HEX, 1);
-    }catch(_){ }
     try{ if (window.cubeUniverse)     cubeUniverse.visible = true; }catch(_){ }
     try{ if (window.permutationGroup) permutationGroup.visible = true; }catch(_){ }
-    try{ renderer.autoClear = true; }catch(_){ }
-    ensureTMSLLighting(true);
-    window.applyTMSLSafeCamera?.();
+
+    // Fondo y clear a negro mate (evita grises heredados de BUILD)
+    try{ scene.background = new THREE.Color(0x000000); }catch(_){ }
+    try{ renderer.autoClear = true; renderer.setClearColor(0x000000, 1); }catch(_){ }
+
+    // Luz de cortesía (suave, no quema el halo)
+    try{
+      if (!window.__tmslAmbient){
+        const amb = new THREE.AmbientLight(0xffffff, 0.55);
+        amb.name = '__tmslAmbient';
+        scene.add(amb);
+        window.__tmslAmbient = amb;
+      }
+    }catch(_){ }
+
+    // Cámara segura
+    window.applyTMSLSafeCamera();
   };
 
   // Parchea toggleTMSL (post-entrada) — sin reactivar el cubo ni el fondo


### PR DESCRIPTION
## Summary
- ensure TMSL always renders against a matte black backdrop and adds a courtesy ambient light
- clamp TMSL halo with black bands around the cube perimeter
- halve TMSL volume depth for shallower geometry

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76f0cf478832cbca60b27d1ce3e5b