### PR TITLE
Add wall plane utilities and unified engine view

### DIFF
--- a/index.html
+++ b/index.html
@@ -6699,221 +6699,255 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
           if (rafId){ cancelAnimationFrame(rafId); rafId = null; }
           dispose(wwRig); wwRig = null; wwFrame = null; wwJambs.length = 0; lastOuter = -1;
         };
+
+        // === utilidades/export para alinear motores al plano del hueco ===
+        // Ojo: wwRig copia la pose de cámara; dir = dirección de mirada (mundo).
+        let wwThickness = 0;   // cache del espesor real pasado a buildWall
+        let wwDistance  = 0;   // cache de la distancia pasada a buildWall
+
+        // Sobrescribe buildWall para memorizar thickness
+        const __buildWallOrig = buildWall;
+        buildWall = function(openSize, wallSize, thickness, distance){
+          wwThickness = Number(thickness)||0;
+          wwDistance  = Number(distance)||0;
+          return __buildWallOrig(openSize, wallSize, thickness, distance);
+        };
+
+        // Centro y normal del plano FRONTAL y TRASERO del hueco en coordenadas de mundo
+        window.getWhiteWallPlanes = function(){
+          const dir = new THREE.Vector3(); // apunta hacia delante (hacia la escena)
+          camera.getWorldDirection(dir);
+          // centro del plano exterior (frontal)
+          const front = camera.position.clone().add(dir.clone().multiplyScalar(wwDistance));
+          // centro del plano interior (trasero) = front + dir * wwThickness
+          const back  = front.clone().add(dir.clone().multiplyScalar(wwThickness));
+          return {
+            dir,                    // normal (unitaria) del plano, hacia la escena
+            frontCenter: front,     // centro plano frontal
+            backCenter:  back,      // centro plano interior (el que queremos “tocar” por detrás)
+            distance: wwDistance,
+            thickness: wwThickness
+          };
+        };
       })();
 
       init();
-      installWhiteWall3D();
 
+      // Pared más lejos de cámara y un poco más gruesa: apertura 70, pared 120, espesor 12, a 85 cm
+      if (typeof updateWhiteWall3D === 'function') updateWhiteWall3D(70, 120, 12, 85);
+      else if (typeof installWhiteWall3D === 'function') { removeWhiteWall3D?.(); installWhiteWall3D(); updateWhiteWall3D(70, 120, 12, 85); }
 
-      // aleja el muro a 60 cm (antes 50 cm)
-      updateWhiteWall3D(50, 100, 15, 60);
+/* ──────────────────────────────────────────────────────────────
+ * Default unified view + per-engine nudges to fit the wall hole
+ * ───────────────────────────────────────────────────────────── */
+(function(){
+  // 0) Pequeña ayuda: z de un objeto en espacio de cámara (frente más cercano)
+  function frontZInCameraSpace(obj){
+    const box = new THREE.Box3().setFromObject(obj);
+    const m = new THREE.Matrix4().copy(camera.matrixWorldInverse);
+    let maxZ = -Infinity;
+    const v = new THREE.Vector3();
+    const xs = [box.min.x, box.max.x], ys = [box.min.y, box.max.y], zs = [box.min.z, box.max.z];
+    for (let i=0;i<2;i++) for (let j=0;j<2;j++) for (let k=0;k<2;k++){
+      v.set(xs[i], ys[j], zs[k]).applyMatrix4(m);
+      if (v.z > maxZ) maxZ = v.z; // z mayor = más cercano (porque en cámara el -Z es al fondo)
+    }
+    return maxZ;
+  }
 
+  // Empuja un grupo para que su frente quede justo DETRÁS del plano interior del hueco
+  function pushBehindWallBackPlane(group, epsilon){
+    if (!group) return;
+    const planes = window.getWhiteWallPlanes?.();
+    if (!planes) return;
+    const targetZ = -(planes.distance + planes.thickness) - Math.abs(epsilon||0.10); // en espacio de cámara
+    const zFront  = frontZInCameraSpace(group);
+    if (zFront > targetZ){
+      const dz = zFront - targetZ;              // lo que hay que “alejar”
+      const dir = planes.dir.clone();           // hacia el fondo
+      group.position.add(dir.multiplyScalar(dz));
+      group.updateMatrixWorld(true);
+    }
+  }
 
-        /* ──────────────────────────────────────────────────────────────
-     * WHITE-WALL VIEW MANAGER · v2
-     * - Vista standard unificada (clon de BUILD), independiente por motor.
-     * - Zoom-out por motor (LCHT, RAUM, GRVTY, 13245 → ×3).
-     * - Alineación precisa: TMSL/R5NOVA pegados al plano trasero del hueco.
-     * ───────────────────────────────────────────────────────────── */
-    (function WWViewManagerV2(){
-      const TMP_V = new THREE.Vector3();
-      function hasControls(){ return (typeof controls !== 'undefined' && controls && controls.target); }
-    
-      // 1) Baseline (se captura a los pocos ms para asegurar cámara/controles)
-      const _baseline = {
-        pos    : new THREE.Vector3(0,0,60),
-        quat   : new THREE.Quaternion(),
-        target : new THREE.Vector3(0,0,0),
-        fov    : 40,
-        near   : 0.1,
-        far    : 4000
-      };
-      function snapshotBUILD(){
-        try{
-          if (camera){
-            _baseline.pos.copy(camera.position);
-            _baseline.quat.copy(camera.quaternion);
-            _baseline.fov  = camera.fov;
-            _baseline.near = Math.min(camera.near||0.1, 0.1);
-            _baseline.far  = Math.max(camera.far||2000, 4000);
-          }
-          if (hasControls()) _baseline.target.copy(controls.target);
-        }catch(_){ }
-      }
-      setTimeout(snapshotBUILD, 50);
-      requestAnimationFrame(snapshotBUILD);
-    
-      // 2) Vistas por motor (independientes, inicializadas como BUILD)
-      const ENGINES = ['BUILD','FRBN','LCHT','OFFNNG','TMSL','RAUM','13245','KEPLR','RAPHI','GRVTY','R5NOVA'];
-      const VIEWS = Object.create(null);
-      function ensureViews(){
-        if (VIEWS.__ready) return;
-        ENGINES.forEach(n=>{
-          VIEWS[n] = {
-            pos: _baseline.pos.clone(),
-            quat: _baseline.quat.clone(),
-            target: _baseline.target.clone(),
-            fov: _baseline.fov, near:_baseline.near, far:_baseline.far
-          };
-        });
-        VIEWS.__ready = true;
-      }
-    
-      // 3) Motor activo
-      function engineId(){
-        if (window.isGRVTY)  return 'GRVTY';
-        if (window.isR5NOVA) return 'R5NOVA';
-        if (window.isRAPHI)  return 'RAPHI';
-        if (window.isKEPLR)  return 'KEPLR';
-        if (window.is13245)  return '13245';
-        if (window.isRAUM)   return 'RAUM';
-        if (window.isTMSL)   return 'TMSL';
-        if (window.isOFFNNG) return 'OFFNNG';
-        if (window.isLCHT)   return 'LCHT';
-        if (window.isFRBN)   return 'FRBN';
-        return 'BUILD';
-      }
-    
-      // 4) Zoom por motor
-      const ZOOM_BASE = 1.40;               // alejamiento suave general
-      const ZOOM_SCALE = {                  // multiplicadores por motor
-        LCHT: 3.0, RAUM: 3.0, GRVTY: 3.0, '13245': 3.0
-      };
-      function applyZoomFromTarget(factor){
-        if (!hasControls()) return;
-        const dir = TMP_V.copy(camera.position).sub(controls.target);
-        camera.position.copy(controls.target).add(dir.multiplyScalar(factor));
+  // 1) Base de vista “BUILD-like” para todo
+  function applyBaseView(){
+    try { applyStandardView(); } catch(_){ }
+    try{
+      camera.up.set(0,1,0);
+      // distancia base (más atrás para encajar en el hueco cómodamente)
+      if (controls && controls.target) controls.target.set(0,0,0);
+      camera.fov = 30;
+      camera.position.set(0,0,84);
+      camera.near = 0.1;
+      camera.far  = 4000;
+      camera.updateProjectionMatrix();
+      controls?.update?.();
+    }catch(_){ }
+  }
+
+  // 2) Ajustes por motor (factor de “zoom” = mover cámara en Z)
+  const ZOOM = {
+    // 1.0 = base; <1 = acercar un poco; >1 = alejar
+    FRBN   : 1.00,
+    BUILD  : 1.00,
+    OFFNNG : 0.92,   // un poco hacia delante
+    TMSL   : 1.25,   // más atrás
+    R5NOVA : 1.25,   // más atrás
+    RAUM   : 1.38,   // más atrás (más que TMSL/R5NOVA)
+    "13245": 1.38,   // más atrás
+    KEPLR  : 1.18,
+    RAPHI  : 1.22,
+    GRVTY  : 1.50    // se reajusta más abajo (cámara y escala)
+  };
+
+  function nudgeFor(engine){
+    // zoom unificado
+    camera.position.z *= (ZOOM[engine] || 1.0);
+    camera.updateProjectionMatrix();
+    controls?.update?.();
+
+    // Alineaciones especiales
+    if (engine === 'TMSL'){
+      // paredes laterales justo detrás del hueco
+      try { pushBehindWallBackPlane(window.__tmslDecorGroup, 0.10); } catch(_){ }
+    }
+    if (engine === 'R5NOVA'){
+      try { pushBehindWallBackPlane(window.groupR5NOVA, 0.10); } catch(_){ }
+    }
+    if (engine === 'GRVTY'){
+      // Encajonado tipo “horizonte” con margen
+      try{
+        camera.fov = 18;
+        camera.position.set(0, 8, 190);
+        if (controls && controls.target) controls.target.set(0, 6, 0);
+        controls.minPolarAngle = Math.PI * 0.49;
+        controls.maxPolarAngle = Math.PI * 0.525;
         camera.updateProjectionMatrix();
-        controls.update();
-      }
-    
-      // 5) Aplicar vista del motor actual
-      function applyViewFor(id){
-        ensureViews();
-        const v = VIEWS[id] || VIEWS.BUILD;
-    
-        camera.position.copy(v.pos);
-        camera.quaternion.copy(v.quat);
-        camera.fov  = v.fov;
-        camera.near = v.near;
-        camera.far  = v.far;
-        camera.updateProjectionMatrix();
-    
-        if (hasControls()){
-          controls.target.copy(v.target);
-          controls.update();
+        controls?.update?.();
+
+        if (window.groupGRVTY){
+          groupGRVTY.scale.set(0.86, 1.0, 0.86);   // reduce anchura y profundidad para no tocar el canto
+          groupGRVTY.updateMatrixWorld(true);
+          const u = groupGRVTY.userData && groupGRVTY.userData.uniforms;
+          if (u){ u.uGridScale.value = 40.0; }     // cuadrícula algo más densa encuadrada
         }
-    
-        // Alejamiento: base × escala por motor (si existe)
-        const factor = ZOOM_BASE * (ZOOM_SCALE[id] || 1.0);
-        applyZoomFromTarget(factor);
+      }catch(_){ }
+    }
+  }
+
+  // 3) Aplica al entrar en cada motor (envolturas “idempotentes”)
+  function hookToggle(name, engine, isFlagName){
+    const prev = window[name];
+    if (typeof prev !== 'function' || prev.__std_hooked) return;
+    window[name] = function(){
+      const wasOn = !!window[isFlagName];
+      const out = prev.apply(this, arguments);
+      const nowOn = !!window[isFlagName];
+      if (!wasOn && nowOn){
+        applyBaseView();
+        nudgeFor(engine);
       }
-    
-      // 6) Guardar vista por motor (para tu “catálogo”)
-      window.setEngineDefaultView = function(id){
-        ensureViews();
-        const key = (id||engineId());
-        const v = VIEWS[key];
-        v.pos.copy(camera.position);
-        v.quat.copy(camera.quaternion);
-        v.fov = camera.fov;
-        if (hasControls()) v.target.copy(controls.target);
+      return out;
+    };
+    window[name].__std_hooked = true;
+  }
+
+  hookToggle('toggleFRBN',   'FRBN',   'isFRBN');
+  hookToggle('toggleLCHT',   'BUILD',  'isLCHT');   // LCHT usa la vista base BUILD
+  hookToggle('toggleOFFNNG', 'OFFNNG', 'isOFFNNG');
+  hookToggle('toggleTMSL',   'TMSL',   'isTMSL');
+  hookToggle('toggleRAUM',   'RAUM',   'isRAUM');
+  hookToggle('toggle13245',  '13245',  'is13245');
+  hookToggle('toggleKEPLR',  'KEPLR',  'isKEPLR');
+  hookToggle('toggleRAPHI',  'RAPHI',  'isRAPHI');
+  hookToggle('toggleGRVTY',  'GRVTY',  'isGRVTY');
+  hookToggle('toggleR5NOVA', 'R5NOVA', 'isR5NOVA');
+
+  // Si ya había un motor activo al cargar, normaliza su vista ahora
+  setTimeout(()=>{
+    try{
+      if (window.isFRBN)   { applyBaseView(); nudgeFor('FRBN'); }
+      if (window.isLCHT)   { applyBaseView(); nudgeFor('BUILD'); }
+      if (window.isOFFNNG) { applyBaseView(); nudgeFor('OFFNNG'); }
+      if (window.isTMSL)   { applyBaseView(); nudgeFor('TMSL'); }
+      if (window.isRAUM)   { applyBaseView(); nudgeFor('RAUM'); }
+      if (window.is13245)  { applyBaseView(); nudgeFor('13245'); }
+      if (window.isKEPLR)  { applyBaseView(); nudgeFor('KEPLR'); }
+      if (window.isRAPHI)  { applyBaseView(); nudgeFor('RAPHI'); }
+      if (window.isGRVTY)  { applyBaseView(); nudgeFor('GRVTY'); }
+      if (window.isR5NOVA) { applyBaseView(); nudgeFor('R5NOVA'); }
+    }catch(_){ }
+  }, 0);
+})();
+
+/* ──────────────────────────────────────────────────────────────
+ * Re-align after rebuilds (TMSL / R5NOVA)
+ * ───────────────────────────────────────────────────────────── */
+(function(){
+  const run = function(){
+    try{ if (window.isTMSL   && window.__tmslDecorGroup) pushBehind(); }catch(_){ }
+    try{ if (window.isR5NOVA && window.groupR5NOVA)      pushBehind(); }catch(_){ }
+    function pushBehind(){
+      // usa la función que añadimos en el bloque 3
+      try { 
+        const gp = window.__tmslDecorGroup || window.groupR5NOVA;
+        if (gp) {
+          // re-calcula un frame después de rebuild para evitar “race”
+          requestAnimationFrame(()=>{ 
+            try { 
+              const planes = window.getWhiteWallPlanes?.(); 
+              if (planes) {
+                // copia local de la función (por si el scope cambió)
+                (function frontZ(obj){
+                  const box = new THREE.Box3().setFromObject(obj);
+                  const m = new THREE.Matrix4().copy(camera.matrixWorldInverse);
+                  let maxZ = -Infinity;
+                  const v = new THREE.Vector3();
+                  const xs = [box.min.x, box.max.x], ys = [box.min.y, box.max.y], zs = [box.min.z, box.max.z];
+                  for (let i=0;i<2;i++) for (let j=0;j<2;j++) for (let k=0;k<2;k++){
+                    v.set(xs[i], ys[j], zs[k]).applyMatrix4(m);
+                    if (v.z > maxZ) maxZ = v.z;
+                  }
+                  return maxZ;
+                });
+                const targetZ = -(planes.distance + planes.thickness) - 0.10;
+                const box = new THREE.Box3().setFromObject(gp);
+                const m = new THREE.Matrix4().copy(camera.matrixWorldInverse);
+                let maxZ = -Infinity;
+                const v = new THREE.Vector3();
+                const xs = [box.min.x, box.max.x], ys = [box.min.y, box.max.y], zs = [box.min.z, box.max.z];
+                for (let i=0;i<2;i++) for (let j=0;j<2;j++) for (let k=0;k<2;k++){
+                  v.set(xs[i], ys[j], zs[k]).applyMatrix4(m);
+                  if (v.z > maxZ) maxZ = v.z;
+                }
+                if (maxZ > targetZ){
+                  const dz = maxZ - targetZ;
+                  const dir = planes.dir.clone();
+                  gp.position.add(dir.multiplyScalar(dz));
+                  gp.updateMatrixWorld(true);
+                }
+              }
+            }catch(_){ }
+          });
+        }
+      } catch(_){ }
+    }
+  };
+
+  ['rebuildTMSLIfActive', 'rebuildR5NOVAIfActive', 'refreshAll', 'buildScene', 'buildUniverse'].forEach(name=>{
+    const orig = window[name];
+    if (typeof orig === 'function' && !orig.__wall_align_hooked){
+      window[name] = function(){
+        const out = orig.apply(this, arguments);
+        setTimeout(run, 0);
+        requestAnimationFrame(run);
+        return out;
       };
-    
-      // 7) Alineación precisa de TMSL/R5NOVA al plano trasero del hueco
-      function cameraForward(){
-        return new THREE.Vector3(0,0,-1).applyQuaternion(camera.quaternion).normalize();
-      }
-      function wwBackPlane(){
-        const d  = (window.__wwDistance||80);
-        const t  = (window.__wwThickness||15);
-        const n  = cameraForward();                    // normal (hacia delante)
-        const p0 = camera.position.clone().add(n.clone().multiplyScalar(-(d+t)));
-        return {n, p0};                                // plano: n·p = n·p0
-      }
-      function projRangeAlong(obj, n){
-        obj.updateMatrixWorld(true);
-        const box = new THREE.Box3().setFromObject(obj);
-        const pts = [
-          new THREE.Vector3(box.min.x, box.min.y, box.min.z),
-          new THREE.Vector3(box.min.x, box.min.y, box.max.z),
-          new THREE.Vector3(box.min.x, box.max.y, box.min.z),
-          new THREE.Vector3(box.min.x, box.max.y, box.max.z),
-          new THREE.Vector3(box.max.x, box.min.y, box.min.z),
-          new THREE.Vector3(box.max.x, box.min.y, box.max.z),
-          new THREE.Vector3(box.max.x, box.max.y, box.min.z),
-          new THREE.Vector3(box.max.x, box.max.y, box.max.z),
-        ];
-        let min=Infinity, max=-Infinity;
-        for (let p of pts){
-          p.applyMatrix4(obj.matrixWorld);
-          const s = n.dot(p);
-          if (s<min) min=s;
-          if (s>max) max=s;
-        }
-        return {min,max};
-      }
-      function alignToBackPlane(obj){
-        if (!obj) return;
-        const {n,p0} = wwBackPlane();
-        const s0 = n.dot(p0);
-        const {max} = projRangeAlong(obj, n); // punto “más cercano” a la cámara en dirección n
-        const EPS = 0.5;                      // 5 mm de holgura
-        const delta = (s0 - EPS) - max;       // queremos max = s0 - EPS
-        obj.position.add(n.clone().multiplyScalar(delta));
-        obj.updateMatrixWorld(true);
-      }
-      function alignShellsIfAny(){
-        try{
-          if (window.isTMSL && window.__tmslDecorGroup) alignToBackPlane(window.__tmslDecorGroup);
-        }catch(_){ }
-        try{
-          if (window.isR5NOVA && window.groupR5NOVA) alignToBackPlane(window.groupR5NOVA);
-        }catch(_){ }
-      }
-    
-      // 8) Reaplicar al cambiar de motor/rebuild
-      function reapplyAll(){
-        applyViewFor(engineId());
-        alignShellsIfAny();
-      }
-      function hook(name){
-        const orig = window[name];
-        if (typeof orig === 'function' && !orig.__wwvm2){
-          window[name] = function(){
-            const out = orig.apply(this, arguments);
-            setTimeout(reapplyAll, 0);
-            requestAnimationFrame(reapplyAll);
-            return out;
-          };
-          window[name].__wwvm2 = true;
-        }
-      }
-    
-      [
-        'toggleFRBN','toggleLCHT','toggleOFFNNG','toggleTMSL','toggleRAUM',
-        'toggle13245','toggleKEPLR','toggleRAPHI','toggleGRVTY','toggleR5NOVA',
-        'ensureOnlyFRBN','ensureOnlyLCHT','ensureOnlyOFFNNG','ensureOnlyTMSL',
-        'ensureOnlyGRVTY','ensureOnlyR5NOVA','applyEngineFromSelect','cycleEngine',
-        'rebuildTMSLIfActive','rebuildR5NOVAIfActive','rebuildGRVTYIfActive',
-        'refreshAll','buildUniverse','buildScene','rebuildUniverse'
-      ].forEach(hook);
-    
-      // También nos re-ajustamos si cambian las medidas del muro
-      const _oldUpdateWW = window.updateWhiteWall3D;
-      if (typeof _oldUpdateWW === 'function' && !_oldUpdateWW.__wwvm2){
-        window.updateWhiteWall3D = function(){
-          const out = _oldUpdateWW.apply(this, arguments);
-          setTimeout(reapplyAll, 0);
-          requestAnimationFrame(reapplyAll);
-          return out;
-        };
-        window.updateWhiteWall3D.__wwvm2 = true;
-      }
-    
-      setTimeout(reapplyAll, 0);
-      requestAnimationFrame(reapplyAll);
-    })();
+      window[name].__wall_align_hooked = true;
+    }
+  });
+})();
 
 
 


### PR DESCRIPTION
## Summary
- export white wall plane data for engine alignment
- place wall further from camera and adjust default dimensions
- unify default camera view with per-engine nudges and auto realignment after rebuilds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a566b72c832cb1c64412d52e3102