### PR TITLE
feat: dark wall and shallower volumes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4047,14 +4047,16 @@ void main(){
       }
       tmslGroup = new THREE.Group();
 
-      /* pared blanca con 2 u de “tiefe” */
+      /* pared NEGRA con 2 u de “tiefe” (fondo real del modo) */
       const DEPTH = 2;
       const wallGeo = new THREE.BoxGeometry(cubeSize*3, cubeSize*3, DEPTH);
-      const wallMat = new THREE.MeshLambertMaterial({color:0xffffff});
+      // ← negro mate; MeshBasicMaterial para que la luz no la vuelva gris
+      const wallMat = new THREE.MeshBasicMaterial({ color: 0x000000 });
       const wall = new THREE.Mesh(wallGeo, wallMat);
       wall.position.set(0, 0, halfCube + DEPTH/2);   // pegada al frontal
-      wall.userData.tmslKind = 'wall';               // ← etiqueta para no eliminarla en rebuild
+      wall.userData.tmslKind = 'wall';
       tmslGroup.add(wall);
+
       scene.add(tmslGroup);
     }
 
@@ -4091,11 +4093,12 @@ void main(){
       const span = cubeSize - PAD*2;
       const step = span / (GRID-1);
 
-      // medidas base (igual que venías usando)
-      const MOD_W = 1.60;     // ancho
-      const DEP   = 0.80;     // profundidad (salida)
-      const HALO_SCALE_X = 4.0;
-      const HALO_SCALE_Y = 4.0;
+      // medidas base (mantenemos ancho; profundidad a la MITAD)
+      // halo más corto: radio reducido en 1/3 (→ 2/3 del anterior)
+      const MOD_W = 1.60;          // ancho
+      const DEP   = 0.40;          // PROFUNDIDAD MITAD (antes 0.80)
+      const HALO_SCALE_X = 2.6666666667;  // 4.0 * (2/3)
+      const HALO_SCALE_Y = 2.6666666667;  // 4.0 * (2/3)
 
       // —— único índice √3 determinista (nunca en la fila inferior)
       const TOTAL = GRID * GRID;


### PR DESCRIPTION
## Summary
- render wall with black `MeshBasicMaterial` so lighting doesn't lighten it
- reduce depth of modules and halo radius for Tomasello–Staudt mode

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/PRMTTN/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a79a81b020832c9477ed238e1e5b4a