### PR TITLE
Update LCHT raster build and cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1111,20 +1111,19 @@ function buildLCHT() {
 
   const step = cubeSize / 5;           // tamaño de una celda del 5×5×5
   const SIDE = 0.2;                    // grosor de línea = arista “andamio”
-  const JOIN = 0.02;                   // pequeño solape (evita gaps por FP)
+  const JOIN = 0.02;                   // pequeño solape (evita gaps FP)
 
-  // ratios raíz para los 5 rasters (mantenemos 1..5 como en attributeMapping[1])
+  // ratios raíz para los 5 rasters: 1, √2, √3, 2, √5  (width : height = ratio : 1)
   const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
 
-  // ——— Permutaciones activas (colores deterministas ya existentes) ———
+  // ——— Permutaciones activas ———
   const perms = Array.from(document.getElementById('permutationList').selectedOptions)
                      .map(o => o.value.split(',').map(Number));
-
   if (!perms.length) return;
 
   // ——— cada permutación → una rejilla en su celda determinista ———
   perms.forEach((pa, permIdx) => {
-    const L   = pa[ attributeMapping[0] ]; // altura torre (la usamos como “densidad”)
+    const L   = pa[ attributeMapping[0] ]; // “altura” → densidad
     const col = colorForPerm(pa);
 
     // índice determinista de celda dentro del 5×5×5 (idéntico a tus andamios)
@@ -1145,50 +1144,88 @@ function buildLCHT() {
 
     // densidad de líneas en función de L (3..10 aprox, determinista)
     const baseRows = 3 + Math.max(0, Math.min(7, L + ((r % 3) - 1))); // 3..10
-    const rows = baseRows;                         // nº de franjas horizontales
-    const cols = Math.max(2, Math.round(rows * ratio)); // mantiene celda ~ratio
+    const rows = baseRows;                         // horizontales
+    const cols = Math.max(2, Math.round(rows * ratio)); // verticales ajustadas al ratio
 
-    // tamaño del panel = 10× más grande que antes
-    const SCALE_FACTOR = 10.0;
-    const PANEL_W = step * 0.92 * SCALE_FACTOR;
-    const PANEL_H = PANEL_W / ratio;
-    const H = PANEL_H;               // ya no recortamos al step: dejamos crecer
-    const W = H * ratio;
+    // *** ESCALA: 3× MÁS GRANDE RESPECTO A TU ESTADO ACTUAL (que ya era ×10) ***
+    const SCALE_FACTOR = 30.0;
 
-    // orientación: XY mirando al +Z o al −Z de forma determinista (variedad)
+    // Definimos ALTURA constante y el ANCHO por el ratio → rectángulos reales
+    const PANEL_H = step * 0.92 * SCALE_FACTOR;     // altura base
+    const PANEL_W = PANEL_H * ratio;                // ancho = ratio * altura
+
     const faceForward = ((r + sceneSeed + S_global) & 1) === 0;
     const normal = faceForward ? 1 : -1;
 
+    // parámetros de “respiración”/parpadeo deterministas (mismos que andamios)
+    const sig = computeSignature(pa);
+    const rng = computeRange(sig);
+    const lcht = {
+      I0 : 0.35 + 0.65 * Math.sqrt(L / 5),
+      amp: 0.05 + 0.10 * rng,
+      f  : 0.10 + 0.175 * rng,
+      phi: 2 * Math.PI * ((r % 360) / 360)
+    };
+
     addRaster({
       center: new THREE.Vector3(cx, cy, cz),
-      width:  W,
-      height: H,
+      width:  PANEL_W,
+      height: PANEL_H,
       cols,
       rows,
       line:  SIDE,
       join:  JOIN,
       color: col,
-      nz:    normal
+      nz:    normal,
+      lcht
     });
   });
 
   // evitar culling para que ninguna rejilla “parpadee”
   lichtGroup.traverse(o => { if (o.isMesh) o.frustumCulled = false; });
+
+  // ——— bucle de animación propio de LCHT (determinista) ———
+  if (window.__lchtRAF) { cancelAnimationFrame(window.__lchtRAF); window.__lchtRAF = null; }
+  const t0 = (sceneSeed*13 + S_global*31) * 0.01745329252; // fase fija (deg→rad)
+  function __lchtLoop(ts){
+    if (!isLCHT || !lichtGroup) { window.__lchtRAF = null; return; }
+    const t = ts*0.001;
+    const oscT = t + t0;
+    lichtGroup.traverse(m=>{
+      if (!m.isMesh || !m.material || !m.userData || !m.userData.lcht) return;
+      const P = m.userData.lcht;
+      const k = P.I0 + P.amp * Math.sin(2*Math.PI*P.f * t + P.phi);
+      // leve modulación de intensidad y tono (como en los andamios)
+      m.material.emissiveIntensity = Math.max(0, k);
+      if (m.userData.baseHsv){
+        const bh = m.userData.baseHsv;
+        const h  = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * t + P.phi)) % 1;
+        const rgb = hsvToRgb(h, bh.s, bh.v);
+        m.material.color.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+        m.material.emissive.copy(m.material.color);
+      }
+    });
+    window.__lchtRAF = requestAnimationFrame(__lchtLoop);
+  }
+  window.__lchtRAF = requestAnimationFrame(__lchtLoop);
 }
 
 
 /* ───────────────────────── helper: crea una rejilla de cajas ────────── */
-function addRaster({ center, width, height, cols, rows, line, join, color, nz }) {
-  // material lambert con leve emisivo (igual pipeline que tubos)
+function addRaster({ center, width, height, cols, rows, line, join, color, nz, lcht }) {
+  // material lambert con leve emisivo (pipeline tipo BUILD/andamios)
   const mat = new THREE.MeshLambertMaterial({
-    color,
+    color: color.clone(),
     dithering: true,
     flatShading: true
   });
   mat.emissive = color.clone();
   mat.emissiveIntensity = 0.08;
 
-  // líneas verticales (cols+1) y horizontales (rows+1) — al estilo Agnes Martin
+  // guardamos HSV base para el wobble de tono
+  const [h0,s0,v0] = rgbToHsv(color.r*255, color.g*255, color.b*255);
+  const baseHsv = { h: h0, s: Math.min(1, s0*1.04), v: Math.min(1, v0*1.03) };
+
   const halfW = width * 0.5, halfH = height * 0.5;
   const dx = width / cols;
   const dy = height / rows;
@@ -1197,10 +1234,11 @@ function addRaster({ center, width, height, cols, rows, line, join, color, nz })
   for (let i = 0; i <= cols; i++) {
     const x = -halfW + i * dx;
     const geo = new THREE.BoxGeometry(line, height + join, line);
-    const mesh = new THREE.Mesh(geo, mat);
+    const mesh = new THREE.Mesh(geo, mat.clone());
     mesh.position.set(center.x + x, center.y, center.z);
-    // orientado en XY; pequeño espesor en Z (usamos “line”)
-    if (nz < 0) mesh.rotateY(Math.PI); // cara opuesta de forma determinista
+    if (nz < 0) mesh.rotateY(Math.PI);
+    mesh.userData.lcht = lcht;
+    mesh.userData.baseHsv = baseHsv;
     lichtGroup.add(mesh);
   }
 
@@ -1208,9 +1246,11 @@ function addRaster({ center, width, height, cols, rows, line, join, color, nz })
   for (let j = 0; j <= rows; j++) {
     const y = -halfH + j * dy;
     const geo = new THREE.BoxGeometry(width + join, line, line);
-    const mesh = new THREE.Mesh(geo, mat);
+    const mesh = new THREE.Mesh(geo, mat.clone());
     mesh.position.set(center.x, center.y + y, center.z);
     if (nz < 0) mesh.rotateY(Math.PI);
+    mesh.userData.lcht = lcht;
+    mesh.userData.baseHsv = baseHsv;
     lichtGroup.add(mesh);
   }
 }
@@ -1253,11 +1293,14 @@ function addRaster({ center, width, height, cols, rows, line, join, color, nz })
           delete cubeUniverse.userData.prevMat;
         }
         if (lichtGroup) lichtGroup.visible = false;
-        if (lchtPrevBg) scene.background = lchtPrevBg;      // restaura fondo
+        if (lchtPrevBg) scene.background = lchtPrevBg;
         lchtPrevBg = null;
         cubeUniverse.visible      = true;
         permutationGroup.visible  = true;
         restoreBuildView();
+
+        // ← cancelar rAF propio de LCHT para no dejar animaciones colgadas
+        if (window.__lchtRAF){ cancelAnimationFrame(window.__lchtRAF); window.__lchtRAF = null; }
       }
       const b = document.getElementById('lchtButton');
       if (b) b.textContent = isLCHT ? 'LCHT ON' : 'LCHT';


### PR DESCRIPTION
## Summary
- enlarge and recolor LCHT rasters while adding deterministic animation parameters
- update raster helper to support emissive wobble and carry animation metadata
- ensure LCHT toggle tears down its requestAnimationFrame loop when deactivated

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d90d3709b8832c97080583298f4380