### PR TITLE
Update LCHT raster construction

### DIFF
--- a/index.html
+++ b/index.html
@@ -1098,23 +1098,6 @@ function initSkySphere() {
       const [r,g,b] = hsvToRgb(h,s,v);
       return new THREE.Color(r/255,g/255,b/255);
     }
-    /* Devuelve un THREE.Color ajustando el H por “ángulo dorado” si ya existe
-       un tono cercano en la escena; umbral ~16.2° (0.045 en [0,1]) */
-    function pickSceneUniqueColor(baseColor, usedH){
-      const golden = 0.38196601125; // φ-1 ≈ 137.5° en círculo unitario
-      const thr    = 0.045;         // distancia mínima de tono
-      let {h,s,v}  = hsvOfTHREE(baseColor);
-      let tries = 0;
-      while (usedH.some(u => Math.abs(((h - u + 0.5) % 1) - 0.5) < thr) && tries < 8){
-        h = (h + golden) % 1;
-        tries++;
-      }
-      usedH.push(h);
-      s = Math.min(1, s*1.02);
-      v = Math.min(1, v*1.02);
-      return colorFromHSV(h,s,v);
-    }
-
     /* ═════════ LCHT “cubos-de-tubos” (Sol LeWitt) ═════════════════ */
 
 function tubeKey(x1, y1, z1, x2, y2, z2) {
@@ -1124,85 +1107,116 @@ function tubeKey(x1, y1, z1, x2, y2, z2) {
 }
 
 
-// —— Escalas globales LCHT (ajustables) ——
-// TILE_SCALE: escala del ancho del rectángulo raíz (fijo para los 5 tipos)
-// PANEL_REPEAT: nº de repeticiones del tile en X e Y (panel "×10")
-const LCHT_SCALE = Object.freeze({
-  TILE_SCALE: 1.0,
-  PANEL_REPEAT: 10
-});
+// 5 razones de aspecto (width:height = R:1). Usaremos ANCHO fijo → HEIGHT = W/R
+const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
+
+// color único por escena: si ya existe, gira el matiz por el ángulo áureo hasta ser único
+function uniqueSceneColor(baseColor, usedSet){
+  // RGB → HSV
+  const [h0,s0,v0] = rgbToHsv(baseColor.r*255, baseColor.g*255, baseColor.b*255);
+  // pasos de matiz (ángulo áureo ~ 0.618… en vueltas)
+  const GOLD = 0.61803398875;
+  let k = 0, h = h0;
+  let tryHex = baseColor.getHexString();
+  while (usedSet.has(tryHex) && k < 16){
+    h = (h0 + GOLD * (k+1)) % 1;
+    const [r,g,b] = hsvToRgb(h, s0, v0);
+    tryHex = new THREE.Color(r/255,g/255,b/255).getHexString();
+    k++;
+  }
+  usedSet.add(tryHex);
+  const [r,g,b] = hsvToRgb(h, s0, v0);
+  return new THREE.Color(r/255,g/255,b/255);
+}
+
+// mapea el z-index de la celda 5×5×5 a un z libre (no repetido) de forma determinista
+function nextFreeZ(zIdx, usedZ){
+  // zIdx en 0..4 (porque tu grid es 5 en Z); avanzamos circular hasta encontrar libre
+  for (let i=0;i<5;i++){
+    const z = (zIdx + i) % 5;
+    if (!usedZ.has(z)){ usedZ.add(z); return z; }
+  }
+  // si hubiera más de 5 rasters seleccionados, “apilamos” en la última capa
+  return 4;
+}
 
 function buildLCHT() {
-  // limpiar escena previa
+  /* limpiar escena previa */
   if (lichtGroup) {
-    lichtGroup.traverse(o => { if (o.isMesh) { o.geometry.dispose(); o.material.dispose(); } });
+    lichtGroup.traverse(o => { if (o.isMesh) { o.geometry?.dispose(); o.material?.dispose(); } });
     scene.remove(lichtGroup);
   }
   lichtGroup = new THREE.Group();
   scene.add(lichtGroup);
 
-  const step = cubeSize / 5;     // tamaño de la celda del 5×5×5
-  const SIDE = 0.2;              // grosor de línea (igual que “andamios”)
-  const JOIN = 0.02;             // pequeño solape
+  const step = cubeSize / 5;     // medida de tu grid 5×5×5
+  const SIDE = 0.2;              // grosor de línea (no se toca)
+  const JOIN = 0.02;             // solape anti-gaps
 
-  // ratios raíz (width : height = ratio : 1) — SOLO 5 RASTERS POSIBLES
-  const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
+  // === escala global CLARA para TU proyecto (puedes tocarla si quieres +/-) ===
+  const TILE_W_BASE   = step * 0.92; // ancho base del tile (común a los 5 tipos)
+  const SCALE_RASTER  = 1.00;        // ← AJUSTE ÚNICO de tamaño global del raster
+  const TILE_W        = TILE_W_BASE * SCALE_RASTER;
 
-  // ——— Permutaciones activas ———
+  // Misma anchura de panel para TODOS (mismo nº de “tiles” a lo ancho)
+  const PANEL_COLS = 24;             // nº de tiles a lo ancho (igual para 1..5)
+  // (Si quieres más/menos panel, cambia sólo este número)
+
+  // Permutaciones activas
   const perms = Array.from(document.getElementById('permutationList').selectedOptions)
                      .map(o => o.value.split(',').map(Number));
   if (!perms.length) return;
 
-  // ——— 1 Raster por Z: elegimos 1 perm representativa por z0 (0..4), determinista ———
-  const byZ = Array.from({length:5}, ()=>[]);
-  perms.forEach((pa, idx) => {
-    const r = lehmerRank(pa);
-    const I = (r + sceneSeed + S_global) % 125;
-    const z0 = I % 5;
-    byZ[z0].push({ pa, idx, r, I });
-  });
+  // sets para evitar colisiones de Z y de color
+  const usedZ     = new Set();    // índices z de las 5 capas (0..4)
+  const usedColor = new Set();    // hex strings vistos esta escena
 
-  // Política determinista: si hay varias en el mismo Z, gana la de menor r
-  const winners = [];
-  for (let z=0; z<5; z++){
-    if (byZ[z].length){
-      byZ[z].sort((a,b)=> a.r - b.r);
-      winners.push(byZ[z][0]); // elige 1 por z
-    }
-  }
+  // rAF de respiración (limpia si estaba corriendo)
+  if (window.__lchtRAF) { cancelAnimationFrame(window.__lchtRAF); window.__lchtRAF = null; }
 
-  // ——— Renderiza solo ganadores (≤5 rasters), uno por Z ———
-  winners.forEach(({ pa, r, I }) => {
-    const col = colorForPerm(pa);
-
-    const x0 = Math.floor(I / 25);
-    const y0 = Math.floor((I % 25) / 5);
-    const z0 = I % 5;
-
-    // centro mundo de esa celda
-    const cx = (x0 - 2) * step;
-    const cy = (y0 - 2) * step;
-    const cz = (z0 - 2) * step;
-
-    // Tipo de Raster 1..5 → 1:1, √2:1, √3:1, 2:1, √5:1
-    const typeIdx = pa[ attributeMapping[1] ];    // 1..5
+  perms.forEach((pa) => {
+    // — Ratio raíz: exactamente 5 tipos —
+    const typeIdx = pa[ attributeMapping[1] ];   // 1..5
     const ratio   = ROOT_RATIOS[typeIdx];
 
-    // —— TAMAÑO TILE: ANCHO FIJO para todos (según TILE_SCALE); ALTO = ancho / ratio ——
-    const TILE_W = step * 0.92 * LCHT_SCALE.TILE_SCALE; // “breite” fijo
-    const TILE_H = TILE_W / ratio;                      // solo cambia altura
+    // — Color determinista, garantizado único en la escena —
+    const baseCol = colorForPerm(pa);
+    const col     = uniqueSceneColor(baseCol, usedColor);
 
-    // Panel = repetición del tile SIN subdividirlo (×10 por defecto)
-    const cols = LCHT_SCALE.PANEL_REPEAT;
-    const rows = LCHT_SCALE.PANEL_REPEAT;
-    const PANEL_W = cols * TILE_W;
-    const PANEL_H = rows * TILE_H;
+    // — Celda determinista 5×5×5 —
+    const r   = lehmerRank(pa);
+    const I   = (r + sceneSeed + S_global) % 125;
+    const x0  = Math.floor(I / 25);
+    const y0  = Math.floor((I % 25) / 5);
+    const z0  = I % 5;
 
-    // orientación estable (variedad determinista cara adelante/atrás)
-    const faceForward = ((r + sceneSeed + S_global) & 1) === 0;
-    const normal = faceForward ? 1 : -1;
+    // **Z único** (resuelve colisiones circulando 0→4)
+    const zFree = nextFreeZ(z0, usedZ);
 
-    // parámetros “respiración” deterministas (idénticos a los andamios)
+    // Centro en mundo (usamos el z libre)
+    const cx = (x0 - 2) * step;
+    const cy = (y0 - 2) * step;
+    const cz = (zFree - 2) * step;
+
+    // ———————— DEFINICIÓN GEOMÉTRICA PURA DEL RASTER —————————
+    // ancho del tile FIJO; altura depende de la raíz (W:R → H = W/R)
+    const tileW = TILE_W;
+    const tileH = tileW / ratio;
+
+    // nº de columnas FIJO (panel igual de ancho para todos)
+    const cols = PANEL_COLS;
+    // nº de filas: las necesarias para cubrir la misma anchura vertical aproximada.
+    // Para que el panel tenga “aparente” equilibrio, hacemos que el alto del panel
+    // sea proporcional al ancho: usamos el mismo nº de tiles de alto que de “tiles
+    // cuadrados equivalentes”. Esto da paneles diferentes pero consistentes.
+    const panelW = cols * tileW;
+    const rows   = Math.max(2, Math.ceil(panelW / tileH)); // sin subdividir tiles
+
+    // dimensiones finales del panel (mismas unidades de mundo)
+    const PANEL_W = cols * tileW;
+    const PANEL_H = rows * tileH;
+
+    // “respiración” determinista (igual que antes)
     const sig = computeSignature(pa);
     const rng = computeRange(sig);
     const L   = pa[ attributeMapping[0] ];
@@ -1213,26 +1227,32 @@ function buildLCHT() {
       phi: 2 * Math.PI * ((r % 360) / 360)
     };
 
+    // cara hacia +Z ó −Z para variedad estable
+    const faceForward = ((r + sceneSeed + S_global) & 1) === 0;
+    const normal = faceForward ? 1 : -1;
+
+    // ¡Construir!
     addRaster({
       center: new THREE.Vector3(cx, cy, cz),
-      tileW:  TILE_W,
-      tileH:  TILE_H,
+      width:  PANEL_W,
+      height: PANEL_H,
       cols,
       rows,
       line:  SIDE,
       join:  JOIN,
       color: col,
       nz:    normal,
-      lcht
+      lcht,
+      // para animación del tono
+      baseHsv: (()=>{ const [h,s,v]=rgbToHsv(col.r*255,col.g*255,col.b*255); return {h,s,v};})()
     });
   });
 
-  // evitar culling para que ninguna rejilla “parpadee”
+  // no culling
   lichtGroup.traverse(o => { if (o.isMesh) o.frustumCulled = false; });
 
-  // ——— bucle de animación propio de LCHT (determinista) ———
-  if (window.__lchtRAF) { cancelAnimationFrame(window.__lchtRAF); window.__lchtRAF = null; }
-  const t0 = (sceneSeed*13 + S_global*31) * 0.01745329252; // fase fija (deg→rad)
+  // ——— rAF de respiración (igual que tenías) ———
+  const t0 = (sceneSeed*13 + S_global*31) * 0.01745329252;
   function __lchtLoop(ts){
     if (!isLCHT || !lichtGroup) { window.__lchtRAF = null; return; }
     const t = ts*0.001;
@@ -1254,10 +1274,8 @@ function buildLCHT() {
   window.__lchtRAF = requestAnimationFrame(__lchtLoop);
 }
 
-
-// Crea una rejilla repitiendo SIEMPRE el mismo rectángulo raíz (tileW × tileH).
-function addRaster({ center, tileW, tileH, cols, rows, line, join, color, nz, lcht }) {
-  // material lambert con leve emisivo (como antes)
+/* ——— Construcción de la rejilla SIN subdividir los tiles ——— */
+function addRaster({ center, width, height, cols, rows, line, join, color, nz, lcht, baseHsv }) {
   const mat = new THREE.MeshLambertMaterial({
     color: color.clone(),
     dithering: true,
@@ -1266,20 +1284,16 @@ function addRaster({ center, tileW, tileH, cols, rows, line, join, color, nz, lc
   mat.emissive = color.clone();
   mat.emissiveIntensity = 0.08;
 
-  // HSV base para el wobble de tono
-  const [h0, s0, v0] = rgbToHsv(color.r*255, color.g*255, color.b*255);
-  const baseHsv = { h: h0, s: Math.min(1, s0*1.04), v: Math.min(1, v0*1.03) };
+  const halfW = width * 0.5, halfH = height * 0.5;
 
-  // dimensiones del panel (derivadas SOLO de los tiles repetidos)
-  const width2  = cols * tileW;
-  const height2 = rows * tileH;
-  const halfW   = width2 * 0.5;
-  const halfH   = height2 * 0.5;
+  // separaciones EXACTAS (tamaño de tile) — no se recalculan luego
+  const dx = width  / cols; // = tileW
+  const dy = height / rows; // = tileH
 
-  // — verticales (bordes de cada columna de tile)
+  // verticales (bordes de los tiles)
   for (let i = 0; i <= cols; i++) {
-    const x = -halfW + i * tileW;
-    const geo = new THREE.BoxGeometry(line, height2 + join, line);
+    const x = -halfW + i * dx;
+    const geo = new THREE.BoxGeometry(line, height + join, line);
     const mesh = new THREE.Mesh(geo, mat.clone());
     mesh.position.set(center.x + x, center.y, center.z);
     if (nz < 0) mesh.rotateY(Math.PI);
@@ -1288,10 +1302,10 @@ function addRaster({ center, tileW, tileH, cols, rows, line, join, color, nz, lc
     lichtGroup.add(mesh);
   }
 
-  // — horizontales (bordes de cada fila de tile)
+  // horizontales (bordes de los tiles)
   for (let j = 0; j <= rows; j++) {
-    const y = -halfH + j * tileH;
-    const geo = new THREE.BoxGeometry(width2 + join, line, line);
+    const y = -halfH + j * dy;
+    const geo = new THREE.BoxGeometry(width + join, line, line);
     const mesh = new THREE.Mesh(geo, mat.clone());
     mesh.position.set(center.x, center.y + y, center.z);
     if (nz < 0) mesh.rotateY(Math.PI);


### PR DESCRIPTION
## Summary
- replace the LCHT build routine to support consistent panel widths, unique colors, and collision-free Z placement
- add helper utilities for deterministic color rotation and layer assignment used by the raster builder
- update raster construction to use fixed tile spacing and propagate breathing animation data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dac0f7f960832ca5d39d71b658e923