### PR TITLE
Force Z-axis spin for R5NOVA panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -5910,9 +5910,9 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
       return 0.30 + (F % 7) * 0.07;
     }
 
-    /* Eje/velocidad (como RAPHI: eje Y local) */
+    /* Eje/velocidad: giro DENTRO DEL PLANO (eje Z local) para que jamás sobresalga del Rahmen */
     function r5nSpinParamsFor(pa){
-      const axis = new THREE.Vector3(0, 1, 0);
+      const axis = new THREE.Vector3(0, 0, 1);       // ← antes (0,1,0)
       const vel  = r5nOmegaFromSignature(pa);
       return { axis, vel };
     }
@@ -6083,9 +6083,9 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
         panel.position.set(cx, cy, zBackEdge + R5_DEPTH/2);
         groupR5NOVA.add(panel);
 
-        // === Movimiento tipo RAPHI/KEPLR para este panel ===
+        // === Movimiento tipo RAPHI/KEPLR para este panel (eje Z para no asomar) ===
         const spin = r5nSpinParamsFor(pa);
-        panel.userData.rotAxis  = spin.axis;
+        panel.userData.rotAxis  = new THREE.Vector3(0, 0, 1); // ← fuerza Z local
         panel.userData.rotVel   = spin.vel;
         panel.userData.permStr  = pa.join(',');     // para getBuildRotStep
         groupR5NOVA.userData.rotators.push(panel);


### PR DESCRIPTION
### **User description**
## Summary
- Spin panels around local Z-axis to keep rotations coplanar
- Hard-code Z-axis rotation per panel in `buildR5NOVA`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf740389c832c8ef413cc13d9cb5e


___

### **PR Type**
Enhancement


___

### **Description**
- Force Z-axis rotation for R5NOVA panels

- Prevent panels from protruding outside frame boundaries

- Update spin axis from Y to Z for coplanar rotations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Panel Rotation System"] --> B["Change Axis Y to Z"]
  B --> C["Coplanar Rotations"]
  C --> D["Prevent Frame Overflow"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update panel rotation axis from Y to Z</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Modified <code>r5nSpinParamsFor</code> function to use Z-axis instead of Y-axis<br> <li> Updated panel rotation axis assignment to force Z-axis rotation<br> <li> Added comments explaining the change prevents frame overflow</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/458/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

