### PR TITLE
Ajusta paneles LCHT con celdas fijas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1114,19 +1114,16 @@ function buildLCHT() {
   const JOIN = 0.02;                   // pequeño solape (evita gaps FP)
 
   // ratios raíz:  width : height = ratio : 1
-  const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
-
   // ——— Permutaciones activas ———
   const perms = Array.from(document.getElementById('permutationList').selectedOptions)
                      .map(o => o.value.split(',').map(Number));
   if (!perms.length) return;
 
   // ——— cada permutación → una rejilla en su celda determinista ———
-  perms.forEach((pa) => {
-    const L   = pa[ attributeMapping[0] ]; // “altura” → densidad
+  perms.forEach((pa, permIdx) => {
     const col = colorForPerm(pa);
 
-    // índice determinista de celda dentro del 5×5×5 (idéntico a tus andamios)
+    // índice determinista de celda 5×5×5 (igual que en andamios)
     const r   = lehmerRank(pa);
     const I   = (r + sceneSeed + S_global) % 125;
     const x0  = Math.floor(I / 25);
@@ -1138,31 +1135,35 @@ function buildLCHT() {
     const cy = (y0 - 2) * step;
     const cz = (z0 - 2) * step;
 
-    // tipo de raster 1..5 → 1:1, √2:1, √3:1, 2:1, √5:1
-    let typeIdx = pa[ attributeMapping[1] ];
-    // blindaje por si llegara algo fuera de 1..5
-    typeIdx = Math.max(1, Math.min(5, typeIdx));
-    const ratio = ROOT_RATIOS[typeIdx];             // width : height = 1 : (1/ratio)
+    // ====== SOLO 5 RASTERS POSIBLES (ratio = width:height) ======
+    const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
+    const typeIdx = pa[ attributeMapping[1] ];   // 1..5
+    const ratio   = ROOT_RATIOS[typeIdx];
 
-    // *** ESCALA: 3× MÁS GRANDE RESPECTO AL ESTADO ANTERIOR (que ya era ×10) ***
-    const SCALE_FACTOR = 30.0;
+    // ====== CELDA FIJA y PANEL 10× MÁS GRANDE (sin tocar línea) ======
+    // ancho de celda constante para todos los rasters
+    const CELL_W = step * 0.92;     // “breite” base (igual que tenías en 1:1)
+    const CELL_H = CELL_W / ratio;  // solo cambia la altura según la raíz
 
-    // ✅ ANCHO FIJO (el del “1:1”); ALTURA = ANCHO / ratio  → solo 5 formatos posibles
-    const PANEL_W = step * 0.92 * SCALE_FACTOR;     // ancho constante para todos
-    const PANEL_H = PANEL_W / ratio;                // altura según la raíz (R2, R3, R4, R5)
+    // repetimos la malla 10× manteniendo el tamaño de celda
+    const REPEAT = 10;
+    const BASE_COLS = 4;                 // estructura base (determinista y simple)
+    const cols = BASE_COLS * REPEAT;     // ancho del panel en nº de celdas
+    // escogemos filas para que el panel sea aprox. cuadrado: rows ≈ cols * ratio
+    const rows = Math.max(2, Math.round(cols * ratio));
 
-    // ✅ DENSIDAD atada al ratio: columnas desde L; filas = columnas / ratio (redondeo determinista)
-    const baseCols = 3 + Math.max(0, Math.min(7, L + ((r % 3) - 1))); // 3..10
-    const cols = baseCols;                                            // verticales
-    const rows = Math.max(2, Math.round(cols / ratio));               // horizontales
+    // dimensiones del panel derivadas de celdas (NO cambian grosores ni celdas)
+    const PANEL_W = cols * CELL_W;
+    const PANEL_H = rows * CELL_H;
 
-    // orientación (variedad determinista)
+    // orientación estable (variedad determinista cara adelante/atrás)
     const faceForward = ((r + sceneSeed + S_global) & 1) === 0;
     const normal = faceForward ? 1 : -1;
 
-    // parámetros de “respiración”/parpadeo deterministas (igual que andamios)
+    // parámetros de “respiración” (los mismos que usabas en andamios)
     const sig = computeSignature(pa);
     const rng = computeRange(sig);
+    const L   = pa[ attributeMapping[0] ];
     const lcht = {
       I0 : 0.35 + 0.65 * Math.sqrt(L / 5),
       amp: 0.05 + 0.10 * rng,


### PR DESCRIPTION
## Summary
- reemplaza el cálculo de rejillas LCHT para ubicar cada permutación en celdas deterministas del 5×5×5
- fija el tamaño de celda y construye paneles ampliados repitiendo la malla con ratios predefinidos
- mantiene los parámetros de animación utilizando la firma y rango existentes

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9696f29bc832cba130071498bc3ae