### PR TITLE
feat: add KEPLR/RAPHI-like material for R5NOVA volumes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5845,6 +5845,35 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
     const R5N_TARGETN   = [4, 8];   // objetivo de celdas del BSP (pocas piezas)
     const R5N_MERGE     = 0.60;     // probabilidad de fusionar adyacentes
 
+    /* ——— Material tipo KEPLR/RAPHI para paneles/volúmenes ———
+       Si el proyecto expone factories propios, se usan; si no, fallback Physical equivalente. */
+    function r5nKeplrRaphiMaterial(colorTHREE){
+      try{
+        if (typeof window.keplrSurfaceMaterial === 'function')
+          return window.keplrSurfaceMaterial(colorTHREE);
+      }catch(_){ }
+
+      try{
+        if (typeof window.raphiSurfaceMaterial === 'function')
+          return window.raphiSurfaceMaterial(colorTHREE);
+      }catch(_){ }
+
+      // Fallback: aspecto físico brillante similar a KEPLR/RAPHI
+      const m = new THREE.MeshPhysicalMaterial({
+        color: colorTHREE,
+        roughness: 0.32,
+        metalness: 0.04,
+        clearcoat: 0.36,
+        clearcoatRoughness: 0.75,
+        envMapIntensity: 0.9,
+        reflectivity: 0.5,
+        dithering: true
+      });
+      m.emissive = colorTHREE.clone().multiplyScalar(0.08);
+      m.emissiveIntensity = 0.08;
+      return m;
+    }
+
     // ——— R5NOVA · ensamblado BSP con Füge perimetral correcta ———
     function r5novaAssembleRects(){
       // Interior visible: restamos el grosor de muros/piso/techo (R5_G)
@@ -5961,13 +5990,7 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
         const offs = offsetFromTag(r.tag);
         const col  = colorR5NFor(pa, offs, i);
 
-        const mat = new THREE.MeshLambertMaterial({
-          color: col,
-          dithering: true,
-          side: THREE.DoubleSide
-        });
-        mat.emissive = col.clone();
-        mat.emissiveIntensity = 0.12;
+        const mat = r5nKeplrRaphiMaterial(col);
 
         const mesh = new THREE.Mesh(geo, mat);
         mesh.position.set(cx, cy, zBackEdge + R5_DEPTH/2); // pegado al canto posterior


### PR DESCRIPTION
### **User description**
## Summary
- add helper r5nKeplrRaphiMaterial with fallback MeshPhysicalMaterial
- use the new material for R5NOVA background volumes, keeping frames lambert

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8bdf7d78832caab7c68846487678


___

### **PR Type**
Enhancement


___

### **Description**
- Add KEPLR/RAPHI-like material helper function with fallback

- Replace Lambert material with new material for R5NOVA volumes

- Maintain compatibility with external material factories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Material Factory"] --> B["r5nKeplrRaphiMaterial()"]
  B --> C["Check KEPLR factory"]
  B --> D["Check RAPHI factory"]
  B --> E["Fallback MeshPhysicalMaterial"]
  C --> F["R5NOVA Volumes"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add KEPLR/RAPHI material system for R5NOVA</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>r5nKeplrRaphiMaterial()</code> helper function with external factory <br>detection<br> <li> Replace <code>MeshLambertMaterial</code> with new material in R5NOVA volume <br>creation<br> <li> Configure fallback <code>MeshPhysicalMaterial</code> with metallic/clearcoat <br>properties</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/455/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+30/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

