### PR TITLE
Adjust GRVTY camera and expand GRVTY grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1470,19 +1470,37 @@ function buildLCHT() {
     }
 
     function setCamera_GRVTY(){
+      // Horizonte/mar: ojo más bajo, un poco más atrás y FOV más estrecho
       camera.up.set(0,1,0);
-      camera.near = 0.1; camera.far = 4000;
-      camera.fov = 75; camera.updateProjectionMatrix();
-      if (controls && controls.target) controls.target.set(0, 0, 0);
-      camera.position.set(4.78, 62.73, 349.66);
+      camera.near = 0.1;
+      camera.far  = 4000;
+      camera.fov  = 60;                 // antes 75 → reduce “abertura” (evita cielo en esquinas)
+      camera.updateProjectionMatrix();
+
+      // Encadre: mira un poco hacia abajo (target más bajo que el ojo)
+      const eyeX = 0.0, eyeY = 38.0, eyeZ = 260.0;
+      const tgtY = 6.0;
+
+      if (controls && controls.target) controls.target.set(0, tgtY, 0);
+      camera.position.set(eyeX, eyeY, eyeZ);
+      camera.lookAt(0, tgtY, 0);
+
       if (controls){
         controls.enabled = true;
         controls.enableRotate = true;
         controls.enablePan    = true;
         controls.enableZoom   = true;
-        controls.minPolarAngle = 0;
-        controls.maxPolarAngle = Math.PI;
         controls.screenSpacePanning = false;
+
+        // Limita el pitch a un rango “mar/horizonte” (ligero tilt hacia abajo)
+        // π/2 es horizontal; permitimos -0.2..+0.1 rad respecto a horizontal.
+        controls.minPolarAngle = Math.PI/2 - 0.20;   //  ~1.37
+        controls.maxPolarAngle = Math.PI/2 + 0.10;   //  ~1.67
+
+        // Rango de zoom razonable para este encuadre (no afecta a otros motores)
+        controls.minDistance = 160;
+        controls.maxDistance = 420;
+
         controls.update();
       }
     }
@@ -8134,7 +8152,7 @@ function disposeGroupGRVTY(){
 }
 
 /* ====== Parámetros del plano y wells ====== */
-const GRVTY_W = 360.0, GRVTY_D = 480.0;   // malla muy amplia tipo horizonte
+const GRVTY_W = 720.0, GRVTY_D = 960.0;   // malla muy amplia tipo horizonte
 const GRVTY_RES_DESKTOP = 360;            // más subdivisiones para ondulación suave
 const GRVTY_RES_MOBILE  = 220;
 /* Tope alto seguro para WebGL (sumatorio de uniforms): 64 pozos máx por draw */
@@ -8398,8 +8416,8 @@ function buildGRVTY(){
     uBreath:    { value: 0.08 },
     uCol1:      { value: C1 },
     uCol2:      { value: C2 },
-    uGridScale: { value: 36.0 },
-    uLineWidth: { value: 0.08 },
+    uGridScale: { value: GRVTY_W * 0.10 },          // 0.10 × ancho → misma separación real que antes
+    uLineWidth: { value: 0.08 * (360.0 / GRVTY_W) },// conserva grosor relativo al escalar el plano
 
     // Gradiente centros
     uHueBase:   { value: hueBase },


### PR DESCRIPTION
## Summary
- update the GRVTY camera setup with a lower eye position, narrower FOV, and constrained controls
- double the GRVTY plane dimensions and adjust grid uniforms to preserve visual density

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cacb96d1f0832cabe9cb5aae433554