### PR TITLE
Protect LCHT build and adjust camera framing

### DIFF
--- a/index.html
+++ b/index.html
@@ -1147,133 +1147,148 @@ function makeCornsweetMaterial(colA, colB, hard, over, vertical){
 
 /* ═════════ buildLCHT: cuarto Cornsweet determinista ════════════════ */
 function buildLCHT(){
-  // limpiar escena previa
-  if (lichtGroup) {
-    lichtGroup.traverse(o => {
-      if (o.isMesh || o.isGroup) {
-        if (o.material && o.material.dispose) o.material.dispose();
-        if (o.geometry && o.geometry.dispose) o.geometry.dispose();
-      }
-    });
-    scene.remove(lichtGroup);
+  try {
+    // limpiar escena previa
+    if (lichtGroup) {
+      lichtGroup.traverse(o => {
+        if (o.isMesh || o.isGroup) {
+          if (o.material && o.material.dispose) o.material.dispose();
+          if (o.geometry && o.geometry.dispose) o.geometry.dispose();
+        }
+      });
+      scene.remove(lichtGroup);
+    }
+    lichtGroup = new THREE.Group();
+    scene.add(lichtGroup);
+
+    // ——— ESCALA CORRECTA (mismo sistema físico que el vano) ———
+    const UNIT = cubeSize / 5;
+    const SIZE = cubeSize * UNIT;
+    const INNER = SIZE * 0.88;
+    const STRIP = INNER * 0.22;
+    const RIM   = INNER * 0.012;
+    const DEPTH = 0.0;
+
+    // —— permutaciones activas (determinismo cromático) ——
+    const perms = Array.from(document.getElementById('permutationList').selectedOptions)
+                       .map(o => o.value.split(',').map(Number));
+    if (!perms.length) {
+      // registra un root vacío para que WW Tuning no se queje
+      if (typeof registerEngineRoot === 'function') registerEngineRoot('LCHT', lichtGroup);
+      return;
+    }
+
+    const baseCol = colorForPerm(perms[0]).clone();
+    const [h0, s0, v0] = rgbToHsv(baseCol.r*255, baseCol.g*255, baseCol.b*255);
+    const sc  = (sceneSeed + S_global + lehmerRank(perms[0])) % 360;
+    const h1  = ((h0*360 + 24 + (sc % 67)) % 360) / 360;
+    const s1  = Math.min(1, s0 * 1.06);
+    const v1  = Math.min(1, v0 * 1.08);
+    let rgb2  = hsvToRgb(h1, s1, v1);
+    rgb2      = ensureContrastRGB(rgb2);
+    const colB = new THREE.Color(rgb2[0]/255, rgb2[1]/255, rgb2[2]/255);
+
+    const HARD = 0.72, OVER = 0.80;
+    const matVert = makeCornsweetMaterial(baseCol, colB, HARD, OVER, true);
+    const matHorz = makeCornsweetMaterial(baseCol, colB, HARD, OVER, false);
+
+    // — Fondo (hueco)
+    const bgGeom = new THREE.PlaneGeometry(INNER, INNER);
+    const bgMat  = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
+    const bg     = new THREE.Mesh(bgGeom, bgMat);
+    bg.position.set(0,0,DEPTH - 0.1);
+    lichtGroup.add(bg);
+
+    // — Rim negro (4 tiras, sin texturas)
+    const rimH = new THREE.PlaneGeometry(INNER, RIM);
+    const rimV = new THREE.PlaneGeometry(RIM, INNER);
+    const rimM = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
+    const rTop = new THREE.Mesh(rimH, rimM); rTop.position.set(0,  INNER/2 - RIM/2, DEPTH - 0.05);
+    const rBot = new THREE.Mesh(rimH, rimM); rBot.position.set(0, -INNER/2 + RIM/2, DEPTH - 0.05);
+    const rLft = new THREE.Mesh(rimV, rimM); rLft.position.set(-INNER/2 + RIM/2, 0, DEPTH - 0.05);
+    const rRgt = new THREE.Mesh(rimV, rimM); rRgt.position.set( INNER/2 - RIM/2, 0, DEPTH - 0.05);
+    lichtGroup.add(rTop, rBot, rLft, rRgt);
+
+    // — Cuatro franjas Cornsweet
+    const gLeft   = new THREE.PlaneGeometry(STRIP, INNER);
+    const gRight  = new THREE.PlaneGeometry(STRIP, INNER);
+    const gTop    = new THREE.PlaneGeometry(INNER, STRIP);
+    const gBottom = new THREE.PlaneGeometry(INNER, STRIP);
+    const left  = new THREE.Mesh(gLeft,  matVert);
+    const right = new THREE.Mesh(gRight, matVert);
+    const top   = new THREE.Mesh(gTop,   matHorz);
+    const bot   = new THREE.Mesh(gBottom,matHorz);
+    left.position.set(-INNER/2 + STRIP/2, 0, DEPTH);
+    right.position.set( INNER/2 - STRIP/2, 0, DEPTH);
+    top.position.set(0,  INNER/2 - STRIP/2, DEPTH);
+    bot.position.set(0, -INNER/2 + STRIP/2, DEPTH);
+    lichtGroup.add(left, right, top, bot);
+
+    // — Asimetría determinista (cielo/suelo)
+    const rgs   = perms.map(p => computeRange(computeSignature(p)));
+    const avgR  = rgs.reduce((a,b)=>a+b,0) / (rgs.length||1);
+    const tintK = ((Math.round(avgR*7 + sceneSeed) % 360) / 360);
+    function tintMat(m, delta){
+      const ca = m.uniforms.uColorA.value, cb = m.uniforms.uColorB.value;
+      let ha = rgbToHsv(ca.r*255, ca.g*255, ca.b*255);
+      let hb = rgbToHsv(cb.r*255, cb.g*255, cb.b*255);
+      ha[0] = (ha[0] + delta) % 1;  hb[0] = (hb[0] + delta) % 1;
+      const ra = hsvToRgb(ha[0], ha[1], ha[2]);
+      const rb = hsvToRgb(hb[0], hb[1], hb[2]);
+      m.uniforms.uColorA.value.setRGB(ra[0]/255, ra[1]/255, ra[2]/255);
+      m.uniforms.uColorB.value.setRGB(rb[0]/255, rb[1]/255, rb[2]/255);
+    }
+    tintMat(top.material,  +tintK*0.06);
+    tintMat(bot.material,  -tintK*0.05);
+
+    // — Respiración sutil (determinista)
+    const phase = ((sceneSeed*13 + S_global*31) % 360) * (Math.PI/180);
+    lichtGroup.userData.animate = function(time){
+      const k = 0.004;
+      const s = 1.0 + k*Math.sin(time*0.35 + phase);
+      left.scale.y = right.scale.y = top.scale.x = bot.scale.x = s;
+    };
+
+    // evita culling
+    lichtGroup.traverse(o => { o.frustumCulled = false; });
+
+    // **Registro para WW Tuning / Minimal UI**
+    if (typeof registerEngineRoot === 'function') {
+      registerEngineRoot('LCHT', lichtGroup);
+    }
+
+  } catch(e){
+    console.error('[LCHT] build error:', e);
+    // no romper el boot ni el Minimal UI
+    try { if (lichtGroup) scene.remove(lichtGroup); } catch(_){ }
   }
-  lichtGroup = new THREE.Group();
-  scene.add(lichtGroup);
-
-  /* ——— ESCALA CORRECTA (mismo sistema físico que el vano) ———
-     En la escena, 1 “celda” = cubeSize/5 unidades físicas.
-     El vano que ves al frente ocupa el cuadrado interno de ese cubo.
-     Por eso construimos el cuarto en unidades físicas (× UNIT). */
-  const UNIT = cubeSize / 5;         // p.ej. 6 si cubeSize=30
-  const SIZE = cubeSize * UNIT;      // tamaño físico total del cubo (p.ej. 180)
-  const INNER = SIZE * 0.88;         // lado útil del hueco (≈ 88% del vano)
-  const STRIP = INNER * 0.22;        // grosor de cada franja Cornsweet
-  const RIM   = INNER * 0.012;       // rim negro muy fino
-  const DEPTH = 0.0;                 // en el plano del hueco
-
-  // —— conjunto de permutaciones activas (determinismo cromático) ——
-  const perms = Array.from(document.getElementById('permutationList').selectedOptions)
-                     .map(o => o.value.split(',').map(Number));
-  if (!perms.length) return;
-
-  // Color base (patrón cromático del sistema)
-  const baseCol = colorForPerm(perms[0]).clone();
-
-  // Segundo color: giro determinista del H a partir de sceneSeed/S_global/lehmerRank
-  const [h0, s0, v0] = rgbToHsv(baseCol.r*255, baseCol.g*255, baseCol.b*255);
-  const sc  = (sceneSeed + S_global + lehmerRank(perms[0])) % 360; // fijo
-  const h1  = ((h0*360 + 24 + (sc % 67)) % 360) / 360;             // despl. 24..90°
-  const s1  = Math.min(1, s0 * 1.06);
-  const v1  = Math.min(1, v0 * 1.08);
-  let rgb2  = hsvToRgb(h1, s1, v1);
-  rgb2      = ensureContrastRGB(rgb2); // mantiene ΔE con el fondo del proyecto
-  const colB = new THREE.Color(rgb2[0]/255, rgb2[1]/255, rgb2[2]/255);
-
-  // Materiales Cornsweet (vertical/horizontal)
-  const HARD = 0.72;     // borde bastante duro
-  const OVER = 0.80;     // amplitud del efecto
-  const matVert = makeCornsweetMaterial(baseCol, colB, HARD, OVER, true);
-  const matHorz = makeCornsweetMaterial(baseCol, colB, HARD, OVER, false);
-
-  // — Fondo “hueco” (oscuro) para reforzar profundidad —
-  const bgGeom = new THREE.PlaneGeometry(INNER, INNER);
-  const bgMat  = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
-  const bg     = new THREE.Mesh(bgGeom, bgMat);
-  bg.position.set(0,0,DEPTH - 0.1);
-  lichtGroup.add(bg);
-
-  // — Rim negro cuadrado muy fino (sin texturas, 4 tiras) —
-  const rimH = new THREE.PlaneGeometry(INNER, RIM);
-  const rimV = new THREE.PlaneGeometry(RIM, INNER);
-  const rimM = new THREE.MeshBasicMaterial({ color: 0x000000, side: THREE.DoubleSide });
-
-  const rTop = new THREE.Mesh(rimH, rimM);
-  rTop.position.set(0,  INNER/2 - RIM/2, DEPTH - 0.05);
-  const rBot = new THREE.Mesh(rimH, rimM);
-  rBot.position.set(0, -INNER/2 + RIM/2, DEPTH - 0.05);
-  const rLft = new THREE.Mesh(rimV, rimM);
-  rLft.position.set(-INNER/2 + RIM/2, 0, DEPTH - 0.05);
-  const rRgt = new THREE.Mesh(rimV, rimM);
-  rRgt.position.set( INNER/2 - RIM/2, 0, DEPTH - 0.05);
-  lichtGroup.add(rTop, rBot, rLft, rRgt);
-
-  // — Cuatro franjas Cornsweet (paredes/techo/suelo) —
-  const gLeft   = new THREE.PlaneGeometry(STRIP, INNER);
-  const gRight  = new THREE.PlaneGeometry(STRIP, INNER);
-  const gTop    = new THREE.PlaneGeometry(INNER, STRIP);
-  const gBottom = new THREE.PlaneGeometry(INNER, STRIP);
-
-  const left  = new THREE.Mesh(gLeft,  matVert);
-  const right = new THREE.Mesh(gRight, matVert);
-  const top   = new THREE.Mesh(gTop,   matHorz);
-  const bot   = new THREE.Mesh(gBottom,matHorz);
-
-  left.position.set(-INNER/2 + STRIP/2, 0, DEPTH);
-  right.position.set( INNER/2 - STRIP/2, 0, DEPTH);
-  top.position.set(0,  INNER/2 - STRIP/2, DEPTH);
-  bot.position.set(0, -INNER/2 + STRIP/2, DEPTH);
-
-  lichtGroup.add(left, right, top, bot);
-
-  // — Orientación existencial mínima (ligera asimetría determinista) —
-  const rgs   = perms.map(p => computeRange(computeSignature(p)));
-  const avgR  = rgs.reduce((a,b)=>a+b,0) / (rgs.length||1);
-  const tintK = ((Math.round(avgR*7 + sceneSeed) % 360) / 360);
-
-  function tintMat(m, delta){
-    const ca = m.uniforms.uColorA.value, cb = m.uniforms.uColorB.value;
-    let ha = rgbToHsv(ca.r*255, ca.g*255, ca.b*255);
-    let hb = rgbToHsv(cb.r*255, cb.g*255, cb.b*255);
-    ha[0] = (ha[0] + delta) % 1;  hb[0] = (hb[0] + delta) % 1;
-    const ra = hsvToRgb(ha[0], ha[1], ha[2]);
-    const rb = hsvToRgb(hb[0], hb[1], hb[2]);
-    m.uniforms.uColorA.value.setRGB(ra[0]/255, ra[1]/255, ra[2]/255);
-    m.uniforms.uColorB.value.setRGB(rb[0]/255, rb[1]/255, rb[2]/255);
-  }
-  tintMat(top.material,  +tintK*0.06);   // leve “cielo”
-  tintMat(bot.material,  -tintK*0.05);   // leve “suelo”
-
-  // — Respiración sutil (determinista; sin PRNG) —
-  const phase = ((sceneSeed*13 + S_global*31) % 360) * (Math.PI/180);
-  lichtGroup.userData.animate = function(time){
-    const k = 0.004;
-    const s = 1.0 + k*Math.sin(time*0.35 + phase);
-    left.scale.y = right.scale.y = top.scale.x = bot.scale.x = s;
-  };
-
-  // Nada fuera de frustum (rinde perfecto al hacer zoom)
-  lichtGroup.traverse(o => { o.frustumCulled = false; });
 }
 
-/* Cámara frontal para LCHT (encuadre estable y cercano) */
+// Encadra el vano Cornsweet en pantalla sin “z” gigantes ni conflictos
 function setCamera_LCHT(){
-  controls.enabled = false;
-  camera.position.set(0, 0, 2.2 * (cubeSize * (cubeSize/5))); // ≈ 2.2 * SIZE
+  // tamaño objetivo = 88% del vano del cubo convertido a unidades físicas
+  const UNIT  = cubeSize / 5;
+  const SIZE  = cubeSize * UNIT;
+  const INNER = SIZE * 0.88;
+
+  // fov estable y distancia calculada para que quepa el cuadro INNER con margen
+  const fovDeg = 28;
+  camera.fov = fovDeg;
+  const fovRad = THREE.MathUtils.degToRad(fovDeg);
+  const height = INNER * 1.08;                   // +8% de margen
+  const dist   = (height/2) / Math.tan(fovRad/2);
+
+  camera.position.set(0, 0, dist);
   camera.lookAt(0,0,0);
-  camera.fov = 28;                         // más cerrado para llenar pantalla
-  camera.near = 0.1;
-  camera.far  = 10000;
+  camera.near = Math.max(0.1, dist * 0.02);
+  camera.far  = dist * 50;
   camera.updateProjectionMatrix();
+
+  // controles bloqueados en LCHT (pero no toques flags globales)
+  if (controls) {
+    controls.enabled = false;
+    controls.update && controls.update();
+  }
 }
     /* ============================================================
        CAMERAS · definición independiente por motor (fuente única)
@@ -1297,20 +1312,25 @@ function setCamera_LCHT(){
     }
 
     function setCamera_LCHT(){
-      camera.up.set(0,1,0);
-      camera.near = 0.1; camera.far = 4000;
-      camera.fov = 75; camera.updateProjectionMatrix();
-      if (controls && controls.target) controls.target.set(0, 0, 0);
-      camera.position.set(0, 0, 130);
-      if (controls){
-        controls.enabled = true;
-        controls.enableRotate = true;
-        controls.enablePan    = true;
-        controls.enableZoom   = true;
-        controls.minPolarAngle = 0;
-        controls.maxPolarAngle = Math.PI;
-        controls.screenSpacePanning = false;
-        controls.update();
+      const UNIT  = cubeSize / 5;
+      const SIZE  = cubeSize * UNIT;
+      const INNER = SIZE * 0.88;
+
+      const fovDeg = 28;
+      camera.fov = fovDeg;
+      const fovRad = THREE.MathUtils.degToRad(fovDeg);
+      const height = INNER * 1.08;
+      const dist   = (height/2) / Math.tan(fovRad/2);
+
+      camera.position.set(0, 0, dist);
+      camera.lookAt(0,0,0);
+      camera.near = Math.max(0.1, dist * 0.02);
+      camera.far  = dist * 50;
+      camera.updateProjectionMatrix();
+
+      if (controls) {
+        controls.enabled = false;
+        controls.update && controls.update();
       }
     }
 


### PR DESCRIPTION
## Summary
- wrap `buildLCHT` in a guarded try/catch, cleaning prior meshes and registering the root for WW Tuning
- update the LCHT camera setup to fit the Cornsweet frame precisely while disabling controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8633c9f6c832c8bc342bb8d0b1119