### PR TITLE
feat: replace WW_PROFILES_SINGLE with minimal manager

### DIFF
--- a/index.html
+++ b/index.html
@@ -6704,14 +6704,16 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
       })();
 
         /* ──────────────────────────────────────────────────────────────
-         * WW_PROFILES · Gestor ÚNICO (sin duplicados)
-         * - outer fijo 200 para todos (pared 2×)
-         * - distance y zoom por motor (como tus imágenes)
-         * - Base de cámara determinista (target 0,0,0; pos 0,0,84; FOV estable)
-         * - Debounce real (cancela llamadas previas) ⇒ fuera “entra dos veces”
-         * - API para la UI: wwTune(kind, factor) + WW_UI.mulWall/mulCam/mulScene
+         * WW_PROFILES · Gestor ÚNICO (sin duplicados, sin rebuild hooks)
+         * - Pared por motor: outer=200, distancia por motor (DIST)
+         * - Base de cámara determinista y zoom por motor (ZOOM)
+         * - Debounce real (cancela previos), aplica 1 sola vez al final
+         * - API para UI: wwTune(kind, factor) + WW_UI.mulWall/mulCam/mulScene
          * ───────────────────────────────────────────────────────────── */
         (function WW_PROFILES_SINGLE(){
+          if (window.__WW_PROFILES_READY) return;     // guardia anti-doble carga
+          window.__WW_PROFILES_READY = true;
+
           // ---------- helpers ----------
           const TMP = new THREE.Vector3();
           function hasControls(){ return (typeof controls !== 'undefined' && controls && controls.target); }
@@ -6736,31 +6738,32 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
             controls.update();
           }
           function setBaseCamera(id){
-            // Base determinista (clon de BUILD): evita drift entre motores
+            // Base determinista (clon de BUILD): evita drift/variaciones entre motores
             camera.up.set(0,1,0);
             if (hasControls()) controls.target.set(0,0,0);
             camera.near = 0.1; camera.far = 4000;
-            camera.fov = (id==='GRVTY' ? 34 : 34);   // FOV estable (GRVTY también)
+            camera.fov  = 34;                 // FOV estable (incluye GRVTY)
             camera.position.set(0,0,84);
             camera.updateProjectionMatrix();
             controls?.update?.();
           }
 
           // ---------- perfiles EXACTOS ----------
-          const DIST = {              // distancia muro (cm)
+          const DIST = {              // distancia del muro (cm) por motor
             BUILD:60, FRBN:60, LCHT:80, OFFNNG:55, TMSL:68, RAUM:70, '13245':72,
             KEPLR:55, RAPHI:55, GRVTY:62, R5NOVA:60
           };
-          const ZOOM = {              // <1 acerca, >1 aleja
+          const ZOOM = {              // <1 acerca, >1 aleja (relativo a base)
             BUILD:1.00, FRBN:1.00, LCHT:1.30, OFFNNG:0.92, TMSL:1.15, RAUM:1.25,
             '13245':1.22, KEPLR:0.92, RAPHI:0.92, GRVTY:1.05, R5NOVA:1.00
           };
 
-          // Alineación de shells al plano trasero del hueco (TMSL/R5NOVA)
+          // Alineación de shells (TMSL/R5NOVA) al plano trasero del hueco
           function alignShellToBackPlane(obj){
             if (!obj) return;
             const info = window.WW?.activeInfo?.(); if (!info) return;
-            const n = info.dir.clone(); const s0 = n.dot(info.backCenter);
+            const n  = info.dir.clone();
+            const s0 = n.dot(info.backCenter);
             obj.updateMatrixWorld(true);
             const box = new THREE.Box3().setFromObject(obj);
             const pts = [
@@ -6775,52 +6778,56 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
             ];
             let max = -Infinity;
             for (let p of pts){ p.applyMatrix4(obj.matrixWorld); const s = n.dot(p); if (s>max) max=s; }
-            const EPS = 0.5; const delta = (s0 - EPS) - max;
-            if (Math.abs(delta) > 1e-6){ obj.position.add(n.multiplyScalar(delta)); obj.updateMatrixWorld(true); }
+            const EPS = 0.5;
+            const delta = (s0 - EPS) - max;
+            if (Math.abs(delta) > 1e-6){
+              obj.position.add(n.multiplyScalar(delta));
+              obj.updateMatrixWorld(true);
+            }
           }
 
           // Raíces de escena para “SCENE”
           const ROOTS = Object.create(null);
           window.registerEngineRoot = function(id, root){ ROOTS[id] = root; };
 
-          // Aplicación del perfil (pared + base + zoom + shells)
+          // Aplicar perfil (pared + base + zoom + shells)
           function applyFor(id){
             const key = id || engineId();
-            WW.show(key);
-            WW.setOuter(key, 200);                         // pared 2× para todos
-            WW.setDistance(key, DIST[key] ?? 60);          // distancia exacta
 
-            setBaseCamera(key);                            // base determinista
-            applyZoomFromTarget(ZOOM[key] ?? 1.0);         // zoom del motor
+            WW.show(key);                         // muestra la pared del motor
+            WW.setOuter(key, 200);                // pared 2× para todos
+            WW.setDistance(key, DIST[key] ?? 60); // distancia exacta
+
+            setBaseCamera(key);                   // base determinista
+            applyZoomFromTarget(ZOOM[key] ?? 1.0);
 
             try{ if (key==='TMSL'   && window.__tmslDecorGroup) alignShellToBackPlane(window.__tmslDecorGroup); }catch(_){ }
             try{ if (key==='R5NOVA' && window.groupR5NOVA)      alignShellToBackPlane(window.groupR5NOVA);      }catch(_){ }
           }
 
-          // Debounce real: cancela solicitudes previas y aplica SOLO la última
-          let rafA = 0, rafB = 0, lastToken = 0;
+          // Debounce real: cancela previos y aplica SOLO el último (post toggles)
+          let raf1 = 0, raf2 = 0, token = 0;
           function scheduleApply(id){
-            lastToken++;
-            if (rafA) cancelAnimationFrame(rafA);
-            if (rafB) cancelAnimationFrame(rafB);
-            const token = lastToken;
+            token++;
+            if (raf1) cancelAnimationFrame(raf1);
+            if (raf2) cancelAnimationFrame(raf2);
+            const my = token;
+            // microtask → RAF → RAF (dejamos terminar todos los toggles internos)
             Promise.resolve().then(()=>{
-              rafA = requestAnimationFrame(()=>{
-                rafB = requestAnimationFrame(()=>{
-                  if (token === lastToken) applyFor(id);
+              raf1 = requestAnimationFrame(()=>{
+                raf2 = requestAnimationFrame(()=>{
+                  if (my === token) applyFor(id);
                 });
               });
             });
           }
 
-          // Engancha eventos de cambio de motor / rebuild (una sola vez)
+          // SOLO hooks de cambio de motor (NO rebuilds genéricos)
           const HOOKS = [
             'toggleFRBN','toggleLCHT','toggleOFFNNG','toggleTMSL','toggleRAUM',
             'toggle13245','toggleKEPLR','toggleRAPHI','toggleGRVTY','toggleR5NOVA',
             'ensureOnlyFRBN','ensureOnlyLCHT','ensureOnlyOFFNNG','ensureOnlyTMSL',
-            'ensureOnlyGRVTY','ensureOnlyR5NOVA','applyEngineFromSelect','cycleEngine',
-            'rebuildTMSLIfActive','rebuildR5NOVAIfActive','rebuildGRVTYIfActive',
-            'refreshAll','buildUniverse','buildScene','rebuildUniverse'
+            'ensureOnlyGRVTY','ensureOnlyR5NOVA','applyEngineFromSelect','cycleEngine'
           ];
           HOOKS.forEach(name=>{
             const orig = window[name];
@@ -6834,10 +6841,9 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
             }
           });
 
-          // Controles para tu panel (WALL / CAM / SCENE)
+          // Controles para el panel (WALL / CAM / SCENE)
           function mulWall(f){
-            const id = engineId(); const w = WW.get(id);
-            if (!w) return;
+            const id = engineId(); const w = WW.get(id); if (!w) return;
             const newDist = Math.max(5, (w.params.distance||60) * f);
             WW.setDistance(id, newDist);
           }
@@ -6850,7 +6856,7 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
           }
           window.WW_UI = { mulWall, mulCam, mulScene };
 
-          // función genérica para tu UI actual (por si llama wwTune)
+          // Puente genérico (por si tu UI llama wwTune)
           window.wwTune = function(kind, factor){
             const f = Number(factor) || 1.25;
             if      (kind==='wall')  mulWall(f);
@@ -6858,7 +6864,7 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
             else if (kind==='scene') mulScene(f);
           };
 
-          // auto-bind si existen ids de botones comunes
+          // auto-bind si existen ids
           [['ww_wall_m',1/1.25],['ww_wall_p',1.25],
            ['ww_cam_m', 1/1.25],['ww_cam_p', 1.25],
            ['ww_scn_m', 1/1.25],['ww_scn_p', 1.25]].forEach(([id,f])=>{
@@ -6866,7 +6872,7 @@ function ensureOnlyRAPHIFromUI(){ ensureOnlyRAPHI(); updateEngineSelectUI(); }
              if (el) el.onclick = ()=>{ id.startsWith('ww_wall')?mulWall(f):id.startsWith('ww_cam')?mulCam(f):mulScene(f); };
           });
 
-          // arranque
+          // arranque (una sola aplicación, sin saltos)
           scheduleApply();
         })();
 


### PR DESCRIPTION
## Summary
- replace WW_PROFILES_SINGLE with streamlined manager that sets deterministic camera base and per-engine wall profiles
- use limited engine-change hooks and debounce without rebuild hooks

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81f60f814832c91a7387ea8252f80