### PR TITLE
Add Rahmen frame helpers and integrate with RAPHI builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -5466,6 +5466,98 @@ const RAPHI_EDGES_ON      = false; // ← aristas apagadas por defecto
 const RAPHI_DIAGONALS_ON  = false; // ← “cruces”/diagonales apagadas por defecto
 const RAPHI_KINGS_OVERLAY = true;  // Cámara del Rey solo cuando n===2
 
+// ──────────────────────────────
+// RAPHI · RAHMEN (marcos por cara)
+// ──────────────────────────────
+const RAPHI_RAHMEN_ON   = true;   // ← desactiva si no quieres marcos
+const RAPHI_FRAME_THICK = 0.10;   // grueso del marco como fracción de min(lados de la cara)
+const RAPHI_FRAME_D     = 0.50;   // profundidad física del marco (extrusión normal a la cara)
+const RAPHI_FRAME_PULL  = 0.06;   // leve separación respecto al plano de la cara
+
+function raphiFrameMaterial(colorTHREE){
+  const c = applyBuildVibranceToColor(colorTHREE);
+  const m = new THREE.MeshLambertMaterial({
+    color: c,
+    dithering: true,
+    side: THREE.DoubleSide,
+    transparent: false,
+    depthTest: true,
+    depthWrite: true,
+    polygonOffset: true,           // tira hacia delante (complementa el pull)
+    polygonOffsetFactor: -1,
+    polygonOffsetUnits:  -1
+  });
+  m.emissive = c.clone();
+  m.emissiveIntensity = 0.12;
+  return m;
+}
+
+/* Construye un marco para UNA cara (4 barras), orientado y posicionado */
+function buildRahmenFace(sizeU, sizeV, sizeN, axis, sign, mat){
+  // Marco en coordenadas locales (normal +Z); luego se rota/traslada
+  const tBase = Math.min(sizeU, sizeV) * RAPHI_FRAME_THICK;
+  const t = Math.max(0.12, Math.min(tBase, Math.min(sizeU,sizeV) * 0.33));  // límites de seguridad
+  const d = RAPHI_FRAME_D;
+
+  const face = new THREE.Group();
+
+  const wU = Math.max(0.001, sizeU - 2*t);
+  const hV = Math.max(0.001, sizeV - 2*t);
+
+  const top = new THREE.Mesh(new THREE.BoxGeometry(wU, t, d), mat);
+  top.position.set(0, +sizeV/2 - t/2, 0);
+
+  const bot = new THREE.Mesh(new THREE.BoxGeometry(wU, t, d), mat);
+  bot.position.set(0, -sizeV/2 + t/2, 0);
+
+  const lef = new THREE.Mesh(new THREE.BoxGeometry(t, hV, d), mat);
+  lef.position.set(-sizeU/2 + t/2, 0, 0);
+
+  const rig = new THREE.Mesh(new THREE.BoxGeometry(t, hV, d), mat);
+  rig.position.set(+sizeU/2 - t/2, 0, 0);
+
+  face.add(top, bot, lef, rig);
+
+  // Orientación para que la normal del grupo sea el eje pedido
+  if (axis === 'z' && sign === +1) { /* 0,0,0 */ }
+  else if (axis === 'z' && sign === -1) { face.rotation.y = Math.PI; }
+  else if (axis === 'x' && sign === +1) { face.rotation.y = -Math.PI/2; }
+  else if (axis === 'x' && sign === -1) { face.rotation.y = +Math.PI/2; }
+  else if (axis === 'y' && sign === +1) { face.rotation.x = +Math.PI/2; }
+  else if (axis === 'y' && sign === -1) { face.rotation.x = -Math.PI/2; }
+
+  // Traslada a lo largo de su normal (local +Z) hasta “delante” de la cara
+  const pull = (sizeN/2) + RAPHI_FRAME_PULL + d/2;
+  const n = (axis === 'x') ? new THREE.Vector3(sign,0,0)
+          : (axis === 'y') ? new THREE.Vector3(0,sign,0)
+                           : new THREE.Vector3(0,0,sign);
+  face.position.copy(n.multiplyScalar(pull));
+
+  face.renderOrder = 4;         // por delante de las caras del cuerpo
+  face.frustumCulled = false;
+  return face;
+}
+
+/* Marco completo (6 caras) para un paralelepípedo sx×sy×sz */
+function raphiBuildRahmenGroup(sx, sy, sz, colorTHREE){
+  const mat = raphiFrameMaterial(colorTHREE);
+  const g = new THREE.Group();
+  g.add(
+    // Z ±
+    buildRahmenFace(sx, sy, sz, 'z', +1, mat),
+    buildRahmenFace(sx, sy, sz, 'z', -1, mat),
+    // X ±  (cara está en plano YZ → ejes tangentes: Z,U y Y,V)
+    buildRahmenFace(sz, sy, sx, 'x', +1, mat),
+    buildRahmenFace(sz, sy, sx, 'x', -1, mat),
+    // Y ±  (cara está en plano XZ → ejes tangentes: X,U y Z,V)
+    buildRahmenFace(sx, sz, sy, 'y', +1, mat),
+    buildRahmenFace(sx, sz, sy, 'y', -1, mat)
+  );
+  g.renderOrder = 4;
+  g.frustumCulled = false;
+  return g;
+}
+
 // Builder principal
 function buildRAPHI(){
   disposeGroupRAPHI();
@@ -5491,50 +5583,43 @@ function buildRAPHI(){
     const s   = MAX / Math.max(dims[0], dims[1], dims[2]);
     const sx = dims[0]*s, sy = dims[1]*s, sz = dims[2]*s;
 
-    // Geometría del paralelepípedo
+    // Geometría del cuerpo
     const geo = new THREE.BoxGeometry(sx, sy, sz);
 
     // Colores (mismo mapeo que BUILD/KEPLR)
     const cFace = raphiFaceColor(pa, uniq);
     const cEdge = raphiEdgeFromFaceColor(cFace);
 
-    // —— CARAS: dos pasadas (igual que KEPLR) → transparencia correcta ——
-    const faceGroup = keplrBuildFaceGroup(geo, cFace); // usa MeshStandardMaterial back+front, depthWrite:false
+    // Caras en dos pasadas (como KEPLR) → transparencia limpia
+    const faceGroup = keplrBuildFaceGroup(geo, cFace);
     faceGroup.renderOrder = 0;
 
-    // —— OPCIONAL: aristas (normalmente OFF) ——
-    let edges = null;
-    if (RAPHI_EDGES_ON){
-      const eGeo = new THREE.EdgesGeometry(geo);
-      const eMat = new THREE.LineBasicMaterial({
-        color: cEdge, transparent:true, opacity:0.65, depthTest:true, depthWrite:false
-      });
-      edges = new THREE.LineSegments(eGeo, eMat);
-      edges.renderOrder = 2;
-    }
-
-    // —— OPCIONAL: “cruces” (diagonales de cara) – APAGADAS por defecto ——
-    let faceDiags = null;
-    if (RAPHI_DIAGONALS_ON){
-      faceDiags = raphiFaceDiagonals(sx, sy, sz, cEdge);
-      faceDiags.renderOrder = 1;
-    }
-
-    // —— Overlays especiales ——
+    // Overlays (líneas) — finos y por detrás del Rahmen
     const overlays = new THREE.Group();
-    if (RAPHI_KINGS_OVERLAY && preset.kings === true){
+    if (preset.kings === true){
       overlays.add(raphiKingsChamberOverlay(sx,sy,sz,cEdge));
     }
-    if (preset.name === 'DS'){ // 1:1:2 → diagonal espacial (fina)
+    if (preset.name === 'DS'){
       overlays.add(raphiSpaceDiagonal(sx,sy,sz,cEdge));
     }
+    overlays.renderOrder = 1;
 
-    // Agrupa todo (solo lo que esté ON)
+    // Marco (RAHMEN) en TODAS las caras — color distinto
+    let frameColor;
+    if (perms.length > 1){
+      // usa el color del siguiente volumen de la escena
+      const paNext = perms[(i+1) % perms.length];
+      frameColor = raphiFaceColor(paNext, 0);
+    } else {
+      // escena de 1 solo volumen → color desplazado
+      frameColor = raphiFaceColor(pa, uniq + 1);
+    }
+    const rahmen = RAPHI_RAHMEN_ON ? raphiBuildRahmenGroup(sx, sy, sz, frameColor) : null;
+
+    // Agrupar
     const g = new THREE.Group();
-    g.add(faceGroup);
-    if (edges)     g.add(edges);
-    if (faceDiags) g.add(faceDiags);
-    if (overlays.children.length) g.add(overlays);
+    g.add(faceGroup, overlays);
+    if (rahmen) g.add(rahmen);
 
     // Giro determinista (idéntico a KEPLR)
     const spin = raphiSpinParamsFor(pa, i);
@@ -5549,12 +5634,12 @@ function buildRAPHI(){
 
   groupRAPHI.add(container);
   scene.add(groupRAPHI);
-  groupRAPHI.traverse(o => { o.frustumCulled = false; });
 
-  // Marca temporal para RAF
+  // Evita culling con transparencias
+  groupRAPHI.traverse(o=>{ o.frustumCulled = false; });
+
+  // Marca temporal y ordenado por objeto para transparencias
   groupRAPHI.userData._lastT = performance.now();
-
-  // Asegura ordenado por objeto para transparencias
   try { renderer.sortObjects = true; } catch(_){ }
 }
 


### PR DESCRIPTION
## Summary
- add RAPHI Rahmen constants and helper functions to generate per-face frames
- replace buildRAPHI to use Rahmen frames and streamlined overlay handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6e0808c8832c9637c41bb81ffe98