### PR TITLE
Adjust LCHT raster sizing and safeguards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1139,21 +1139,22 @@ function buildLCHT() {
     const cz = (z0 - 2) * step;
 
     // tipo de raster 1..5 → 1:1, √2:1, √3:1, 2:1, √5:1
-    const typeIdx = pa[ attributeMapping[1] ];        // 1–5 (coincide con color)
-    const ratio   = ROOT_RATIOS[typeIdx];
+    let typeIdx = pa[ attributeMapping[1] ];
+    // blindaje por si llegara algo fuera de 1..5
+    typeIdx = Math.max(1, Math.min(5, typeIdx));
+    const ratio = ROOT_RATIOS[typeIdx];             // width : height = 1 : (1/ratio)
 
-    // *** ESCALA: 3× MÁS GRANDE (respecto al estado previo de rasters) ***
+    // *** ESCALA: 3× MÁS GRANDE RESPECTO AL ESTADO ANTERIOR (que ya era ×10) ***
     const SCALE_FACTOR = 30.0;
 
-    // ── ANCHO FIJO, ALTURA = ANCHO / ratio  → rectángulos de raíz
-    const PANEL_W = step * 0.92 * SCALE_FACTOR;   // ancho constante (Breite)
-    const PANEL_H = PANEL_W / ratio;              // solo cambia la altura
+    // ✅ ANCHO FIJO (el del “1:1”); ALTURA = ANCHO / ratio  → solo 5 formatos posibles
+    const PANEL_W = step * 0.92 * SCALE_FACTOR;     // ancho constante para todos
+    const PANEL_H = PANEL_W / ratio;                // altura según la raíz (R2, R3, R4, R5)
 
-    // ── densidad: base = columnas; filas se ajustan por el ratio
-    const clamp7 = (x)=>Math.max(0, Math.min(7, x));
-    const baseCols = 3 + clamp7(L + ((r % 3) - 1));     // 3..10 aprox.
-    const cols = baseCols;
-    const rows = Math.max(2, Math.round(cols / ratio)); // mantiene celdas ~cuadradas
+    // ✅ DENSIDAD atada al ratio: columnas desde L; filas = columnas / ratio (redondeo determinista)
+    const baseCols = 3 + Math.max(0, Math.min(7, L + ((r % 3) - 1))); // 3..10
+    const cols = baseCols;                                            // verticales
+    const rows = Math.max(2, Math.round(cols / ratio));               // horizontales
 
     // orientación (variedad determinista)
     const faceForward = ((r + sceneSeed + S_global) & 1) === 0;


### PR DESCRIPTION
## Summary
- clamp the raster type index in buildLCHT to the valid 1–5 range
- switch to fixed panel width with ratio-derived height and density calculations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d939dbb204832c8c021547b377c03c