### PR TITLE
Replace LCHT scaffolding with Cornsweet plane

### DIFF
--- a/index.html
+++ b/index.html
@@ -1089,171 +1089,119 @@ function initSkySphere() {
         : new THREE.Color(val);
     }
 
-    /* ═════════ LCHT “cubos-de-tubos” (Sol LeWitt) ═════════════════ */
+    /* ───────── Helpers LCHT · Cornsweet ───────── */
 
-function tubeKey(x1, y1, z1, x2, y2, z2) {
-  const a = `${x1},${y1},${z1}`;
-  const b = `${x2},${y2},${z2}`;
-  return (a < b) ? `${a}|${b}` : `${b}|${a}`;
-}
-
-function buildLCHT() {
-  /* ── limpiar escena previa ─────────────────────────────── */
-  if (lichtGroup) {
-    lichtGroup.traverse(o => { if (o.isMesh) { o.geometry.dispose(); o.material.dispose(); } });
-    scene.remove(lichtGroup);
-  }
-  lichtGroup = new THREE.Group();
-  scene.add(lichtGroup);
-
-  // Mantén el fondo sincronizado con el sistema (marco + apertura)
-  updateBackground(false);
-
-  // === Recoger permutaciones activas (determinismo de escena) ===
-  const perms = Array.from(document.getElementById('permutationList').selectedOptions)
-                     .map(o => o.value.split(',').map(Number));
-
-  // Suficiente para que el motor funcione con 0..n perms
-  const ranks = perms.map(p => lehmerRank(p));
-  const sumR  = ranks.reduce((a,b)=>a+b, 0);
-  const sumR2 = ranks.reduce((a,b)=>a+b*b, 0);
-  const minP  = perms.length ? perms.slice().sort((A,B)=> {
-                  for (let i=0;i<5;i++){ if (A[i]!==B[i]) return A[i]-B[i]; }
-                  return 0;
-                })[0] : [1,2,3,4,5];
-  const mRank = lehmerRank(minP);
-
-  // Paleta base determinista (3 matices relacionados)
-  // 144 pasos de H (como BUILD). mapeo fijo → 0..1 en shader.
-  const H0i = ( (37*sumR + 13*mRank + sceneSeed) % 144 );
-  const H1i = ( (H0i + 41) % 144 );  // desplazamientos fijos y coprimos
-  const H2i = ( (H0i + 89) % 144 );
-
-  const H0  = H0i / 144.0;
-  const H1  = H1i / 144.0;
-  const H2  = H2i / 144.0;
-
-  // Saturación/valor base (grid discreto como BUILD)
-  const slot = ( (sumR + sumR2 + mRank + sceneSeed) % 12 );
-  const Sidx = (slot * 5) % 12;
-  const Vidx = (slot * 7) % 12;
-  const S0   = 0.25 + 0.72 * (Sidx / 11.0);
-  const V0   = 0.20 + 0.75 * (Vidx / 11.0);
-
-  // Dirección del gradiente interno (diagonal) y torsión suave
-  const theta = ((53*sumR2 + 17*mRank + S_global) % 360) * (Math.PI/180);
-  const dir   = new THREE.Vector2(Math.cos(theta), Math.sin(theta));
-
-  // Intensidades Cornsweet/vineta deterministas a partir del rango medio
-  const rgs = perms.map(p => computeRange(computeSignature(p)));
-  const avgRange = rgs.length ? (rgs.reduce((a,b)=>a+b,0)/rgs.length) : 0.5;
-
-  const edgeLift    = 0.10 + 0.25 * avgRange;    // cuánto “sube” justo dentro del borde
-  const edgeFall    = 0.12 + 0.28 * avgRange;    // cuánto “cae” en el borde extremo
-  const edgeWidth   = 0.045 + 0.035 * ((sceneSeed + sumR) % 7) / 6.0; // 0.045..0.08
-  const vignStrength= 0.25 + 0.35 * ((S_global + mRank) % 9) / 8.0;   // 0.25..0.60
-  const vignSoft    = 0.7;                         // suavidad fija (buena perceptualmente)
-
-  // === Geometría: un plano dentro del vano (apertura) ===
-  const inner = cubeSize * 0.86;                   // encaja con el marco existente
-  const planeGeo = new THREE.PlaneGeometry(inner, inner, 1, 1);
-
-  // === Shader Cornsweet + campo cromático ===
-  const planeMat = new THREE.ShaderMaterial({
-    uniforms: {
-      uH0: { value: H0 }, uH1: { value: H1 }, uH2: { value: H2 },
-      uS:  { value: S0 }, uV:  { value: V0 },
-      uDir:{ value: new THREE.Vector2(dir.x, dir.y) },
-      uEdgeWidth:    { value: edgeWidth },
-      uEdgeLift:     { value: edgeLift },
-      uEdgeFall:     { value: edgeFall },
-      uVignette:     { value: vignStrength },
-      uVignSoft:     { value: vignSoft }
-    },
-    vertexShader: `
-      varying vec2 vUv;
-      void main(){
-        vUv = uv;
-        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    /* HSV helpers usando las mismas utilidades globales rgbToHsv/hsvToRgb */
+    function __hsvFromTHREE(c){
+      const [h,s,v] = rgbToHsv(c.r*255, c.g*255, c.b*255);
+      return { h, s, v };
+    }
+    function __rgbFromHSV(h,s,v){
+      const [r,g,b] = hsvToRgb(h,s,v);
+      return new THREE.Color(r/255, g/255, b/255);
+    }
+    /* media de H (circular) + S,V (aritmética) */
+    function __avgHSV(colors){
+      if (!colors.length) return { h:0, s:0, v:0.5 };
+      let sx=0, sy=0, ss=0, sv=0;
+      for (let i=0;i<colors.length;i++){
+        const [h,s,v] = rgbToHsv(colors[i].r*255, colors[i].g*255, colors[i].b*255);
+        const a = h/360 * Math.PI*2;
+        sx += Math.cos(a); sy += Math.sin(a);
+        ss += s; sv += v;
       }
-    `,
-    fragmentShader: `
-      precision highp float;
-      varying vec2 vUv;
+      let ang = Math.atan2(sy, sx) / (Math.PI*2) * 360;
+      if (ang < 0) ang += 360;
+      return { h: ang, s: ss/colors.length, v: sv/colors.length };
+    }
 
-      uniform float uH0, uH1, uH2;
-      uniform float uS, uV;
-      uniform vec2  uDir;
-      uniform float uEdgeWidth, uEdgeLift, uEdgeFall;
-      uniform float uVignette, uVignSoft;
+    /* Genera un texture “Cornsweet” determinista en Canvas (lineal, no radial)
+       - orientation: 'vertical' (borde en X) o 'horizontal' (borde en Y)
+       - amp: amplitud en ΔV (0..1)
+       - decayPx: decaimiento exponencial (px)
+       - offsetNorm: desplazamiento del borde (−0.5..+0.5 → usamos ±0.25 interno)
+       - invert: invierte claro/oscuro a ambos lados
+    */
+    function __makeCornsweetTexture(size, baseHSV, orientation, amp, decayPx, offsetNorm, invert){
+      const cvs = document.createElement('canvas');
+      cvs.width = size; cvs.height = size;
+      const ctx = cvs.getContext('2d', { willReadFrequently: true });
+      const img = ctx.createImageData(size, size);
 
-      // HSV → RGB
-      vec3 hsv2rgb(vec3 c){
-        vec3 K = vec3(1.0, 2.0/3.0, 1.0/3.0);
-        vec3 p = abs(fract(vec3(c.x) + K.xyz) * 6.0 - 3.0);
-        vec3 rgb = c.z * mix(vec3(1.0), clamp(p - 1.0, 0.0, 1.0), c.y);
-        return rgb;
+      const cx = size*0.5 + offsetNorm * size * 0.25;
+      const cy = size*0.5 + offsetNorm * size * 0.25;
+      const sign = invert ? -1 : 1;
+
+      for (let y=0; y<size; y++){
+        for (let x=0; x<size; x++){
+          const d = (orientation === 'vertical') ? (x - cx) : (y - cy); // distancia al borde
+          const side = (d <= 0 ? 1 : -1) * sign;                        // lado claro/oscuro
+          const delta = amp * Math.exp(-Math.abs(d) / Math.max(1, decayPx)) * side; // ΔV
+          const v = Math.min(1, Math.max(0, baseHSV.v + delta));
+          const rgb = hsvToRgb(baseHSV.h, baseHSV.s, v);
+          const k = (y*size + x) * 4;
+          img.data[k  ] = rgb[0];
+          img.data[k+1] = rgb[1];
+          img.data[k+2] = rgb[2];
+          img.data[k+3] = 255;
+        }
       }
+      ctx.putImageData(img, 0, 0);
+      const tex = new THREE.CanvasTexture(cvs);
+      tex.minFilter = THREE.LinearFilter;
+      tex.magFilter = THREE.LinearFilter;
+      tex.needsUpdate = true;
+      return tex;
+    }
 
-      void main(){
-        // Coordenadas centradas
-        vec2 uv = vUv;
-        vec2 c  = uv - 0.5;
-
-        // === Gradiente interno (no geométrico) entre 3 matices ===
-        float g1 = 0.5 + 0.5 * dot(normalize(uDir), normalize(c));
-        float g2 = 0.5 + 0.5 * dot(normalize(vec2(-uDir.y, uDir.x)), normalize(c));
-        g1 = clamp(g1, 0.0, 1.0);
-        g2 = clamp(g2, 0.0, 1.0);
-
-        // Tri-blend: H0 ↔ H1 ↔ H2
-        float w0 = (1.0 - g1) * (1.0 - 0.35*g2);
-        float w1 = g1 * (1.0 - 0.35*(1.0-g2));
-        float w2 = 0.35 * g2;
-        float W  = max(1e-5, (w0 + w1 + w2));
-        w0 /= W; w1 /= W; w2 /= W;
-
-        float H = fract(uH0*w0 + uH1*w1 + uH2*w2);
-        float S = uS;
-        float V = uV;
-
-        vec3 base = hsv2rgb(vec3(H, S, V));
-
-        // === Vineta sutil para convertir plano en “atmósfera” ===
-        float dEdge = min(min(uv.x, 1.0-uv.x), min(uv.y, 1.0-uv.y)); // dist a bordes
-        float vig   = smoothstep(0.0, uVignSoft, dEdge);              // 0 en borde → 1 interior
-        base *= mix(1.0 - uVignette, 1.0, vig);
-
-        // === Banda Cornsweet: oscuro en el extremo + claro inmediatamente dentro ===
-        float w = uEdgeWidth;
-        // “franjas” usando dos smoothstep encadenados
-        float ringDark  = 1.0 - smoothstep(w, w*2.0, dEdge);                 // cae en el borde
-        float ringLift  = smoothstep(w*1.2, w*2.4, dEdge) *
-                          (1.0 - smoothstep(w*2.4, w*3.6, dEdge));           // sube justo dentro
-
-        vec3 col = base;
-        col *= (1.0 - uEdgeFall * ringDark);
-        col *= (1.0 + uEdgeLift * ringLift);
-
-        // clamp leve para evitar “quemados”
-        col = clamp(col, 0.0, 1.0);
-        gl_FragColor = vec4(col, 1.0);
+    function buildLCHT() {
+      // — limpiar escena previa
+      if (lichtGroup) {
+        lichtGroup.traverse(o => { if (o.isMesh) { o.geometry.dispose(); o.material.dispose(); } });
+        scene.remove(lichtGroup);
       }
-    `,
-    depthWrite: false,
-    depthTest: false,
-    transparent: false,
-    side: THREE.DoubleSide
-  });
+      lichtGroup = new THREE.Group();
+      scene.add(lichtGroup);
 
-  const plane = new THREE.Mesh(planeGeo, planeMat);
-  plane.position.set(0, 0, -cubeSize * 0.001); // un pelo hacia atrás para que no z-flickee con el plano de fondo
-  lichtGroup.add(plane);
+      // — recogemos las permutaciones activas (respeta 11 patrones vía getColor)
+      const perms = Array.from(document.getElementById('permutationList').selectedOptions)
+                         .map(o => o.value.split(',').map(Number));
 
-  // Evitar culling si luego movemos cámara o marco
-  lichtGroup.traverse(o => { o.frustumCulled = false; });
-}
-/* ════════════════════════════════════════════════════════════ */
+      // — determinismo de escena (ancla cromática y parámetros)
+      const withRanks = perms.map(p => ({ p, r: lehmerRank(p) }));
+      withRanks.sort((a,b) => a.r - b.r);
+      const anchor = (withRanks.length ? withRanks[0].p : [1,2,3,4,5]);
+
+      // rango (0..1 aprox) para escalar amplitud (usa misma lógica del sistema)
+      const rng = computeRange(computeSignature(anchor));
+
+      // color base = media HSV de los colores deterministas de las perms
+      const cols = perms.length ? perms.map(colorForPerm)
+                                : [ new THREE.Color(getColor(3)) ]; // fallback determinista
+      const baseHSV = __avgHSV(cols);
+
+      // parámetros deterministas (solo de estructura; nada aleatorio)
+      const sumR = withRanks.reduce((a,x)=>a+x.r,0);
+      const dir      = ((sumR + sceneSeed + S_global) % 2) ? 'vertical'   : 'horizontal';
+      const invert   = ((sumR ^ sceneSeed) & 1) === 1;
+      const amp      = 0.08 + 0.10 * rng;          // ΔV de la ilusión (claro/oscuro)
+      const decayPx  = 48 + Math.floor(80 * rng);  // extensión del halo
+      const offsetNm = (((sceneSeed * 13 + sumR) % 101) / 100) - 0.5; // −0.5..+0.5
+
+      // textura Cornsweet (lineal, no radial) → “horizonte existencial”
+      const TEX_SIZE = 768;
+      const tex = __makeCornsweetTexture(TEX_SIZE, baseHSV, dir, amp, decayPx, offsetNm, invert);
+
+      // plano único en el fondo de la “apertura” (mínimo gesto arquitectónico)
+      const planeSize = cubeSize * 0.86;                 // deja reborde para el marco
+      const geo  = new THREE.PlaneGeometry(planeSize, planeSize);
+      const mat  = new THREE.MeshBasicMaterial({ map: tex, toneMapped: false });
+      const pane = new THREE.Mesh(geo, mat);
+
+      // sitúa el plano en el fondo de la caja (detrás del vano)
+      pane.position.set(0, 0, -halfCube + 0.001);
+      lichtGroup.add(pane);
+    }
 
 
     function toggleLCHT(){


### PR DESCRIPTION
## Summary
- replace the legacy LCHT tube helpers with HSV-based Cornsweet helpers
- rebuild `buildLCHT` to render a deterministic Cornsweet plane based on selected permutation colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d852df86b0832caa94595db49caed2