### PR TITLE
Adjust horizon camera for more sky

### DIFF
--- a/index.html
+++ b/index.html
@@ -7276,29 +7276,30 @@ function toggleGRVTY(){
 
     buildGRVTY();
 
-    // Cámara “horizonte” — más cielo
+    // Cámara “horizonte” — corregida para ver MÁS cielo
     camera.up.set(0,1,0);
-    camera.fov  = 16;         // un toque menos de perspectiva para enfatizar cielo
+    camera.fov  = 15;        // un poco más “tele” → el cielo ocupa más altura
     camera.near = 0.1;
     camera.far  = 3200;
     camera.updateProjectionMatrix();
 
-    if (controls && controls.target) controls.target.set(0, 0, 0);
+    // Apunta ligeramente POR ENCIMA del horizonte (sube el target)
+    if (controls && controls.target) controls.target.set(0, 3.0, 0);
 
-    // Más lejos y muy baja ⇒ el plano queda abajo, domina el cielo FRBN
-    camera.position.set(0, 2.6, 320);
+    // Muy baja y un pelín más lejos → el plano queda más abajo en pantalla
+    camera.position.set(0, 1.4, 340);
 
     controls.enabled            = true;
     controls.enableRotate       = true;
     controls.enablePan          = true;
     controls.enableZoom         = true;
     controls.minDistance        = 20;
-    controls.maxDistance        = 800;
+    controls.maxDistance        = 900;
     controls.screenSpacePanning = true;
 
-    // Permite mirar un poco por ENCIMA y por DEBAJO del horizonte (más cielo)
-    controls.minPolarAngle      = Math.PI * 0.46;  // ≈ 82.8°
-    controls.maxPolarAngle      = Math.PI * 0.52;  // ≈ 93.6°
+    // Ventana angular centrada por ENCIMA del horizonte (más cielo, menos suelo)
+    controls.minPolarAngle      = Math.PI * 0.40;  // ≈ 72°
+    controls.maxPolarAngle      = Math.PI * 0.50;  // = 90°
     controls.update();
 
     try{ if (cubeUniverse)     cubeUniverse.visible = false; }catch(_){ }


### PR DESCRIPTION
### **User description**
## Summary
- refine horizon camera configuration in `toggleGRVTY()` to see more sky and limit ground

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e22de398832c8513565820a1b92b


___

### **PR Type**
Enhancement


___

### **Description**
- Adjust horizon camera configuration for broader sky view

- Modify camera position, target, and angle constraints

- Update field of view and distance limits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Camera FOV"] -- "15° (narrower)" --> B["More Sky Coverage"]
  C["Camera Position"] -- "lower Y, farther Z" --> B
  D["Target Position"] -- "raised to Y=3.0" --> B
  E["Polar Angles"] -- "40°-50° range" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Camera configuration adjustments for sky emphasis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Reduced camera FOV from 16 to 15 degrees for telephoto effect<br> <li> Lowered camera position and moved target above horizon<br> <li> Adjusted polar angle constraints to favor sky over ground<br> <li> Increased maximum zoom distance to 900</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/437/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+10/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

