### PR TITLE
Decouple movement time in gravity shader and boost velocity

### DIFF
--- a/index.html
+++ b/index.html
@@ -7007,8 +7007,8 @@ function grvtyVelocityFor(pa, H){
   const seed = (Math.imul((r ^ (H>>>0)) >>> 0, 1664525) + 1013904223) >>> 0;
   // ángulo en [0, 2π)
   const ang = ((seed & 0xFFFF) / 65535) * 6.283185307179586;
-  // velocidad en unidades/seg (rango 6..18)
-  const spd = 6.0 + (((seed >>> 16) & 0xFFFF) / 65535) * (18.0 - 6.0);
+  // velocidad en unidades/seg (rango 12..36)
+  const spd = 12.0 + (((seed >>> 16) & 0xFFFF) / 65535) * (36.0 - 12.0);
   return [ Math.cos(ang) * spd, Math.sin(ang) * spd ]; // [vx, vz]
 }
 
@@ -7042,13 +7042,14 @@ void main(){
   vec3 p = position;           // geometría ya está en plano XZ (rotateX aplicado)
   float y = 0.0;
   float gx = 0.0, gz = 0.0;    // gradiente para slope
-  float t = uTime * uStep;
+  // Tiempo de MOVIMIENTO independiente del "step" de BUILD
+  float tMove = uTime;
 
   for (int i=0;i<${GRVTY_MAX_WELLS};i++){
     if (i >= uN) break;
 
     // Centro animado con rebote en rectángulo [-uHalf.x,+uHalf.x]×[-uHalf.y,+uHalf.y]
-    vec2 c0 = uC[i] + uV[i] * t;
+    vec2 c0 = uC[i] + uV[i] * tMove;
     float cx = reflect1D(c0.x, -uHalf.x, uHalf.x);
     float cz = reflect1D(c0.y, -uHalf.y, uHalf.y);
 


### PR DESCRIPTION
### **User description**
## Summary
- Separate movement time from breathing step in gravity vertex shader
- Increase deterministic well velocity range for more apparent motion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c2d31234832cadab71200b761563


___

### **PR Type**
Enhancement


___

### **Description**
- Decouple movement time from breathing step in gravity shader

- Increase well velocity range from 6-18 to 12-36 units/sec

- Improve visual motion effects for gravity wells


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Gravity Shader"] --> B["Movement Time"]
  A --> C["Velocity Range"]
  B --> D["Independent from Build Step"]
  C --> E["12-36 units/sec"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Enhanced gravity shader movement and velocity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Separate movement time (<code>tMove</code>) from breathing step (<code>uStep</code>) in vertex <br>shader<br> <li> Increase deterministic well velocity range from 6-18 to 12-36 <br>units/second<br> <li> Use independent time variable for gravity well animation</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/435/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

