### PR TITLE
feat: per-engine white wall and view manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -6526,16 +6526,29 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
     }
 
       /* ──────────────────────────────────────────────────────────────
-       * WHITE WALL 3D – pared “infinita” con Leibung y luces propias
-       *  Unidades = cm. Apertura 50×50, espesor 12, distancia 48.
-       *  Las luces sólo iluminan el muro (layer aislada), no a la escena.
+       * WHITE WALL · per-engine (una pared por motor, visible solo la activa)
+       *  Unidades = cm. Luces aisladas en layer 7.
        * ───────────────────────────────────────────────────────────── */
       (function(){
-        const WALL_LAYER = 7;            // capa exclusiva para el muro
-        let wwRig = null;                // rig que sigue a la cámara
-        let wwFrame = null;              // marco (plano con hueco extruido)
-        let wwJambs = [];                // 4 jambas (izq/der/sup/inf)
-        let wwOpen = 50, wwWall = 100, wwThk = 12, wwDist = 48;
+        const WALL_LAYER = 7;
+
+        // Especificaciones por motor (puedes ajustar cada una cuando quieras)
+        const SPECS = {
+          BUILD : { open:50, wall:100, thk:12, dist:60 },
+          FRBN  : { open:50, wall:100, thk:12, dist:60 },
+          LCHT  : { open:50, wall:100, thk:12, dist:60 },
+          OFFNNG: { open:50, wall:100, thk:12, dist:60 },
+          TMSL  : { open:50, wall:120, thk:12, dist:60 },
+          RAUM  : { open:50, wall:100, thk:12, dist:60 },
+          "13245":{ open:50, wall:100, thk:12, dist:60 },
+          KEPLR : { open:50, wall:100, thk:12, dist:60 },
+          RAPHI : { open:50, wall:100, thk:12, dist:60 },
+          GRVTY : { open:50, wall:120, thk:12, dist:60 },
+          R5NOVA: { open:50, wall:120, thk:12, dist:60 },
+        };
+
+        const walls = new Map();      // engine -> {rig, frame, jambs[], specs}
+        let activeEngine = null;
         let rafId = null, lastOuter = -1;
 
         function dispose(obj){
@@ -6546,11 +6559,11 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
               const mats = Array.isArray(n.material) ? n.material : [n.material];
               mats.forEach(m=>m?.dispose?.());
             }
+            if (n.isLight) n.dispose?.();
           });
           obj.parent?.remove?.(obj);
         }
 
-        // Tamaño exterior necesario para cubrir el frustum en z = -dist
         function computeOuterSize(distCm){
           const fovRad = THREE.MathUtils.degToRad(camera.fov);
           const halfH  = Math.tan(fovRad * 0.5) * distCm;
@@ -6559,361 +6572,303 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
           return Math.max(W, H) * 1.2; // margen 20%
         }
 
-        // Geometría del marco con hueco y extrusión = espesor
         function makeFrameGeometry(outer, open, thickness){
           const half = outer * 0.5;
           const h2   = open  * 0.5;
 
           const shape = new THREE.Shape();
-          shape.moveTo(-half, -half);
-          shape.lineTo( half, -half);
-          shape.lineTo( half,  half);
-          shape.lineTo(-half,  half);
-          shape.lineTo(-half, -half);
+          shape.moveTo(-half,-half); shape.lineTo(half,-half);
+          shape.lineTo(half,half);   shape.lineTo(-half,half);
+          shape.lineTo(-half,-half);
 
           const hole = new THREE.Path();
-          hole.moveTo(-h2, -h2);
-          hole.lineTo( h2, -h2);
-          hole.lineTo( h2,  h2);
-          hole.lineTo(-h2,  h2);
-          hole.lineTo(-h2, -h2);
+          hole.moveTo(-h2,-h2); hole.lineTo(h2,-h2);
+          hole.lineTo(h2,h2);   hole.lineTo(-h2,h2);
+          hole.lineTo(-h2,-h2);
           shape.holes.push(hole);
 
-          const geo = new THREE.ExtrudeGeometry(shape, {
-            depth: thickness,
-            bevelEnabled: false,
-            steps: 1,
-            curveSegments: 1
-          });
-          // cara exterior del muro en z = 0
-          geo.translate(0, 0, -thickness);
+          const geo = new THREE.ExtrudeGeometry(shape,{ depth:thickness, bevelEnabled:false, steps:1, curveSegments:1 });
+          geo.translate(0,0,-thickness); // cara exterior en z=0
           geo.computeBoundingSphere(); geo.computeBoundingBox();
           return geo;
         }
 
-        function buildWall(openCm, wallCm, thkCm, distCm){
-          // limpiar anterior
-          if (rafId) { cancelAnimationFrame(rafId); rafId = null; }
-          dispose(wwRig); wwRig = null; wwFrame = null; wwJambs.length = 0; lastOuter = -1;
+        function buildGroup(spec){
+          const {open, wall, thk, dist} = spec;
 
-          wwOpen = openCm; wwWall = wallCm; wwThk = thkCm; wwDist = distCm;
+          const rig = new THREE.Group();
+          rig.matrixAutoUpdate = false;
+          rig.frustumCulled = false;
 
-          // rig que sigue a la cámara
-          wwRig = new THREE.Group();
-          wwRig.matrixAutoUpdate = false;
-          wwRig.frustumCulled = false;
-          scene.add(wwRig);
+          const matFront = new THREE.MeshStandardMaterial({ color:0xECE9E4, roughness:0.92, metalness:0.0, dithering:true });
+          const matJamb  = new THREE.MeshStandardMaterial({ color:0xDEDAD4, roughness:0.95, metalness:0.0, dithering:true });
 
-          // materiales (mate arquitectónico)
-          const matFront = new THREE.MeshStandardMaterial({
-            color: 0xECE9E4,      // “blanco cálido” (frente del muro)
-            roughness: 0.92, metalness: 0.0, dithering: true
-          });
-          const matJamb = new THREE.MeshStandardMaterial({
-            color: 0xDEDAD4,      // un 10–12% más oscuro (Leibung)
-            roughness: 0.95, metalness: 0.0, dithering: true
-          });
+          const outer = wall || computeOuterSize(dist);
+          const geo   = makeFrameGeometry(outer, open, thk);
+          const frame = new THREE.Mesh(geo, matFront);
+          frame.renderOrder = 100000;
+          frame.frustumCulled = false;
+          frame.position.set(0,0,-dist);
+          frame.layers.set(WALL_LAYER);
+          rig.add(frame);
 
-          // “pared infinita”: tamaño exterior según frustum o fijo
-          const outer = wwWall || computeOuterSize(wwDist);
-          const geo   = makeFrameGeometry(outer, wwOpen, wwThk);
-          lastOuter = outer;
+          // jambas (leibung)
+          const h2 = open*0.5, t = thk, zc = -dist - t*0.5;
+          const left   = new THREE.Mesh(new THREE.BoxGeometry(t, open, t), matJamb); left.position.set(-h2 - t*0.5, 0, zc);
+          const right  = new THREE.Mesh(new THREE.BoxGeometry(t, open, t), matJamb); right.position.set( h2 + t*0.5, 0, zc);
+          const top    = new THREE.Mesh(new THREE.BoxGeometry(open, t, t), matJamb); top.position.set(0,  h2 + t*0.5, zc);
+          const bottom = new THREE.Mesh(new THREE.BoxGeometry(open, t, t), matJamb); bottom.position.set(0, -h2 - t*0.5, zc);
+          [left,right,top,bottom].forEach(m=>{ m.renderOrder=100001; m.frustumCulled=false; m.layers.set(WALL_LAYER); rig.add(m); });
 
-          wwFrame = new THREE.Mesh(geo, matFront);
-          wwFrame.renderOrder = 100000;
-          wwFrame.frustumCulled = false;
-          wwFrame.position.set(0, 0, -wwDist);    // cara exterior a wwDist
-          wwFrame.layers.set(WALL_LAYER);
-          wwRig.add(wwFrame);
-
-          // JAMBAS reales (4 cajas)
-          const h2 = wwOpen * 0.5, t = wwThk, zc = -wwDist - t*0.5;
-
-          const left   = new THREE.Mesh(new THREE.BoxGeometry(t, wwOpen, t), matJamb);
-          left.position.set(-h2 - t*0.5, 0, zc);
-
-          const right  = new THREE.Mesh(new THREE.BoxGeometry(t, wwOpen, t), matJamb);
-          right.position.set( h2 + t*0.5, 0, zc);
-
-          const top    = new THREE.Mesh(new THREE.BoxGeometry(wwOpen, t, t), matJamb);
-          top.position.set(0,  h2 + t*0.5, zc);
-
-          const bottom = new THREE.Mesh(new THREE.BoxGeometry(wwOpen, t, t), matJamb);
-          bottom.position.set(0, -h2 - t*0.5, zc);
-
-          [left,right,top,bottom].forEach(m=>{
-            m.renderOrder = 100001;
-            m.frustumCulled = false;
-            m.layers.set(WALL_LAYER);
-            wwRig.add(m);
-          });
-          wwJambs = [left,right,top,bottom];
-
-          // Luces AISLADAS al muro (no afectan la escena)
+          // luces propias
           camera.layers.enable(WALL_LAYER);
-          const hemi = new THREE.HemisphereLight(0xffffff, 0x888888, 0.55);
-          hemi.layers.set(WALL_LAYER);
-          const dir  = new THREE.DirectionalLight(0xffffff, 0.65);
-          dir.position.set(-wwDist*0.8, wwDist*1.2, -wwDist*0.2);
-          dir.layers.set(WALL_LAYER);
-          wwRig.add(hemi, dir);
+          const hemi = new THREE.HemisphereLight(0xffffff, 0x888888, 0.55); hemi.layers.set(WALL_LAYER);
+          const dir  = new THREE.DirectionalLight(0xffffff, 0.65);          dir.position.set(-dist*0.8, dist*1.2, -dist*0.2); dir.layers.set(WALL_LAYER);
+          rig.add(hemi, dir);
 
-          // seguir cámara + reajustar “pared infinita”
-          (function tick(){
-            try{
-              wwRig.position.copy(camera.position);
-              wwRig.quaternion.copy(camera.quaternion);
-              wwRig.scale.set(1,1,1);
-              wwRig.updateMatrix(); wwRig.updateMatrixWorld(true);
+          return { rig, frame, jambs:[left,right,top,bottom], specs:spec, _outer:outer };
+        }
 
-              const needOuter = wwWall || computeOuterSize(wwDist);
-              if (Math.abs(needOuter - lastOuter) > 1e-2){
-                const newGeo = makeFrameGeometry(needOuter, wwOpen, wwThk);
-                wwFrame.geometry.dispose();
-                wwFrame.geometry = newGeo;
-                lastOuter = needOuter;
-              }
-            }catch(_){ }
-            rafId = requestAnimationFrame(tick);
-          })();
+        function ensureAll(){
+          if (walls.size) return;
+          Object.keys(SPECS).forEach(engine=>{
+            const g = buildGroup(SPECS[engine]);
+            g.rig.visible = false;            // se muestran bajo demanda
+            scene.add(g.rig);
+            walls.set(engine, g);
+          });
+        }
+
+        function followActive(){
+          try{
+            if (!activeEngine) return rafId = requestAnimationFrame(followActive);
+            const g = walls.get(activeEngine);
+            if (!g) return rafId = requestAnimationFrame(followActive);
+            const {dist} = g.specs;
+
+            // sincroniza con cámara
+            g.rig.position.copy(camera.position);
+            g.rig.quaternion.copy(camera.quaternion);
+            g.rig.updateMatrix(); g.rig.updateMatrixWorld(true);
+
+            // “pared infinita”: reajusta tamaño si cambia el FOV/aspect
+            const needOuter = g.specs.wall || computeOuterSize(dist);
+            if (Math.abs(needOuter - g._outer) > 1e-2){
+              const newGeo = makeFrameGeometry(needOuter, g.specs.open, g.specs.thk);
+              g.frame.geometry.dispose();
+              g.frame.geometry = newGeo;
+              g._outer = needOuter;
+            }
+          }catch(_){ }
+          rafId = requestAnimationFrame(followActive);
+        }
+
+        function show(engine){
+          ensureAll();
+          walls.forEach((g,key)=>{ g.rig.visible = (key===engine); });
+          activeEngine = engine;
+          if (!rafId) rafId = requestAnimationFrame(followActive);
+        }
+
+        function update(engine, spec){
+          ensureAll();
+          const old = walls.get(engine);
+          if (old){
+            const wasVisible = old.rig.visible;
+            dispose(old.rig);
+            walls.delete(engine);
+            const g = buildGroup(spec);
+            g.rig.visible = !!wasVisible;
+            scene.add(g.rig);
+            walls.set(engine, g);
+            if (wasVisible) activeEngine = engine;
+          }
+        }
+
+        function activeInfo(){
+          if (!activeEngine) return null;
+          const g = walls.get(activeEngine);
+          if (!g) return null;
+          const dir = new THREE.Vector3(); camera.getWorldDirection(dir);
+          const frontCenter = camera.position.clone().add(dir.clone().multiplyScalar(g.specs.dist));
+          const backCenter  = frontCenter.clone().add(dir.clone().multiplyScalar(g.specs.thk));
+          return { engine:activeEngine, dir, frontCenter, backCenter, distance:g.specs.dist, thickness:g.specs.thk };
         }
 
         // API pública
-        window.installWhiteWall3D = function(){
-          // apertura 50×50, pared 100×100, espesor 15, a 50 cm de la cámara
-          window.__wwDistance = 50;      // ← expone distancia global
-          window.__wwThickness = 15;     // ← expone espesor global
-          buildWall(50, 100, 15, 50);
-        };
-        // Cambia medidas en caliente
-        window.updateWhiteWall3D = function(openSize, wallSize, thickness, distance){
-          const o = Number(openSize)||50;
-          const w = Number(wallSize)||100;
-          const t = Number(thickness)||15;
-          const d = Number(distance)||50;
-          window.__wwDistance  = d;   // ← actualiza globales
-          window.__wwThickness = t;   // ← actualiza globales
-          buildWall(o, w, t, d);
-        };
-        window.removeWhiteWall3D  = function(){
-          if (rafId){ cancelAnimationFrame(rafId); rafId = null; }
-          dispose(wwRig); wwRig = null; wwFrame = null; wwJambs.length = 0; lastOuter = -1;
+        window.WW = {
+          ensureAll, show,
+          update,         // update('TMSL', {open:55, wall:120, thk:14, dist:64})
+          activeInfo,     // {distance, thickness, dir, …} de la pared visible
+          SPECS           // acceso directo a las medidas por motor
         };
       })();
 
       init();
-      installWhiteWall3D();
 
+      /* ──────────────────────────────────────────────────────────────
+       * VIEW MANAGER · per-engine + wall binding
+       *  - Misma base para todos (tipo BUILD).
+       *  - Zoomeos por motor según lo pedido.
+       *  - Alineación de TMSL/R5NOVA a plano trasero del hueco.
+       * ───────────────────────────────────────────────────────────── */
+      (function(){
+        const TMP_V = new THREE.Vector3();
+        function hasControls(){ return (typeof controls !== 'undefined' && controls && controls.target); }
 
-      // aleja el muro a 60 cm (antes 50 cm)
-      updateWhiteWall3D(50, 100, 15, 60);
+        // 1) Baseline de cámara tipo BUILD (neutral y repetible)
+        function applyBaseView(){
+          try{
+            camera.up.set(0,1,0);
+            if (hasControls()) controls.target.set(0,0,0);
+            camera.fov = 34;
+            camera.near = 0.1;
+            camera.far  = 4000;
+            camera.position.set(0,0,84);
+            camera.updateProjectionMatrix();
+            controls?.update?.();
+          }catch(_){ }
+        }
 
+        // 2) Motor activo
+        function engineId(){
+          if (window.isGRVTY)  return 'GRVTY';
+          if (window.isR5NOVA) return 'R5NOVA';
+          if (window.isRAPHI)  return 'RAPHI';
+          if (window.isKEPLR)  return 'KEPLR';
+          if (window.is13245)  return '13245';
+          if (window.isRAUM)   return 'RAUM';
+          if (window.isTMSL)   return 'TMSL';
+          if (window.isOFFNNG) return 'OFFNNG';
+          if (window.isLCHT)   return 'LCHT';
+          if (window.isFRBN)   return 'FRBN';
+          return 'BUILD';
+        }
 
-        /* ──────────────────────────────────────────────────────────────
-     * WHITE-WALL VIEW MANAGER · v2
-     * - Vista standard unificada (clon de BUILD), independiente por motor.
-     * - Zoom-out por motor (LCHT, RAUM, GRVTY, 13245 → ×3).
-     * - Alineación precisa: TMSL/R5NOVA pegados al plano trasero del hueco.
-     * ───────────────────────────────────────────────────────────── */
-    (function WWViewManagerV2(){
-      const TMP_V = new THREE.Vector3();
-      function hasControls(){ return (typeof controls !== 'undefined' && controls && controls.target); }
-    
-      // 1) Baseline (se captura a los pocos ms para asegurar cámara/controles)
-      const _baseline = {
-        pos    : new THREE.Vector3(0,0,60),
-        quat   : new THREE.Quaternion(),
-        target : new THREE.Vector3(0,0,0),
-        fov    : 40,
-        near   : 0.1,
-        far    : 4000
-      };
-      function snapshotBUILD(){
-        try{
-          if (camera){
-            _baseline.pos.copy(camera.position);
-            _baseline.quat.copy(camera.quaternion);
-            _baseline.fov  = camera.fov;
-            _baseline.near = Math.min(camera.near||0.1, 0.1);
-            _baseline.far  = Math.max(camera.far||2000, 4000);
-          }
-          if (hasControls()) _baseline.target.copy(controls.target);
-        }catch(_){ }
-      }
-      setTimeout(snapshotBUILD, 50);
-      requestAnimationFrame(snapshotBUILD);
-    
-      // 2) Vistas por motor (independientes, inicializadas como BUILD)
-      const ENGINES = ['BUILD','FRBN','LCHT','OFFNNG','TMSL','RAUM','13245','KEPLR','RAPHI','GRVTY','R5NOVA'];
-      const VIEWS = Object.create(null);
-      function ensureViews(){
-        if (VIEWS.__ready) return;
-        ENGINES.forEach(n=>{
-          VIEWS[n] = {
-            pos: _baseline.pos.clone(),
-            quat: _baseline.quat.clone(),
-            target: _baseline.target.clone(),
-            fov: _baseline.fov, near:_baseline.near, far:_baseline.far
-          };
-        });
-        VIEWS.__ready = true;
-      }
-    
-      // 3) Motor activo
-      function engineId(){
-        if (window.isGRVTY)  return 'GRVTY';
-        if (window.isR5NOVA) return 'R5NOVA';
-        if (window.isRAPHI)  return 'RAPHI';
-        if (window.isKEPLR)  return 'KEPLR';
-        if (window.is13245)  return '13245';
-        if (window.isRAUM)   return 'RAUM';
-        if (window.isTMSL)   return 'TMSL';
-        if (window.isOFFNNG) return 'OFFNNG';
-        if (window.isLCHT)   return 'LCHT';
-        if (window.isFRBN)   return 'FRBN';
-        return 'BUILD';
-      }
-    
-      // 4) Zoom por motor
-      const ZOOM_BASE = 1.40;               // alejamiento suave general
-      const ZOOM_SCALE = {                  // multiplicadores por motor
-        LCHT: 3.0, RAUM: 3.0, GRVTY: 3.0, '13245': 3.0
-      };
-      function applyZoomFromTarget(factor){
-        if (!hasControls()) return;
-        const dir = TMP_V.copy(camera.position).sub(controls.target);
-        camera.position.copy(controls.target).add(dir.multiplyScalar(factor));
-        camera.updateProjectionMatrix();
-        controls.update();
-      }
-    
-      // 5) Aplicar vista del motor actual
-      function applyViewFor(id){
-        ensureViews();
-        const v = VIEWS[id] || VIEWS.BUILD;
-    
-        camera.position.copy(v.pos);
-        camera.quaternion.copy(v.quat);
-        camera.fov  = v.fov;
-        camera.near = v.near;
-        camera.far  = v.far;
-        camera.updateProjectionMatrix();
-    
-        if (hasControls()){
-          controls.target.copy(v.target);
+        // 3) Zoomeos por motor
+        const STEP = 1.25;                          // “un zoom”
+        const ZOOM = {
+          // atrás = mayor factor; adelante = menor factor
+          LCHT  : STEP*STEP,   // dos hacia atrás
+          RAUM  : STEP*STEP,   // dos hacia atrás
+          TMSL  : STEP,        // uno hacia atrás
+          OFFNNG: 1/STEP,      // uno hacia adelante
+          KEPLR : 1/STEP,      // uno hacia adelante
+          RAPHI : 1/STEP       // uno hacia adelante
+          // los demás = 1.0
+        };
+        function applyZoomFromTarget(factor){
+          if (!hasControls()) return;
+          const dir = TMP_V.copy(camera.position).sub(controls.target);
+          camera.position.copy(controls.target).add(dir.multiplyScalar(factor));
+          camera.updateProjectionMatrix();
           controls.update();
         }
-    
-        // Alejamiento: base × escala por motor (si existe)
-        const factor = ZOOM_BASE * (ZOOM_SCALE[id] || 1.0);
-        applyZoomFromTarget(factor);
-      }
-    
-      // 6) Guardar vista por motor (para tu “catálogo”)
-      window.setEngineDefaultView = function(id){
-        ensureViews();
-        const key = (id||engineId());
-        const v = VIEWS[key];
-        v.pos.copy(camera.position);
-        v.quat.copy(camera.quaternion);
-        v.fov = camera.fov;
-        if (hasControls()) v.target.copy(controls.target);
-      };
-    
-      // 7) Alineación precisa de TMSL/R5NOVA al plano trasero del hueco
-      function cameraForward(){
-        return new THREE.Vector3(0,0,-1).applyQuaternion(camera.quaternion).normalize();
-      }
-      function wwBackPlane(){
-        const d  = (window.__wwDistance||80);
-        const t  = (window.__wwThickness||15);
-        const n  = cameraForward();                    // normal (hacia delante)
-        const p0 = camera.position.clone().add(n.clone().multiplyScalar(-(d+t)));
-        return {n, p0};                                // plano: n·p = n·p0
-      }
-      function projRangeAlong(obj, n){
-        obj.updateMatrixWorld(true);
-        const box = new THREE.Box3().setFromObject(obj);
-        const pts = [
-          new THREE.Vector3(box.min.x, box.min.y, box.min.z),
-          new THREE.Vector3(box.min.x, box.min.y, box.max.z),
-          new THREE.Vector3(box.min.x, box.max.y, box.min.z),
-          new THREE.Vector3(box.min.x, box.max.y, box.max.z),
-          new THREE.Vector3(box.max.x, box.min.y, box.min.z),
-          new THREE.Vector3(box.max.x, box.min.y, box.max.z),
-          new THREE.Vector3(box.max.x, box.max.y, box.min.z),
-          new THREE.Vector3(box.max.x, box.max.y, box.max.z),
-        ];
-        let min=Infinity, max=-Infinity;
-        for (let p of pts){
-          p.applyMatrix4(obj.matrixWorld);
-          const s = n.dot(p);
-          if (s<min) min=s;
-          if (s>max) max=s;
+
+        // 4) Alineación precisa de shells laterales al plano trasero del hueco
+        function alignShellsIfAny(){
+          const info = window.WW?.activeInfo?.();
+          if (!info) return;
+          const n  = info.dir.clone();                 // normal hacia la escena
+          const s0 = n.dot(info.backCenter);           // plano trasero (d = n·p0)
+          const EPS = 0.10;                            // 1 mm (unidades cm → 0.10 = 1 mm)
+
+          function pushBehind(obj){
+            if (!obj) return;
+            obj.updateMatrixWorld(true);
+            const box = new THREE.Box3().setFromObject(obj);
+            const pts = [
+              new THREE.Vector3(box.min.x, box.min.y, box.min.z),
+              new THREE.Vector3(box.min.x, box.min.y, box.max.z),
+              new THREE.Vector3(box.min.x, box.max.y, box.min.z),
+              new THREE.Vector3(box.min.x, box.max.y, box.max.z),
+              new THREE.Vector3(box.max.x, box.min.y, box.min.z),
+              new THREE.Vector3(box.max.x, box.min.y, box.max.z),
+              new THREE.Vector3(box.max.x, box.max.y, box.min.z),
+              new THREE.Vector3(box.max.x, box.max.y, box.max.z),
+            ];
+            let max = -Infinity;
+            for (let p of pts){ p.applyMatrix4(obj.matrixWorld); const s = n.dot(p); if (s>max) max=s; }
+            const delta = (s0 - EPS) - max;            // queremos max = s0 - EPS
+            if (delta !== 0){
+              obj.position.add(n.clone().multiplyScalar(delta));
+              obj.updateMatrixWorld(true);
+            }
+          }
+
+          try{ if (window.isTMSL   && window.__tmslDecorGroup) pushBehind(window.__tmslDecorGroup); }catch(_){ }
+          try{ if (window.isR5NOVA && window.groupR5NOVA)      pushBehind(window.groupR5NOVA);      }catch(_){ }
         }
-        return {min,max};
-      }
-      function alignToBackPlane(obj){
-        if (!obj) return;
-        const {n,p0} = wwBackPlane();
-        const s0 = n.dot(p0);
-        const {max} = projRangeAlong(obj, n); // punto “más cercano” a la cámara en dirección n
-        const EPS = 0.5;                      // 5 mm de holgura
-        const delta = (s0 - EPS) - max;       // queremos max = s0 - EPS
-        obj.position.add(n.clone().multiplyScalar(delta));
-        obj.updateMatrixWorld(true);
-      }
-      function alignShellsIfAny(){
-        try{
-          if (window.isTMSL && window.__tmslDecorGroup) alignToBackPlane(window.__tmslDecorGroup);
-        }catch(_){ }
-        try{
-          if (window.isR5NOVA && window.groupR5NOVA) alignToBackPlane(window.groupR5NOVA);
-        }catch(_){ }
-      }
-    
-      // 8) Reaplicar al cambiar de motor/rebuild
-      function reapplyAll(){
-        applyViewFor(engineId());
-        alignShellsIfAny();
-      }
-      function hook(name){
-        const orig = window[name];
-        if (typeof orig === 'function' && !orig.__wwvm2){
+
+        // 5) Aplicación completa al entrar en un motor
+        function applyFor(engine){
+          // pared del motor
+          window.WW?.show?.(engine);
+
+          // vista base y zoom del motor
+          applyBaseView();
+          const f = ZOOM[engine] || 1.0;
+          applyZoomFromTarget(f);
+
+          // ajustes especiales por motor
+          if (engine === 'GRVTY'){
+            // horizonte limpio dentro del hueco
+            try{
+              camera.fov = 20;
+              camera.updateProjectionMatrix();
+              if (hasControls()) controls.target.set(0,6,0);
+              camera.position.set(0,8,190);
+              controls?.update?.();
+              if (window.groupGRVTY){ groupGRVTY.scale.set(0.86,1.0,0.86); groupGRVTY.updateMatrixWorld(true); }
+            }catch(_){ }
+          }
+
+          // deja shells pegados al plano trasero del hueco
+          alignShellsIfAny();
+        }
+
+        // 6) Enganches (idempotentes)
+        function hook(name, engine){
+          const orig = window[name];
+          if (typeof orig !== 'function' || orig.__view_hooked) return;
           window[name] = function(){
             const out = orig.apply(this, arguments);
-            setTimeout(reapplyAll, 0);
-            requestAnimationFrame(reapplyAll);
+            setTimeout(()=>applyFor(engine), 0);
+            requestAnimationFrame(()=>applyFor(engine));
             return out;
           };
-          window[name].__wwvm2 = true;
+          window[name].__view_hooked = true;
         }
-      }
-    
-      [
-        'toggleFRBN','toggleLCHT','toggleOFFNNG','toggleTMSL','toggleRAUM',
-        'toggle13245','toggleKEPLR','toggleRAPHI','toggleGRVTY','toggleR5NOVA',
-        'ensureOnlyFRBN','ensureOnlyLCHT','ensureOnlyOFFNNG','ensureOnlyTMSL',
-        'ensureOnlyGRVTY','ensureOnlyR5NOVA','applyEngineFromSelect','cycleEngine',
-        'rebuildTMSLIfActive','rebuildR5NOVAIfActive','rebuildGRVTYIfActive',
-        'refreshAll','buildUniverse','buildScene','rebuildUniverse'
-      ].forEach(hook);
-    
-      // También nos re-ajustamos si cambian las medidas del muro
-      const _oldUpdateWW = window.updateWhiteWall3D;
-      if (typeof _oldUpdateWW === 'function' && !_oldUpdateWW.__wwvm2){
-        window.updateWhiteWall3D = function(){
-          const out = _oldUpdateWW.apply(this, arguments);
-          setTimeout(reapplyAll, 0);
-          requestAnimationFrame(reapplyAll);
-          return out;
+
+        const MAP = {
+          toggleFRBN:'FRBN', toggleLCHT:'LCHT', toggleOFFNNG:'OFFNNG',
+          toggleTMSL:'TMSL', toggleRAUM:'RAUM', toggle13245:'13245',
+          toggleKEPLR:'KEPLR', toggleRAPHI:'RAPHI', toggleGRVTY:'GRVTY',
+          toggleR5NOVA:'R5NOVA',
+          ensureOnlyFRBN:'FRBN', ensureOnlyLCHT:'LCHT', ensureOnlyOFFNNG:'OFFNNG',
+          ensureOnlyTMSL:'TMSL', ensureOnlyGRVTY:'GRVTY', ensureOnlyR5NOVA:'R5NOVA'
         };
-        window.updateWhiteWall3D.__wwvm2 = true;
-      }
-    
-      setTimeout(reapplyAll, 0);
-      requestAnimationFrame(reapplyAll);
-    })();
+        Object.keys(MAP).forEach(fn=>hook(fn, MAP[fn]));
+
+        // Reaplicar tras rebuilds o refresh del universo
+        ['rebuildTMSLIfActive','rebuildR5NOVAIfActive','rebuildGRVTYIfActive','refreshAll','buildUniverse','buildScene','rebuildUniverse'].forEach(name=>{
+          const orig = window[name];
+          if (typeof orig === 'function' && !orig.__view_hooked2){
+            window[name] = function(){
+              const out = orig.apply(this, arguments);
+              const eng = (window.WW && window.WW.activeInfo && engineId()) || 'BUILD';
+              setTimeout(()=>applyFor(eng), 0);
+              requestAnimationFrame(()=>applyFor(eng));
+              return out;
+            };
+            window[name].__view_hooked2 = true;
+          }
+        });
+
+        // Al cargar (o tras refresh), aplica al motor que esté activo o BUILD
+        setTimeout(()=>applyFor(engineId()), 0);
+        requestAnimationFrame(()=>applyFor(engineId()));
+      })();
 
 
 


### PR DESCRIPTION
## Summary
- implement per-engine white wall with customizable specs and public WW API
- overhaul view manager to bind wall and apply engine-specific zoom/alignments
- remove redundant install/update wall calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c692dafcb8832ca2ad71fdf7a17d5f