### PR TITLE
feat: add black backdrop and halve TMSL thickness

### DIFF
--- a/index.html
+++ b/index.html
@@ -3919,7 +3919,7 @@ void main(){
 
     /* ═════════════════════ FIN BLOQUE OFFNNG v4 ═════════════════════ */
 
-    /* ───────────────  TMSL  ·  frontal white wall  ─────────────── */
+    /* ───────────────  TMSL  ·  black matte background  ─────────────── */
     let isTMSL = false;
     let tmslGroup = null;
     let tmslPrevBg = null;
@@ -4036,7 +4036,105 @@ void main(){
       try{
         if (!tmslGroup) buildTMSL();
         buildTMSL_TomaselloStaudt();
+        tmslSetBackgroundBlack();
+        tmslEnsureBlackBackdrop();
+        tmslHalveVolumeThickness();
       }catch(_){ }
+    }
+
+    // === FONDO NEGRO MATE PARA TMSL ===
+    function tmslSetBackgroundBlack(){
+      // negro real en el clear del renderer y en el canvas
+      renderer.autoClear = true;
+      renderer.setClearColor(0x000000, 1);
+      if (scene) scene.background = new THREE.Color(0x000000);
+      if (renderer.domElement && renderer.domElement.style){
+        renderer.domElement.style.background = '#000000';
+      }
+    }
+
+    // Pared negra justo detrás del campo de volúmenes (siempre mirando a cámara)
+    function tmslEnsureBlackBackdrop(){
+      const root = (window.tmslGroup ?? scene);
+      if (!root) return;
+
+      // calcula el área a cubrir
+      const box = new THREE.Box3().setFromObject(root);
+      const size = box.getSize(new THREE.Vector3());
+      const center = box.getCenter(new THREE.Vector3());
+
+      const W = Math.max(1, size.x * 1.1);
+      const H = Math.max(1, size.y * 1.1);
+
+      let plane = scene.getObjectByName('TMSL_BACKDROP');
+      if (!plane){
+        plane = new THREE.Mesh(
+          new THREE.PlaneGeometry(W, H),
+          new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide })
+        );
+        plane.name = 'TMSL_BACKDROP';
+        plane.renderOrder = -1_000_000; // SIEMPRE al fondo
+        scene.add(plane);
+      }else{
+        // actualiza tamaño por si cambió la retícula
+        plane.geometry.dispose?.();
+        plane.geometry = new THREE.PlaneGeometry(W, H);
+        plane.material.color.set(0x000000);
+      }
+
+      // coloca la pared detrás, perpendicular a cámara
+      const dir = new THREE.Vector3();
+      camera.getWorldDirection(dir);         // dirección hacia delante
+      const offset = 0.1;                     // distancia pequeña detrás
+      plane.position.copy(center).add(dir.multiplyScalar(-offset));
+      plane.quaternion.copy(camera.quaternion);
+    }
+
+    // === MITAD DE ESPESOR EN VOLÚMENES ===
+    function tmslHalveVolumeThickness(){
+      const root = (window.tmslGroup ?? scene);
+      if (!root) return;
+
+      const processed = new Set();
+
+      root.traverse(obj=>{
+        if (!obj || !obj.isMesh) return;
+        if (obj.name === 'TMSL_BACKDROP') return;                    // no tocar fondo
+        const mat = obj.material;
+        // evita halos/capas transparentes
+        if (Array.isArray(mat) ? mat.some(m=>m.transparent) : (mat && mat.transparent)) return;
+
+        const g = obj.geometry;
+        if (!g) return;
+
+        // sólo candidatos que parecen volúmenes (caja/extrusión o nombre típico)
+        const name = (obj.name||'').toLowerCase();
+        const isCandidate =
+          g.type === 'BoxGeometry' || g.type === 'ExtrudeGeometry' ||
+          name.includes('vol') || name.includes('block') || name.includes('cube');
+        if (!isCandidate) return;
+
+        if (processed.has(obj)) return;
+        processed.add(obj);
+
+        g.computeBoundingBox?.();
+        const bb = g.boundingBox;
+        if (!bb) return;
+
+        const sx = bb.max.x - bb.min.x;
+        const sy = bb.max.y - bb.min.y;
+        const sz = bb.max.z - bb.min.z;
+
+        // el eje con menor dimensión es el espesor
+        let axis = 'x', min = sx;
+        if (sy < min){ axis = 'y'; min = sy; }
+        if (sz < min){ axis = 'z'; min = sz; }
+
+        // mitad del espesor
+        if (axis === 'x') obj.scale.x *= 0.5;
+        if (axis === 'y') obj.scale.y *= 0.5;
+        if (axis === 'z') obj.scale.z *= 0.5;
+      });
     }
 
     function buildTMSL(){
@@ -4046,25 +4144,16 @@ void main(){
         scene.remove(tmslGroup);
       }
       tmslGroup = new THREE.Group();
-
-      /* pared blanca con 2 u de “tiefe” */
-      const DEPTH = 2;
-      const wallGeo = new THREE.BoxGeometry(cubeSize*3, cubeSize*3, DEPTH);
-      const wallMat = new THREE.MeshLambertMaterial({color:0xffffff});
-      const wall = new THREE.Mesh(wallGeo, wallMat);
-      wall.position.set(0, 0, halfCube + DEPTH/2);   // pegada al frontal
-      wall.userData.tmslKind = 'wall';               // ← etiqueta para no eliminarla en rebuild
-      tmslGroup.add(wall);
       scene.add(tmslGroup);
+      window.tmslGroup = tmslGroup;
     }
 
     function buildTMSL_TomaselloStaudt(){
       if (!tmslGroup) return;
 
-      // ── 0) ELIMINA TODO lo que no sea la pared (evita duplicados al regenerar)
+      // ── 0) ELIMINA TODO (evita duplicados al regenerar)
       for (let i = tmslGroup.children.length - 1; i >= 0; i--){
         const ch = tmslGroup.children[i];
-        if (ch.userData?.tmslKind === 'wall') continue; // conserva la pared
         // libera y quita
         ch.traverse?.(o=>{ if (o.isMesh){ o.geometry?.dispose?.(); o.material?.dispose?.(); }});
         tmslGroup.remove(ch);
@@ -4080,10 +4169,8 @@ void main(){
       tmslHaloGroup = new THREE.Group();
       tmslGroup.add(tmslHaloGroup);
 
-      // ── 2) localiza la pared para posicionar frente
-      const wall = tmslGroup.children.find(o => o.userData?.tmslKind === 'wall');
-      if (!wall || !wall.geometry?.parameters) return;
-      const wallFrontZ = wall.position.z + (wall.geometry.parameters.depth/2);
+      // ── 2) posición frontal base
+      const wallFrontZ = halfCube + 2;
 
       // ── 3) parámetros de grilla
       const GRID = 9;
@@ -4250,9 +4337,12 @@ void main(){
         if (isLCHT)   toggleLCHT();
         if (isOFFNNG) toggleOFFNNG();
 
-        // Construye pared + halo
+        // Construye escena TMSL
         buildTMSL();
         buildTMSL_TomaselloStaudt();
+        tmslSetBackgroundBlack();
+        tmslEnsureBlackBackdrop();
+        tmslHalveVolumeThickness();
 
         // Exclusividad visual
         cubeUniverse.visible     = false;
@@ -4277,6 +4367,14 @@ void main(){
           tmslCellsGroup = null;
         }
         disposeAndRemove(tmslGroup);      tmslGroup      = null;
+        window.tmslGroup = null;
+
+        const bd = scene.getObjectByName('TMSL_BACKDROP');
+        if (bd){
+          bd.geometry.dispose?.();
+          bd.material.dispose?.();
+          scene.remove(bd);
+        }
 
         if (tmslPrevBg) scene.background = tmslPrevBg;
 


### PR DESCRIPTION
## Summary
- add utilities to set matte black background and backdrop for TMSL
- automatically halve the thinnest axis of TMSL volumes
- invoke new helpers after building and rebuilding the TMSL scene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a790aefa90832c833ef6fbc1c10f9a