### PR TITLE
Update parkett shader to physical scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -5649,7 +5649,28 @@ void main(){
         return tex;
       }
 
-      // ---------- Hash determinista existente ----------
+      // === 15 familias (aprox) con haces de líneas ponderados ====================
+      // Cada familia es un vector de 5 pesos que modula los 5 haces (rotados 72°).
+      // Los pesos están normalizados internamente.
+      const PARKETT15_WEIGHTS = [
+        [1,1,1,1,1],            // 1  : regular (estrella uniforme)
+        [2,1,1,1,1],            // 2  : énfasis 1 haz
+        [1,2,1,1,1],            // 3
+        [1,1,2,1,1],            // 4
+        [1,1,1,2,1],            // 5
+        [1,1,1,1,2],            // 6
+        [2,2,1,1,1],            // 7  : 2 haces dominantes
+        [2,1,2,1,1],            // 8
+        [2,1,1,2,1],            // 9
+        [2,1,1,1,2],            // 10
+        [1,2,2,1,1],            // 11 : pareja contigua
+        [1,2,1,2,1],            // 12 : alternado
+        [1,2,1,1,2],            // 13
+        [1,1,2,2,1],            // 14
+        [1,1,2,1,2],            // 15
+      ];
+
+      // Hash determinista (igual que ya venimos usando)
       function fnv1a32_step(h, x){ h ^= (x>>>0); h = Math.imul(h, 16777619)>>>0; return h>>>0; }
       function raumParkettFamilyHash(){
         let h = 2166136261>>>0;
@@ -5664,21 +5685,118 @@ void main(){
         return h>>>0;
       }
 
-      // ---------- Material público ----------
-      window.makeParkettMaterial = function(wallIndex /*0..4*/){
+      // wallIndex: 0..4 → left,right,floor,ceil,back
+      // sizeU,sizeV: tamaño FÍSICO de la pared (en unidades de escena) para escalar celdas correctamente
+      function makeParkettMaterial(wallIndex, sizeU, sizeV){
         const H = raumParkettFamilyHash();
-        const family = 1 + (H % 15);
-        function rotl(x,b){ return ((x<<b)|(x>>> (32-b)))>>>0; }
-        const Fw  = (rotl(H, 5*wallIndex) ^ (0x9E3779B9*wallIndex))>>>0;
+        const family = 1 + (H % 15); // 1..15
 
-        const dens  = 0.85 + ((Fw>>>10)&1023)/1023 * 0.50;          // 0.85..1.35
-        const theta = ((rotl(Fw,13)&2047)/2048)*Math.PI*2.0;
-        const luma  = lerp(PARK_LINE_LUMA_MIN, PARK_LINE_LUMA_MAX, ((rotl(Fw,17)&255)/255));
+        // variaciones suaves por pared (deterministas)
+        const rotl = (x,b)=>((x<<b)|(x>>> (32-b)))>>>0;
+        const Fw = (rotl(H, 5*wallIndex) ^ (0x9E3779B9*wallIndex))>>>0;
 
-        const tex = makeParkettTexture({ W:1024, H:1024, family, density:dens, theta, luma });
-        // BasicMaterial para “tinta” exacta (sin luces)
-        return new THREE.MeshBasicMaterial({ map: tex, color: 0xffffff, transparent:false });
-      };
+        // Tamaño de celda EN UNIDADES FÍSICAS (grande, estilo referencia)
+        // 2.8–3.6 u; más grande ⇒ menos líneas ⇒ celdas “gruesas”
+        const cellBase = 2.8 + ((Fw>>>10)&1023)/1023 * (3.6-2.8);
+        // Grosor relativo a la celda (más marcado que antes)
+        const lineFrac = 0.060 + Math.pow(((Fw>>>3)&511)/511,1.4) * 0.025; // 6% … 8.5%
+        // Rotación global del raster
+        const theta = ((rotl(Fw,13)&2047)/2048.0) * Math.PI*2.0;
+        // Afinidad (deformación leve del pentágono)
+        const aff = 0.92 + (family/15)*0.20;
+
+        // pesos de familia (normalizados)
+        const Wraw = PARKETT15_WEIGHTS[family-1].slice(0,5);
+        const Wsum = Wraw.reduce((a,b)=>a+b,0);
+        const W = Wraw.map(x=>x / (Wsum>1e-6?Wsum:1));
+
+        const uniforms = {
+          uInk:   { value: new THREE.Color(0x0F0F0F) },   // negro suave (más visible)
+          uBg:    { value: new THREE.Color(0xFFFFFF) },   // pared blanca
+          uCell:  { value: cellBase },                    // tamaño de celda (u,v en “metros”)
+          uLineF: { value: lineFrac },                    // grosor relativo a la celda
+          uRot:   { value: theta },
+          uAff:   { value: aff },
+          uSize:  { value: new THREE.Vector2(sizeU, sizeV) }, // tamaño físico de la pared
+          uW:     { value: new THREE.Vector4(W[0],W[1],W[2],W[3]) }, // 4 primeros
+          uW4:    { value: W[4] } // último
+        };
+
+        const vs = `
+          varying vec2 vUV;
+          void main(){
+            // uv 0..1 de la geometría (plane) — lo convertimos en coordenadas físicas en el FS
+            vUV = uv;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position,1.0);
+          }
+        `;
+
+        // Raster físico: 5 haces de líneas periódicas con antialias en espacio de célula.
+        const fs = `
+          precision highp float;
+          varying vec2 vUV;
+          uniform vec3  uInk, uBg;
+          uniform vec2  uSize;    // (ancho, alto) pared en unidades de escena
+          uniform float uCell;    // tamaño de celda en unidades físicas
+          uniform float uLineF;   // grosor relativo (0..1) respecto a la celda
+          uniform float uRot;     // rotación global
+          uniform float uAff;     // afinidad (estira eje x del haz)
+          uniform vec4  uW;       // pesos 0..3
+          uniform float uW4;      // peso 4
+
+          mat2 rot(float a){ float c=cos(a), s=sin(a); return mat2(c,-s,s,c); }
+
+          // distancia “firmada” a línea horizontal periódica (en coords de célula)
+          float lineAA(float y, float frac){
+            // grosor en píxeles = frac * fwidth(y) * escala (ajuste generoso)
+            float w = max(1.0/255.0, frac * fwidth(y) * 1.5);
+            float d = abs(y);
+            return smoothstep(w, 0.0, d);
+          }
+
+          float starRaster(vec2 p){
+            // p en unidades de CELDA (ya dividido por uCell fuera)
+            // 5 haces rotados 72°; cada haz con x estirado por uAff.
+            float A = 3.141592653589793 / 5.0; // 36°
+            float acc = 0.0;
+            float W[5];
+            W[0]=uW.x; W[1]=uW.y; W[2]=uW.z; W[3]=uW.w; W[4]=uW4;
+
+            for (int i=0;i<5;i++){
+              float ang = float(i) * 2.0 * A;
+              vec2 q = rot(ang) * p;
+              q.x *= uAff; // afinidad desplaza el cierre de pentágonos
+              // coordenada periódica en X: una “línea” cada 1.0 de celda
+              // centramos el trazo en múltiplos de 1.0
+              float u = q.x - round(q.x);
+              float g = lineAA(u, uLineF) * W[i];
+              acc = max(acc, g);
+            }
+            return acc;
+          }
+
+          void main(){
+            // pasa a coordenadas físicas (centro = 0)
+            vec2 p = (vUV - 0.5) * uSize;   // “metros”
+            // aplica rotación global
+            p = rot(uRot) * p;
+            // normaliza a CELDAS
+            p /= uCell;
+
+            float g = starRaster(p);
+
+            vec3 col = mix(uBg, uInk, g);
+            gl_FragColor = vec4(col, 1.0);
+          }
+        `;
+
+        return new THREE.ShaderMaterial({
+          uniforms, vertexShader:vs, fragmentShader:fs,
+          transparent:false, depthTest:true, depthWrite:false, dithering:false
+        });
+      }
+
+      window.makeParkettMaterial = makeParkettMaterial;
     })();
 
 
@@ -5695,9 +5813,9 @@ void main(){
 
         // ——— paredes blancas (Lambert) ———
         function lambertWhite(){
-          const m = new THREE.MeshLambertMaterial({ color: 0xffffff, dithering: true });
-          m.emissive = new THREE.Color(0xffffff);
-          m.emissiveIntensity = 0.08;
+          const m = new THREE.MeshLambertMaterial({ color: 0xFFFFFF, dithering: true });
+          m.emissive = new THREE.Color(0xFFFFFF);
+          m.emissiveIntensity = 0.03;
           return m;
         }
 
@@ -5720,40 +5838,57 @@ void main(){
 
         raumGroup.add(left, right, floor, ceil, back);
 
-        // ——— RASTER PLANES (cinco) con tamaño INTERIOR correcto ———
-        const rasterMat = makeParkettMaterial(0);            // left
-        const rasterMatR = makeParkettMaterial(1);           // right
-        const rasterMatF = makeParkettMaterial(2);           // floor
-        const rasterMatC = makeParkettMaterial(3);           // ceil
-        const rasterMatB = makeParkettMaterial(4);           // back
+        // ——— RASTER PLANES (cinco) usando tamaño físico ———
+        const EPS = 0.001;           // separación del muro real
+        const OVER = 1.004;          // sobre-escala suave para cubrir esquinas
 
-        const EPS = 0.001; // separa el plano del muro hacia el interior
+        // tamaños interiores
+        const sizeLeftU = D - 2*0;   // u=Z   (profundidad)
+        const sizeLeftV = H - 2*0;   // v=Y   (alto)
+        const sizeRightU = sizeLeftU, sizeRightV = sizeLeftV;
+        const sizeFloorU = W - 2*g,  sizeFloorV = D;
+        const sizeCeilU  = W - 2*g,  sizeCeilV  = D;
+        const sizeBackU  = W - 2*g,  sizeBackV  = H - 2*g;
 
-        // izquierda (YZ): tamaño = H × D
-        const pLeft = new THREE.Mesh(new THREE.PlaneGeometry(D, H),  rasterMat);
+        // materiales por pared (deterministas pero con variación leve)
+        const mLeft  = makeParkettMaterial(0, sizeLeftU,  sizeLeftV);
+        const mRight = makeParkettMaterial(1, sizeRightU, sizeRightV);
+        const mFloor = makeParkettMaterial(2, sizeFloorU, sizeFloorV);
+        const mCeil  = makeParkettMaterial(3, sizeCeilU,  sizeCeilV);
+        const mBack  = makeParkettMaterial(4, sizeBackU,  sizeBackV);
+
+        // Geometrías con OVER para que no “queden huecos” en esquinas
+        const geoLeft  = new THREE.PlaneGeometry(D*OVER, H*OVER);
+        const geoRight = new THREE.PlaneGeometry(D*OVER, H*OVER);
+        const geoFloor = new THREE.PlaneGeometry(Wi*OVER, D*OVER);
+        const geoCeil  = new THREE.PlaneGeometry(Wi*OVER, D*OVER);
+        const geoBack  = new THREE.PlaneGeometry(Wi*OVER, Hi*OVER);
+
+        // izquierda (YZ)
+        const pLeft = new THREE.Mesh(geoLeft, mLeft);
         pLeft.position.set(-W/2 + g + EPS, 0, 0);
         pLeft.rotation.y = Math.PI/2;
 
-        // derecha (YZ): tamaño = H × D
-        const pRight = new THREE.Mesh(new THREE.PlaneGeometry(D, H),  rasterMatR.clone());
-        pRight.position.set(W/2 - g - EPS, 0, 0);
+        // derecha (YZ)
+        const pRight = new THREE.Mesh(geoRight, mRight);
+        pRight.position.set( W/2 - g - EPS, 0, 0);
         pRight.rotation.y = -Math.PI/2;
 
-        // piso (XZ): tamaño = W_i × D
-        const pFloor = new THREE.Mesh(new THREE.PlaneGeometry(Wi, D), rasterMatF.clone());
+        // piso (XZ)
+        const pFloor = new THREE.Mesh(geoFloor, mFloor);
         pFloor.position.set(0, -H/2 + g + EPS, 0);
         pFloor.rotation.x = -Math.PI/2;
 
-        // techo (XZ): tamaño = W_i × D
-        const pCeil = new THREE.Mesh(new THREE.PlaneGeometry(Wi, D),  rasterMatC.clone());
-        pCeil.position.set(0, H/2 - g - EPS, 0);
-        pCeil.rotation.x = Math.PI/2;
+        // techo (XZ)
+        const pCeil = new THREE.Mesh(geoCeil, mCeil);
+        pCeil.position.set(0,  H/2 - g - EPS, 0);
+        pCeil.rotation.x =  Math.PI/2;
 
-        // fondo (XY): tamaño = W_i × H_i
-        const pBack = new THREE.Mesh(new THREE.PlaneGeometry(Wi, Hi), rasterMatB.clone());
+        // fondo (XY)
+        const pBack = new THREE.Mesh(geoBack, mBack);
         pBack.position.set(0, 0, -D/2 + g + EPS);
 
-        // añade todos los planos al grupo
+        // añade al grupo
         raumGroup.add(pLeft, pRight, pFloor, pCeil, pBack);
         pLeft.renderOrder = pRight.renderOrder = pFloor.renderOrder = pCeil.renderOrder = pBack.renderOrder = 10;
 


### PR DESCRIPTION
## Summary
- replace the canvas-based parkett material with a shader that works in physical units, includes 15 weighted line families, and scales to wall size
- update RAUM wall construction to pass physical dimensions to the material and oversize the planes to hide seams while tweaking the white lambert material contrast

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d45f0b1f90832c956e6a19c6e13325