### PR TITLE
feat: add directional soft shadow shader

### DIFF
--- a/index.html
+++ b/index.html
@@ -3936,7 +3936,6 @@ void main(){
     }
     // ── TMSL · Tomasello/Staudt — estado + textura halo ────────────────
     let tmslHaloTex   = null;      // (se mantiene por compatibilidad)
-    let tmslShadowTex = null;      // ← NUEVO: textura direccional
     let tmslHaloGroup = null;
     let tmslCellsGroup = null;   // ← NUEVO: contenedor único de volúmenes+marcos
 
@@ -3974,61 +3973,106 @@ void main(){
       return tex;
     }
 
-    /* === TMSL · sombra direccional tipo “sol” ===================== */
-
-    /* Cono direccional: u=0 en el origen (pegado al volumen) → cola
-       que se abre y se desvanece de forma suave */
-    function makeDirectionalShadowTexture(size = 1024){
-      const c = document.createElement('canvas');
-      c.width = size; c.height = size;
-      const ctx = c.getContext('2d');
-      const img = ctx.createImageData(size, size);
-
-      const powU = 2.2;        // caída a lo largo
-      const powV = 2.0;        // suavidad transversal
-      for (let y=0; y<size; y++){
-        for (let x=0; x<size; x++){
-          // u: 0..1 a lo largo (izq→der), v: -1..1 transversal (centro=0)
-          const u = x / (size-1);
-          const v = ((y + 0.5) - size/2) / (size/2);
-
-          // ancho que crece con la distancia (cono/trapecio suave)
-          const widthGrow = 0.28 + 0.72 * u; // 28% en origen → 100% en la cola
-          const vNorm = Math.abs(v) / widthGrow;
-
-          let along = Math.max(0, 1 - u);            // 1 en origen → 0 en cola
-          along = Math.pow(along, powU);
-
-          let across = Math.max(0, 1 - Math.min(1, vNorm));
-          across = Math.pow(across, powV);
-
-          const a = Math.max(0, Math.min(1, along * across));
-
-          const off = (y*size + x)*4;
-          img.data[off    ] = 255;
-          img.data[off + 1] = 255;
-          img.data[off + 2] = 255;
-          img.data[off + 3] = Math.round(a * 255);
-        }
-      }
-      ctx.putImageData(img, 0, 0);
-      const tex = new THREE.CanvasTexture(c);
-      tex.minFilter = THREE.LinearFilter;
-      tex.magFilter = THREE.LinearFilter;
-      tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
-      return tex;
-    }
-
-    /* Parámetros globales del “sol” */
-    const TMSL_LIGHT = {
-      angle0 : Math.PI * 38/180,   // ángulo inicial ≈ 38°
-      speed  : 0.06                // rad/s (giro lento, contemplativo)
+    // ──────────────────────────────────────────────────────────────
+    // TMSL · Soft directional shadow (single global light)
+    // ──────────────────────────────────────────────────────────────
+    const TMSL_SHADOW_CONF = {
+      BASE_ANGLE   : Math.PI * 0.33,   // ángulo inicial (≈ 60°)
+      ANG_SPEED    : 0.035,            // velocidad angular (lenta, contemplativa)
+      STRENGTH     : 1.45,             // intensidad del degradado (sube sombra)
+      LENGTH_K     : 3.0,              // largo de sombra relativo a la altura H
+      SOFT_PERP    : 0.22,             // suavidad transversal (penumbra lateral)
+      SOFT_ALONG   : 0.70,             // suavidad que aumenta hacia la punta
+      HARDNESS     : 0.85              // 0..1 (0 muy blando, 1 más contrastado)
     };
+    // colección de materiales para actualizar la dirección de luz
+    let __tmslShadowMaterials = [];
 
-    // Factores geométricos de la sombra (longitud/anchura/contacto)
-    const TMSL_SHADOW_LEN_FACTOR   = 6.0;  // L ≈ 6× max(W,H)
-    const TMSL_SHADOW_WIDTH_BOOST  = 1.05; // +5% para evitar recortes
-    const TMSL_SHADOW_CONTACT_K    = 0.32; // arranque pegado al volumen
+    function makeDirectionalShadowMaterial(colorTHREE, rectHalfX_N, rectHalfY_N, length_N){
+      const vsh = `
+        varying vec2 vUv;
+        void main(){
+          vUv = uv;
+          gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+        }
+      `;
+      const fsh = `
+        precision mediump float;
+
+        uniform vec3  uColor;
+        uniform vec2  uRect;      // (halfW, halfH) normalizados al semitamaño del plano
+        uniform float uLength;    // largo de sombra (normalizado al semiancho del plano)
+        uniform vec2  uLightDir;  // dirección 2D normalizada (común para todas)
+        uniform float uSoftPerp;  // suavidad transversal base
+        uniform float uSoftAlong; // cuánto crece suavidad hacia la punta
+        uniform float uHard;      // mezcla gauss / núcleo duro
+        uniform float uStrength;  // multiplicador de alpha
+
+        varying vec2 vUv;
+
+        void main(){
+          // uv en [-1,1]
+          vec2 uv = vUv * 2.0 - 1.0;
+
+          // ejes: d = dirección de luz; p = perpendicular
+          vec2 d = normalize(uLightDir);
+          vec2 p = vec2(-d.y, d.x);
+
+          // coords en el sistema (s,t)
+          float s = dot(uv, d); // a lo largo de la luz
+          float t = dot(uv, p); // perpendicular
+
+          // dominio longitudinal de la sombra:
+          // arranca cerca del cuerpo y llega hasta uLength + ancho proyectado
+          float s0 = 0.0;
+          float s1 = uLength + uRect.x * 2.0;
+
+          // “puerta” en s con bordes suaves (evita cortes duros fuera del plano)
+          float gateS = smoothstep(s0 - 0.02, s0 + 0.02, s)
+                      * (1.0 - smoothstep(s1 - 0.04, s1 + 0.04, s));
+
+          // penumbra: el medio ancho crece ligeramente hacia la punta
+          float k   = clamp(s / max(0.0001, uLength), 0.0, 1.0);
+          float w   = uRect.y + (uSoftAlong * k) * (uRect.y * 0.7);
+
+          // gauss transversal cuyo sigma también crece hacia la punta
+          float sigma = max(0.001, uSoftPerp * (0.75 + 0.75 * k));
+          float gauss = exp(-(t*t) / (2.0 * sigma * sigma));
+
+          // núcleo tipo “umbra” (más duro cerca del centro)
+          float umbra = smoothstep(w, w * 0.20, abs(t));
+
+          // combinación: mezcla controlada por uHard
+          float alpha = gateS * mix(gauss, umbra, uHard);
+
+          // caída extra hacia la punta (se disuelve)
+          alpha *= (1.0 - smoothstep(uLength * 0.70, uLength * 1.10, s));
+
+          alpha = clamp(alpha * uStrength, 0.0, 0.98);
+          if (alpha < 0.002) discard;
+
+          gl_FragColor = vec4(uColor, alpha);
+        }
+      `;
+
+      return new THREE.ShaderMaterial({
+        transparent: true,
+        depthWrite : false,
+        blending   : THREE.NormalBlending,  // nada de Multiply que ennegrece
+        uniforms   : {
+          uColor    : { value: colorTHREE.clone() },
+          uRect     : { value: new THREE.Vector2(rectHalfX_N, rectHalfY_N) },
+          uLength   : { value: length_N },
+          uLightDir : { value: new THREE.Vector2(Math.cos(TMSL_SHADOW_CONF.BASE_ANGLE), Math.sin(TMSL_SHADOW_CONF.BASE_ANGLE)) },
+          uSoftPerp : { value: TMSL_SHADOW_CONF.SOFT_PERP },
+          uSoftAlong: { value: TMSL_SHADOW_CONF.SOFT_ALONG },
+          uHard     : { value: TMSL_SHADOW_CONF.HARDNESS },
+          uStrength : { value: TMSL_SHADOW_CONF.STRENGTH }
+        },
+        vertexShader  : vsh,
+        fragmentShader: fsh
+      });
+    }
 
     // ★ Mantén el flag global sincronizado (necesario para hooks/watchdogs)
     window.isTMSL = false;
@@ -4113,6 +4157,7 @@ void main(){
       wall.position.set(0, 0, halfCube + DEPTH/2);   // pegada al frontal
       wall.userData.tmslKind = 'wall';
       tmslGroup.add(wall);
+      wall.renderOrder = -50; // muy detrás
 
       scene.add(tmslGroup);
     }
@@ -4138,6 +4183,8 @@ void main(){
 
       tmslHaloGroup = new THREE.Group();
       tmslGroup.add(tmslHaloGroup);
+      tmslHaloGroup.renderOrder = -30; // sombras por delante de la pared pero detrás de los volúmenes
+      __tmslShadowMaterials.length = 0;
 
       // ── 2) localiza la pared para posicionar frente
       const wall = tmslGroup.children.find(o => o.userData?.tmslKind === 'wall');
@@ -4237,84 +4284,52 @@ void main(){
           // Rahmen frontal del mismo color que los laterales
           addFrameFor(cube, W, H, color);
 
-          // === SOMBRA direccional con proyección “tipo sol” ==============
-          if (!tmslShadowTex) tmslShadowTex = makeDirectionalShadowTexture(1024);
+          // —— Sombra direccional “tipo luz” (paralelogramo + penumbra) ——
+          // largo de sombra relativo a la altura (más altura → sombra más larga)
+          const SH_LEN = Math.max(0.10, H * TMSL_SHADOW_CONF.LENGTH_K);
 
-          // Longitud base y dimensiones del volumen
-          const L  = Math.max(W, H) * TMSL_SHADOW_LEN_FACTOR;
+          // plano lo bastante grande para cubrir largo+desenfoque
+          const PLx = W + SH_LEN + W * 0.5;   // margen frontal
+          const PLy = H * 3.0;                // penumbra generosa vertical
 
-          // Usamos PlaneGeometry(1,1) y escalamos en update() para ajustar ancho según ángulo
-          const pgeo = new THREE.PlaneGeometry(1, 1);
-          const pmat = new THREE.MeshBasicMaterial({
-            color: color,
-            map: tmslShadowTex,
-            transparent: true,
-            depthWrite: false,
-            blending: THREE.MultiplyBlending,   // ← se lee como sombra real
-            premultipliedAlpha: false,
-            opacity: 0.90                        // intensidad alta (puedes subir a 0.95)
-          });
+          const pgeo = new THREE.PlaneGeometry(PLx, PLy);
 
-          const halo = new THREE.Mesh(pgeo, pmat);
-          halo.position.set(x, y, wallFrontZ + 0.005);
+          // normalización de parámetros al semitamaño del plano
+          const halfX = PLx * 0.5;
+          const halfY = PLy * 0.5;
 
-          // guardamos parámetros para el update direccional
-          halo.userData.anchorX = x;                // centro del volumen
-          halo.userData.anchorY = y;
-          halo.userData.len     = L;                // longitud (escala X)
-          halo.userData.W       = W;                // tamaño real del volumen
-          halo.userData.H       = H;
-          halo.userData.contact = Math.max(0.05, Math.min(W,H) * TMSL_SHADOW_CONTACT_K);
+          // el “rectángulo” que proyecta sombra: mitad de ancho/alto en coords normalizados
+          const rectHalfX_N = (W * 0.5) / halfX;
+          const rectHalfY_N = (H * 0.5) / halfY;
 
-          // iniciamos con la escala correcta en X; Y se ajusta cada frame según ángulo
-          halo.scale.set(L, Math.max(W,H), 1);
+          // largo de sombra normalizado
+          const length_N = SH_LEN / halfX;
 
-          // esta textura está pensada con “u→derecha” = dirección de la luz
-          // la rotación real se pone en updateTMSLHalos(t)
+          // material shader (mismo color que los laterales; más visible)
+          const smat = makeDirectionalShadowMaterial(color, rectHalfX_N, rectHalfY_N, length_N);
+
+          const halo = new THREE.Mesh(pgeo, smat);
+          halo.position.set(x, y, wallFrontZ + 0.001); // bien pegado al fondo
+          halo.renderOrder = -20;                       // se dibuja antes que los volúmenes
+
           tmslHaloGroup.add(halo);
+          __tmslShadowMaterials.push(smat);
         }
       }
     }
 
     function updateTMSLHalos(t){
-      if (!tmslHaloGroup) return;
+      if (!tmslHaloGroup || __tmslShadowMaterials.length === 0) return;
 
-      // ángulo global del “sol” (todas las sombras igual)
-      const theta = TMSL_LIGHT.angle0 + TMSL_LIGHT.speed * t;
+      // Luz global: ángulo base + giro MUY lento (contemplativo)
+      const a = TMSL_SHADOW_CONF.BASE_ANGLE + TMSL_SHADOW_CONF.ANG_SPEED * t;
+      const dir = new THREE.Vector2(Math.cos(a), Math.sin(a));
 
-      tmslHaloGroup.children.forEach(h=>{
-        if (!h.isMesh) return;
-
-        // datos guardados al construir
-        const L   = h.userData.len     || 6.0;
-        const W   = h.userData.W       || 1.6;
-        const H   = h.userData.H       || 1.6;
-        const cx  = h.userData.anchorX || h.position.x;
-        const cy  = h.userData.anchorY || h.position.y;
-        const c   = h.userData.contact || 0.2;
-
-        // ancho “proyectado” del volumen en el eje perpendicular a la luz:
-        // |W·sinθ| + |H·cosθ|   (muy parecido a una sombra real)
-        const width = (Math.abs(W * Math.sin(theta)) + Math.abs(H * Math.cos(theta)))
-                      * TMSL_SHADOW_WIDTH_BOOST;
-
-        // escala del plano: X=longitud (constante), Y=ancho proyectado (dinámico)
-        h.scale.x = L;
-        h.scale.y = Math.max(Math.max(W,H)*0.8, width);
-
-        // rotación del plano para alinear la dirección de la textura
-        h.rotation.z = theta;
-
-        // colocamos el CENTRO del plano de forma que su borde de arranque
-        // quede pegado al volumen (compensando que PlaneGeometry está centrado)
-        const dx = Math.cos(theta) * (L/2 - c);
-        const dy = Math.sin(theta) * (L/2 - c);
-        h.position.x = cx + dx;
-        h.position.y = cy + dy;
-
-        // opacidad fija alta (sombras marcadas); si quieres interacción, modificala aquí
-        h.material.opacity = 0.90;
-      });
+      // Aplica la misma dirección a TODAS las sombras
+      for (let i = 0; i < __tmslShadowMaterials.length; i++){
+        const m = __tmslShadowMaterials[i];
+        if (m && m.uniforms && m.uniforms.uLightDir) m.uniforms.uLightDir.value.copy(dir);
+      }
     }
 
     function enterTMSLView(){


### PR DESCRIPTION
## Summary
- add configurable shader for soft directional shadows with single global light
- render halos using shader-based materials and unify light direction updates
- adjust render order of wall and halos to avoid z-fighting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8821791c0832c8a9746fa3481b83a