### PR TITLE
feat: add Ramses floral corridor

### DIFF
--- a/index.html
+++ b/index.html
@@ -5594,17 +5594,127 @@ function scatterFlowersInCube(H, count, half, minDist){
 }
 
 /* Velocidad determinista (magnitud desde “Signature Range”) */
-function flwrSpeedFromSignature(pa){
-  let F = computeSignature(pa); if (!Array.isArray(F)) F=[Number(F)||0];
-  let mn=Infinity,mx=-Infinity; for (let i=0;i<F.length;i++){ const v=+F[i]; if(v<mn)mn=v; if(v>mx)mx=v; }
-  const range = Math.max(0, mx-mn);
-  const vMin = 2.0, vMax = 8.0;                  // unidades/seg
-  const norm = Math.tanh(range*0.5);
-  return vMin + norm*(vMax-vMin);
-}
+  function flwrSpeedFromSignature(pa){
+    let F = computeSignature(pa); if (!Array.isArray(F)) F=[Number(F)||0];
+    let mn=Infinity,mx=-Infinity; for (let i=0;i<F.length;i++){ const v=+F[i]; if(v<mn)mn=v; if(v>mx)mx=v; }
+    const range = Math.max(0, mx-mn);
+    const vMin = 2.0, vMax = 8.0;                  // unidades/seg
+    const norm = Math.tanh(range*0.5);
+    return vMin + norm*(vMax-vMin);
+  }
 
-/* === Familias de flores =================================================== */
-/* 1) PhylloDisk (girasol/dalia) – cúpula + "flósculos" instanciados */
+  /* === Volumen “Ramsés” hecho de flores =================================== */
+  /* Floretes sobre un rectángulo (plano) → InstancedMesh con color por instancia */
+  function rectSurfaceInstanced(pa, slot, origin, uDir, vDir, uLen, vLen, stepU, stepV, jitter, scaleBase, H, seedOffset){
+    const rng = makeRng(((flwrsSeedFromPerms([pa]) ^ H ^ (seedOffset|0))>>>0));
+    const u = uDir.clone().normalize(), v = vDir.clone().normalize();
+    const uCount = Math.max(1, Math.floor(uLen/stepU)+1);
+    const vCount = Math.max(1, Math.floor(vLen/stepV)+1);
+    const N = uCount * vCount;
+
+    const geo = makeFloretGeometry(1.0);                           // tamaño lo damos por escala
+    const mat = makeFloretMaterial(colorFromPerm(pa, slot));       // base, pero teñimos por instancia
+    const inst = new THREE.InstancedMesh(geo, mat, N);
+    inst.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+
+    const m = new THREE.Matrix4();
+    const p = new THREE.Vector3();
+    const q = new THREE.Quaternion();
+    const s = new THREE.Vector3();
+
+    let idx = 0;
+    for (let i=0;i<uCount;i++){
+      const du = -uLen*0.5 + i*stepU;
+      for (let j=0;j<vCount;j++){
+        const dv = -vLen*0.5 + j*stepV;
+
+        p.copy(origin)
+         .addScaledVector(u, du + (rng()-0.5)*jitter)
+         .addScaledVector(v, dv + (rng()-0.5)*jitter);
+
+        const sca = (0.75 + 0.65*rng()) * FLWRS_GLOBAL_SCALE * scaleBase; // determinista
+        s.set(sca, sca, sca);
+        q.identity();
+        m.compose(p, q, s);
+
+        inst.setMatrixAt(idx, m);
+        inst.setColorAt(idx, instColor(pa, slot, idx, N, rng));
+        idx++;
+      }
+    }
+    inst.instanceMatrix.needsUpdate = true;
+    if (inst.instanceColor) inst.instanceColor.needsUpdate = true;
+    inst.frustumCulled = false;
+    return inst;
+  }
+
+  /* Planta/Sección determinista del “corredor con cámaras” (medidas suaves) */
+  function buildRamesesFlowers(group, perms, H){
+    const pa0 = perms[0] || [1,2,3,4,5];
+
+    // Dimensiones deterministas (aprox. tumba-corridor)
+    const W  = 26 + ((H>>>5)&15);           // ancho ~26..41
+    const HH = 18 + ((H>>>9)&15);           // alto  ~18..33
+    const L  = 340 + ((H>>>13)&63);         // largo ~340..403
+    const stepU = 2.6, stepV = 2.6, jitter = 0.9;
+
+    const z0 = -L*0.5, z1 = L*0.5;
+
+    // Paredes principales: suelo/techo, laterales y testeros
+    const surfaces = [
+      // suelo / techo (u = z, v = x)
+      { slot:0, origin:new THREE.Vector3(0, -HH*0.5, 0), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:L, vLen:W,  scale:1.0 },
+      { slot:1, origin:new THREE.Vector3(0,  HH*0.5, 0), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:L, vLen:W,  scale:1.0 },
+      // paredes laterales (u = z, v = y)
+      { slot:2, origin:new THREE.Vector3(-W*0.5, 0, 0), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(0,1,0), uLen:L, vLen:HH, scale:1.0 },
+      { slot:3, origin:new THREE.Vector3( W*0.5, 0, 0), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(0,1,0), uLen:L, vLen:HH, scale:1.0 },
+      // testeros (u = x, v = y)
+      { slot:4, origin:new THREE.Vector3(0, 0, z0),     u:new THREE.Vector3(1,0,0), v:new THREE.Vector3(0,1,0), uLen:W, vLen:HH,  scale:1.0 },
+      { slot:5, origin:new THREE.Vector3(0, 0, z1),     u:new THREE.Vector3(1,0,0), v:new THREE.Vector3(0,1,0), uLen:W, vLen:HH,  scale:1.0 }
+    ];
+
+    // Cámaras laterales simples (izq/der en dos tramos)
+    const roomDepth = 22 + ((H>>>1)&7);
+    const roomWidth = 22 + ((H>>>3)&7);
+    const roomHeight= Math.min(HH*0.9, HH-2);
+    const roomZPos  = [ z0*0.6, z1*0.6 ];   // posiciones a 60% de cada extremo
+
+    roomZPos.forEach((zc, idx)=>{
+      const xL = -(W*0.5 + roomWidth*0.5);
+      const xR =  (W*0.5 + roomWidth*0.5);
+      // pared del fondo de cada cámara (u = profundidad, v = alto)
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xL, 0, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(0,1,0), uLen:roomDepth, vLen:roomHeight, scale:1.0 });
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xR, 0, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(0,1,0), uLen:roomDepth, vLen:roomHeight, scale:1.0 });
+      // suelos/techos de cámaras (u = profundidad, v = ancho)
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xL,  roomHeight*0.5, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:roomDepth, vLen:roomWidth, scale:0.95 });
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xL, -roomHeight*0.5, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:roomDepth, vLen:roomWidth, scale:0.95 });
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xR,  roomHeight*0.5, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:roomDepth, vLen:roomWidth, scale:0.95 });
+      surfaces.push({ slot:(idx%6), origin:new THREE.Vector3(xR, -roomHeight*0.5, zc), u:new THREE.Vector3(0,0,1), v:new THREE.Vector3(1,0,0), uLen:roomDepth, vLen:roomWidth, scale:0.95 });
+    });
+
+    const seedBase = H ^ 0x7f4a1;
+    for (let si=0; si<surfaces.length; si++){
+      const s = surfaces[si];
+      const inst = rectSurfaceInstanced(
+        pa0, (s.slot%6),
+        s.origin, s.u, s.v, s.uLen, s.vLen,
+        stepU, stepV, 1.0, s.scale, H, seedBase + si*1337
+      );
+      group.add(inst);
+    }
+
+    // guía mínima para el “umbral” de entrada (solo para orientación visual)
+    try{
+      const box = new THREE.Box3(
+        new THREE.Vector3(-W*0.5, -HH*0.5, z0),
+        new THREE.Vector3( W*0.5,  HH*0.5, z1)
+      );
+      group.userData.__ramsesBox = box;
+    }catch(_){ }
+  }
+
+  /* === Familias de flores =================================================== */
+  /* 1) PhylloDisk (girasol/dalia) – cúpula + "flósculos" instanciados */
 function buildPhylloDisk(container, pa, H, rng, baseScale){
   const GOLDEN_ANGLE = 2.39996322972865332;
   let F = computeSignature(pa); if (!Array.isArray(F)) F=[+F||0];
@@ -5757,84 +5867,42 @@ function buildAster(container, pa, H, rng, baseScale){
 }
 
 /* === Builder principal ==================================================== */
-function buildFLWRS(){
-  disposeGroupFLWRS();
-  groupFLWRS = new THREE.Group();
-  groupFLWRS.userData.half = FLWRS_BOX_HALF;
+  function buildFLWRS(){
+    disposeGroupFLWRS();
+    groupFLWRS = new THREE.Group();
 
-  updateBackground(true);
+    updateBackground(true);
 
-  let perms = (typeof getSelectedPerms === 'function' ? getSelectedPerms() : []) || [];
-  if (!perms.length) perms = [[1,2,3,4,5]];
-  const H   = flwrsSeedFromPerms(perms)>>>0;
-  const rng = makeRng(H^0x51ed1);
+    let perms = (typeof getSelectedPerms === 'function' ? getSelectedPerms() : []) || [];
+    if (!perms.length) perms = [[1,2,3,4,5]];
+    const H = flwrsSeedFromPerms(perms)>>>0;
 
-  // MUCHAS flores dentro del cubo, sin “camino”
-  const N = 160 + ((H>>>7) % 120);                // 160..279 flores
-  const spots = scatterFlowersInCube(H, N, FLWRS_BOX_HALF*0.92, 4.5); // minDist 4.5
+    // Construye el volumen tipo “Tumba de Ramsés IV” con flores en las superficies
+    buildRamesesFlowers(groupFLWRS, perms, H);
 
-  const families = ['PHYLLO','RHODO','SUPERF','ASTER'];
-  groupFLWRS.userData.flowers = [];
+    scene.add(groupFLWRS);
 
-  for (let i=0;i<spots.length;i++){
-    const pos = spots[i];
-    const pa  = perms[i % perms.length];
-    const rnk = lehmerRank(pa)>>>0;
-    const fam = families[(rnk + i + (H>>>13)) % families.length];
+    // Cámara: entrada del corredor, mirando hacia dentro
+    const box = groupFLWRS.userData.__ramsesBox;
+    const z0  = (box ? box.min.z : -200);
+    camera.up.set(0,1,0);
+    camera.fov = 48;
+    camera.near = 0.1; camera.far = 5000;
+    camera.updateProjectionMatrix();
+    if (controls && controls.target) controls.target.set(0, 0, 0);
+    camera.position.set(0, 0, z0 - 40);
+    controls.enabled = true;
+    controls.enableRotate = true;
+    controls.enablePan = true;
+    controls.enableZoom = true;
+    controls.minDistance = 10;
+    controls.maxDistance = 2000;
+    controls.screenSpacePanning = true;
+    controls.update();
 
-    // RNG local + escala (1/6 global + variación por flor)
-    const seedLocal = (Math.imul((rnk ^ H ^ (i*2654435761)>>>0), 2246822519) + 1013904223)>>>0;
-    const rngLocal  = makeRng(seedLocal);
-    const baseScale = FLWRS_GLOBAL_SCALE * (0.7 + 1.6*rngLocal()); // cada flor distinta
-
-    const g = new THREE.Group();
-    g.position.set(pos.x, pos.y, pos.z);
-    g.rotation.y = ((rnk ^ (H>>>7) ^ i) % 360) * (Math.PI/180);
-
-    try{
-      if (fam === 'PHYLLO')      buildPhylloDisk(g,  pa, H, rngLocal, baseScale);
-      else if (fam === 'RHODO')  buildRhodonea(g,    pa, H, rngLocal, baseScale);
-      else if (fam === 'SUPERF') buildSuperformula(g,pa, H, rngLocal, baseScale);
-      else                       buildAster(g,       pa, H, rngLocal, baseScale);
-    }catch(_){ }
-
-    // sway leve + velocidad de traslación determinista dentro del cubo
-    const swayA = 0.05 + ((rnk>>>3)%100)/2000;   // amplitud pequeña
-    const swayW = 0.12 + ((rnk>>>11)%100)/600;   // frecuencia
-    const swayP = ((rnk>>>19)%628)/100;
-    const speed = flwrSpeedFromSignature(pa);    // 2..8 u/s
-    const dir   = new THREE.Vector3(rngLocal()*2-1, rngLocal()*2-1, rngLocal()*2-1).normalize();
-    const vel   = dir.multiplyScalar(speed);
-
-    g.userData.sway = { A: swayA, W: swayW, P: swayP };
-    g.userData.vel  = vel;
-
-    groupFLWRS.add(g);
-    groupFLWRS.userData.flowers.push(g);
+    // no animación
+    groupFLWRS.userData._lastT = performance.now();
   }
-
-  scene.add(groupFLWRS);
-
-  // Cámara centrada al cubo
-  camera.up.set(0,1,0);
-  camera.fov = 55;
-  camera.near = 0.1; camera.far = 2000;
-  camera.updateProjectionMatrix();
-  if (controls && controls.target) controls.target.set(0, 0, 0);
-  camera.position.set(0, 0, FLWRS_BOX_HALF*3.2);   // vista general del cubo
-  controls.enabled = true;
-  controls.enableRotate = true;
-  controls.enablePan = true;
-  controls.enableZoom = true;
-  controls.minDistance = 10;
-  controls.maxDistance = 800;
-  controls.screenSpacePanning = true;
-  controls.minPolarAngle = 0.0;
-  controls.maxPolarAngle = Math.PI;
-  controls.update();
-
-  groupFLWRS.userData._lastT = performance.now();
-}
 
 /* === Exclusivo + hooks ==================================================== */
 function toggleFLWRS(){
@@ -5917,54 +5985,14 @@ function ensureOnlyFLWRSFromUI(){ ensureOnlyFLWRS(); if (typeof updateEngineSele
     try{ if (groupFLWRS) groupFLWRS.userData._lastT = performance.now(); }catch(_){ }
   };
 
-  function tick(){
-    try{
-      if (!isFLWRS || !groupFLWRS){ requestAnimationFrame(tick); return; }
-
-      let paused = !!window.__flwrsPaused;
-      try{ if (!paused && typeof window.isBuildMotionPaused==='function') paused = !!window.isBuildMotionPaused(); }catch(_){ }
-
-      const now  = performance.now();
-      const last = groupFLWRS.userData._lastT || now;
-      const dt   = Math.max(0, (now - last)/1000);
-      groupFLWRS.userData._lastT = now;
-
-      if (!paused){
-        const arr = groupFLWRS.userData.flowers || [];
-        const half = groupFLWRS.userData.half || FLWRS_BOX_HALF;
-        for (let i=0;i<arr.length;i++){
-          const g = arr[i]; if (!g || !g.userData) continue;
-
-          // sway (inclinación suave)
-          if (g.userData.sway){
-            const s = g.userData.sway;
-            const tilt = s.A * Math.sin(s.W*now*0.001 + s.P);
-            g.rotation.x = tilt;
-          }
-
-          // movimiento 3D con rebote en el cubo
-          if (g.userData.vel){
-            const v = g.userData.vel;
-            g.position.x += v.x * dt;
-            g.position.y += v.y * dt;
-            g.position.z += v.z * dt;
-
-            if (g.position.x >  half){ g.position.x =  half; v.x *= -1; }
-            if (g.position.x < -half){ g.position.x = -half; v.x *= -1; }
-            if (g.position.y >  half){ g.position.y =  half; v.y *= -1; }
-            if (g.position.y < -half){ g.position.y = -half; v.y *= -1; }
-            if (g.position.z >  half){ g.position.z =  half; v.z *= -1; }
-            if (g.position.z < -half){ g.position.z = -half; v.z *= -1; }
-          }
-
-          if (!g.matrixAutoUpdate) g.updateMatrix();
-          g.updateMatrixWorld(true);
-        }
-      }
-    }catch(_){ }
+    function tick(){
+      try{
+        // Animación desactivada para el modo “Ramsés floral”
+        // Solo mantenemos el loop para que otros motores no se rompan.
+      }catch(_){ }
+      requestAnimationFrame(tick);
+    }
     requestAnimationFrame(tick);
-  }
-  requestAnimationFrame(tick);
 
   // Bridge con menú BUILD si existe
   function wrap(name, after){


### PR DESCRIPTION
## Summary
- render Ramses IV-style corridor via rectangular flower surfaces
- replace buildFLWRS to assemble Ramses volume and adjust camera
- disable flower animator loop and keep other engines hidden

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1e180840832c87c2a20565fd8571