### PR TITLE
Replace LCHT engine implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1080,311 +1080,275 @@ function initSkySphere() {
        LCHT · Rasters de “root rectangles” (sin subdividir tiles)
        - 5 tipos: 1:1, √2:1, √3:1, 2:1, √5:1
        - Altura de tile fija; ancho = ratio × altura
-       - Panel = repetición de tiles (sin subdividirlos).
-       - Z único por raster (si hay <5 perms, se rellenan hasta 5).
-       - Fondo siempre coloreado (no blanco) con deriva suave.
-       - Protagonismo rotativo por Z para profundidad perceptual.
-       - Respiración/luz determinista (como “andamios”).
+       - Siempre 5 capas Z (si hay menos perms, se rellenan cíclicamente).
+       - Fondo = scene.background con deriva de tono (nunca blanco).
+       - Protagonismo rotativo MUY marcado por Z.
        ════════════════════════════════════════════════════════════ */
-    
+
     let lichtGroup = null;
     let isLCHT     = false;
     let lchtPrevBg = null;
-    
-    // ——— Fondo coloreado (plane) ———
-    let lchtBackPlane = null;
-    const LCHT_BG_OPACITY   = 0.94;
-    const LCHT_BG_HUE_DRIFT = 0.018;         // amplitud (en 0..1)
-    const LCHT_BG_SPEED     = 0.06;          // Hz, deriva muy lenta
-    
-    // ——— Protagonismo rotativo ———
-    const LCHT_FOCUS_PERIOD = 10.0;          // segundos por capa en foco
-    const LCHT_FOCUS_GAIN   = 1.00;          // intensidad máx. extra en foco
-    const LCHT_BASE_DIM     = 0.42;          // dim para capas fuera de foco
-    
-    /* color determinista base (igual que antes) */
+
+    /* ——— Fondo animado (deriva de hue, sin llegar a blanco) ——— */
+    let __lchtBgBaseHSV = null;
+    const LCHT_BG_DRIFT_AMP   = 0.07;   // amplitud de hue (0..1)
+    const LCHT_BG_DRIFT_SPEED = 0.04;   // Hz (lento)
+    const LCHT_BG_S_MIN       = 0.16;   // evita desaturar (no blanco)
+    const LCHT_BG_S_MAX       = 0.28;
+    const LCHT_BG_V_MIN       = 0.88;   // evita blanco brillante
+    const LCHT_BG_V_MAX       = 0.94;
+
+    /* ——— Protagonismo rotativo (una capa a la vez) ——— */
+    const LCHT_FOCUS_PERIOD   = 8.0;    // segundos por capa
+    const LCHT_FOCUS_OPACITY  = 0.95;   // opacidad de la capa en foco
+    const LCHT_OFF_OPACITY    = 0.08;   // opacidad del resto
+    const LCHT_FOCUS_GAIN     = 1.75;   // multiplicador de “presencia” en foco
+    const LCHT_OFF_GAIN       = 0.18;   // presencia del resto
+
+    /* color determinista base */
     function colorForPerm(pa){
       const idx = pa[ attributeMapping[1] ]; // 1..5
       const val = getColor(idx);
       return Array.isArray(val)
-    ? new THREE.Color(val[0]/255, val[1]/255, val[2]/255)
-    : new THREE.Color(val);
+        ? new THREE.Color(val[0]/255, val[1]/255, val[2]/255)
+        : new THREE.Color(val);
     }
-    
-    /* helpers HSV ya existen: rgbToHsv / hsvToRgb */
-    
-    // color de fondo determinista, nunca blanco
-    function lchtBackgroundColor(sceneKey){
-      // semilla → hue en [0..1], s en [0.25..0.35], v en [0.86..0.93]
-      const h = ((sceneKey*37 + 113) % 360) / 360;
-      const s = 0.25 + ((sceneKey*19 + 71) % 100) / 100 * 0.10;
-      const v = 0.86 + ((sceneKey*53 + 29) % 100) / 100 * 0.07;
-      const rgb = hsvToRgb(h, s, v);
-      return new THREE.Color(rgb[0]/255, rgb[1]/255, rgb[2]/255);
-    }
-    
-    /* Construye panel de líneas que SOLO delinean cada tile raíz (sin subdividir). */
+
+    /* helpers HSV existen: rgbToHsv / hsvToRgb */
+
+    /* Construye panel de líneas que SOLO delinean cada tile raíz */
     function addRootRaster({ center, widthTile, heightTile, tilesX, tilesY, line, join, color, nz, lcht, zSlot }){
       const matBase = new THREE.MeshLambertMaterial({
-    color: color.clone(),
-    dithering: true,
-    flatShading: true,
-    transparent: false
+        color: color.clone(),
+        dithering: true,
+        flatShading: true,
+        transparent: true,           // ← para opacidad del foco
+        opacity: LCHT_OFF_OPACITY
       });
       matBase.emissive = color.clone();
       matBase.emissiveIntensity = 0.08;
-    
-      // guardamos HSV base para la animación determinista
+
+      // HSV base para respiración
       const [h0,s0,v0] = rgbToHsv(color.r*255, color.g*255, color.b*255);
       const baseHsv = { h: h0, s: Math.min(1, s0*1.04), v: Math.min(1, v0*1.03) };
-    
+
       const panelW = tilesX * widthTile;
       const panelH = tilesY * heightTile;
       const halfW  = panelW * 0.5;
       const halfH  = panelH * 0.5;
-    
+
       // — Verticales
       for (let i=0; i<=tilesX; i++){
-    const x = -halfW + i*widthTile;
-    const geo  = new THREE.BoxGeometry(line, panelH + join, line);
-    const mesh = new THREE.Mesh(geo, matBase.clone());
-    mesh.position.set(center.x + x, center.y, center.z);
-    if (nz < 0) mesh.rotateY(Math.PI);
-    mesh.userData.lcht     = lcht;
-    mesh.userData.baseHsv  = baseHsv;
-    mesh.userData.zSlot    = zSlot;  // ← para foco por Z
-    lichtGroup.add(mesh);
+        const x = -halfW + i*widthTile;
+        const geo  = new THREE.BoxGeometry(line, panelH + join, line);
+        const mesh = new THREE.Mesh(geo, matBase.clone());
+        mesh.position.set(center.x + x, center.y, center.z);
+        if (nz < 0) mesh.rotateY(Math.PI);
+        mesh.userData.lcht     = lcht;
+        mesh.userData.baseHsv  = baseHsv;
+        mesh.userData.zSlot    = zSlot;  // ← foco por Z
+        lichtGroup.add(mesh);
       }
-    
       // — Horizontales
       for (let j=0; j<=tilesY; j++){
-    const y = -halfH + j*heightTile;
-    const geo  = new THREE.BoxGeometry(panelW + join, line, line);
-    const mesh = new THREE.Mesh(geo, matBase.clone());
-    mesh.position.set(center.x, center.y + y, center.z);
-    if (nz < 0) mesh.rotateY(Math.PI);
-    mesh.userData.lcht     = lcht;
-    mesh.userData.baseHsv  = baseHsv;
-    mesh.userData.zSlot    = zSlot;
-    lichtGroup.add(mesh);
+        const y = -halfH + j*heightTile;
+        const geo  = new THREE.BoxGeometry(panelW + join, line, line);
+        const mesh = new THREE.Mesh(geo, matBase.clone());
+        mesh.position.set(center.x, center.y + y, center.z);
+        if (nz < 0) mesh.rotateY(Math.PI);
+        mesh.userData.lcht     = lcht;
+        mesh.userData.baseHsv  = baseHsv;
+        mesh.userData.zSlot    = zSlot;
+        lichtGroup.add(mesh);
       }
     }
-    
-    /* plano de fondo coloreado detrás del vano (siempre con color, nunca blanco) */
-    function addBackPlane({ z, width, height, sceneKey }){
-      if (lchtBackPlane){
-    lchtBackPlane.geometry.dispose();
-    lchtBackPlane.material.dispose();
-    if (lchtBackPlane.parent) lchtBackPlane.parent.remove(lchtBackPlane);
-    lchtBackPlane = null;
-      }
-      const geo = new THREE.PlaneGeometry(width, height, 1, 1);
-      const col = lchtBackgroundColor(sceneKey);
-      const mat = new THREE.MeshBasicMaterial({
-    color: col,
-    transparent: true,
-    opacity: LCHT_BG_OPACITY,
-    depthWrite: false
-      });
-      lchtBackPlane = new THREE.Mesh(geo, mat);
-      lchtBackPlane.position.set(0, 0, z);
-      lchtBackPlane.renderOrder = -10;      // dibujar antes
-      lchtBackPlane.frustumCulled = false;
-      lichtGroup.add(lchtBackPlane);
-    }
-    
+
     /* ———————————————————————————————————————————————————————————— */
     function buildLCHT(){
       // limpiar escena previa
       if (lichtGroup) {
-    lichtGroup.traverse(o=>{
-      if (o.isMesh){
-        o.material?.dispose?.();
-        o.geometry?.dispose?.();
-      }
-    });
-    scene.remove(lichtGroup);
+        lichtGroup.traverse(o=>{
+          if (o.isMesh){
+            o.material?.dispose?.();
+            o.geometry?.dispose?.();
+          }
+        });
+        scene.remove(lichtGroup);
       }
       lichtGroup = new THREE.Group();
       scene.add(lichtGroup);
-    
-      const step = cubeSize / 5; 
-      const SIDE = 0.24;         // ← líneas un poco más gruesas (antes 0.2)
+
+      const step = cubeSize / 5;
+      const SIDE = 0.24;          // ← un poco más gruesas
       const JOIN = 0.02;
-    
+
       // Altura de tile fija para TODOS los rasters
-      const TILE_H = step * 0.92 * 3.0;     // tu escala global ×3
-      // Ratios raíz (ratio = width:height)
+      const TILE_H = step * 0.92 * 3.0;
       const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
-    
+
       // Permutaciones activas
       const perms = Array.from(document.getElementById('permutationList').selectedOptions)
                      .map(o => o.value.split(',').map(Number));
       if (!perms.length) return;
-    
+
       // Orden determinista por lehmerRank
       const order = perms.map((pa, i)=>({i, r: lehmerRank(pa)}))
                      .sort((a,b)=> a.r - b.r);
-    
-      // ——— SIEMPRE 5 capas: si hay <5 perms, se repiten cíclicamente (determinista) ———
+
+      // ——— SIEMPRE 5 capas: si hay <5 perms, repetir cíclicamente ———
       const layers = [];
       for (let z=0; z<5; z++){
-    const pick = order[(z + sceneSeed + S_global) % order.length].i; // ciclo estable
-    layers.push({ zSlot:z, permIdx: pick });
+        const pick = order[(z + sceneSeed + S_global) % order.length].i;
+        layers.push({ zSlot:z, permIdx: pick });
       }
-    
-      // Construcción de rasters
+
       const REPEAT = 10;
+
+      // Fondo animado (escogemos base HSV determinista)
       const sceneKey = (37*sceneSeed + 101*S_global) % 360;
-    
-      let minZ = +Infinity;
-    
+      const baseH = ((sceneKey*37 + 113) % 360) / 360;
+      const baseS = LCHT_BG_S_MIN + ((sceneKey*19 + 71) % 100)/100 * (LCHT_BG_S_MAX - LCHT_BG_S_MIN);
+      const baseV = LCHT_BG_V_MIN + ((sceneKey*53 + 29) % 100)/100 * (LCHT_BG_V_MAX - LCHT_BG_V_MIN);
+      __lchtBgBaseHSV = [baseH, baseS, baseV];
+
+      // color inicial del fondo ya no blanco
+      {
+        const rgb = hsvToRgb(__lchtBgBaseHSV[0], __lchtBgBaseHSV[1], __lchtBgBaseHSV[2]);
+        scene.background = new THREE.Color(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+      }
+
+      // Construcción de capas
       layers.forEach(({zSlot, permIdx})=>{
-    const pa      = perms[permIdx];
-    const baseCol = colorForPerm(pa);
-    // tipo segun perm elegida (si quisieras la progresión estricta 1..5, cambia aquí)
-    const typeIdx = pa[ attributeMapping[1] ]; // 1..5
-    const ratio   = ROOT_RATIOS[typeIdx];
-    
-    // Tamaños de tile raíz (fijos por tipo)
-    const widthTile  = ratio * TILE_H;
-    const heightTile = TILE_H;
-    
-    // Centro determinista de la celda 5×5×5, pero con Z forzado a zSlot
-    const r  = lehmerRank(pa);
-    const I  = (r + sceneSeed + S_global) % 125;
-    const x0 = Math.floor(I / 25);
-    const y0 = Math.floor((I % 25) / 5);
-    const cx = (x0 - 2) * step;
-    const cy = (y0 - 2) * step;
-    const cz = (zSlot - 2) * step;               // ← Z único por capa 0..4
-    
-    minZ = Math.min(minZ, cz);
-    
-    // panel ancho a base de tiles (sin subdividir)
-    const baseTilesX = 4;
-    const tilesX     = baseTilesX * REPEAT;
-    const tilesY     = Math.max(2, Math.round(tilesX / ratio));
-    
-    const sig  = computeSignature(pa);
-    const rng  = computeRange(sig);
-    const L    = pa[ attributeMapping[0] ];
-    const lcht = {
-      I0 : 0.35 + 0.65 * Math.sqrt(L / 5),
-      amp: 0.05 + 0.10 * rng,
-      f  : 0.10 + 0.175 * rng,
-      phi: 2 * Math.PI * ((lehmerRank(pa) % 360) / 360)
-    };
-    
-    const faceForward = (((lehmerRank(pa) + sceneSeed + S_global) & 1) === 0);
-    const normal = faceForward ? 1 : -1;
-    
-    addRootRaster({
-      center: new THREE.Vector3(cx, cy, cz),
-      widthTile,
-      heightTile,
-      tilesX,
-      tilesY,
-      line: SIDE,
-      join: JOIN,
-      color: baseCol.clone(),
-      nz: normal,
-      lcht,
-      zSlot
-    });
+        const pa      = perms[permIdx];
+        const baseCol = colorForPerm(pa);
+        const typeIdx = pa[ attributeMapping[1] ]; // 1..5
+        const ratio   = ROOT_RATIOS[typeIdx];
+
+        // Tamaño de tile raíz (fijo por tipo)
+        const widthTile  = ratio * TILE_H;
+        const heightTile = TILE_H;
+
+        // Centro determinista con Z forzado a zSlot
+        const r  = lehmerRank(pa);
+        const I  = (r + sceneSeed + S_global) % 125;
+        const x0 = Math.floor(I / 25);
+        const y0 = Math.floor((I % 25) / 5);
+        const cx = (x0 - 2) * step;
+        const cy = (y0 - 2) * step;
+        const cz = (zSlot - 2) * step;
+
+        const baseTilesX = 4;
+        const tilesX     = baseTilesX * REPEAT;
+        const tilesY     = Math.max(2, Math.round(tilesX / ratio));
+
+        const sig  = computeSignature(pa);
+        const rng  = computeRange(sig);
+        const L    = pa[ attributeMapping[0] ];
+        const lcht = {
+          I0 : 0.35 + 0.65 * Math.sqrt(L / 5),
+          amp: 0.05 + 0.10 * rng,
+          f  : 0.10 + 0.175 * rng,
+          phi: 2 * Math.PI * ((lehmerRank(pa) % 360) / 360)
+        };
+
+        const faceForward = (((lehmerRank(pa) + sceneSeed + S_global) & 1) === 0);
+        const normal = faceForward ? 1 : -1;
+
+        addRootRaster({
+          center: new THREE.Vector3(cx, cy, cz),
+          widthTile,
+          heightTile,
+          tilesX,
+          tilesY,
+          line: SIDE,
+          join: JOIN,
+          color: baseCol.clone(),
+          nz: normal,
+          lcht,
+          zSlot
+        });
       });
-    
-      // Plano de fondo SIEMPRE coloreado (nunca blanco), un poco detrás de la capa más lejana
-      if (!isFinite(minZ)) minZ = -step*3;
-      addBackPlane({
-    z: minZ - step*0.25,
-    width:  cubeSize * 0.92,
-    height: cubeSize * 0.92,
-    sceneKey
-      });
-    
-      // No hacer culling
+
+      // No culling
       lichtGroup.traverse(o => { if (o.isMesh) o.frustumCulled = false; });
-    
-      // bucle determinista (respiración + foco rotativo + deriva del fondo)
+
+      // Animación: respiración + fondo + foco rotativo
       if (window.__lchtRAF){ cancelAnimationFrame(window.__lchtRAF); window.__lchtRAF = null; }
       const t0 = (sceneSeed*13 + S_global*31) * 0.01745329252;
-      // base H del back plane
-      const baseBgHSV = rgbToHsv(
-    lchtBackPlane.material.color.r*255,
-    lchtBackPlane.material.color.g*255,
-    lchtBackPlane.material.color.b*255
-      );
-    
-      function smoothPulse(x){ // x en [0..1] devuelve una campana suave
-    const d = 1.0 - Math.abs(2.0*x - 1.0); // triángulo
-    return d*d*(3 - 2*d);                  // suavizado (smoothstep-ish)
-      }
-    
+
+      function smooth(x){ return x*x*(3-2*x); }   // suavizado 0..1
+
       function __lchtLoop(ts){
-    if (!isLCHT || !lichtGroup) { window.__lchtRAF = null; return; }
-    const t = ts * 0.001;
-    
-    // índice de capa en foco: rota 0→1→2→3→4
-    const cycle = (t / LCHT_FOCUS_PERIOD) % 5;
-    const focusIndex = Math.floor(cycle);
-    const frac = cycle - focusIndex; // 0..1 dentro de la capa actual
-    
-    lichtGroup.traverse(m=>{
-      if (!m.isMesh || !m.material) return;
-    
-      // — fondo: deriva cromática suave, nunca a blanco
-      if (m === lchtBackPlane){
-        const h = (baseBgHSV[0] + LCHT_BG_HUE_DRIFT * Math.sin(2*Math.PI*LCHT_BG_SPEED * t)) % 1;
-        const s = Math.max(0.25, baseBgHSV[1]);   // evita desaturar a blanco
-        const v = Math.min(0.93, Math.max(0.86, baseBgHSV[2]));
-        const rgb = hsvToRgb(h, s, v);
-        m.material.color.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
-        return;
+        if (!isLCHT || !lichtGroup) { window.__lchtRAF = null; return; }
+        const t = ts * 0.001;
+
+        // — Fondo animado (deriva de hue, manteniendo s/v lejos del blanco)
+        {
+          const h = (__lchtBgBaseHSV[0] + LCHT_BG_DRIFT_AMP * Math.sin(2*Math.PI*LCHT_BG_DRIFT_SPEED * t)) % 1;
+          const s = THREE.MathUtils.clamp(__lchtBgBaseHSV[1], LCHT_BG_S_MIN, LCHT_BG_S_MAX);
+          const v = THREE.MathUtils.clamp(__lchtBgBaseHSV[2], LCHT_BG_V_MIN, LCHT_BG_V_MAX);
+          const rgb = hsvToRgb(h, s, v);
+          scene.background.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+        }
+
+        // — Foco rotativo: solo UNA capa protagonista
+        const cycle = (t / LCHT_FOCUS_PERIOD) % 5;
+        const focusIndex = Math.floor(cycle);    // capa activa
+        const frac = cycle - focusIndex;         // 0..1 dentro del ciclo
+
+        const prevIndex = (focusIndex + 4) % 5;  // la que sale
+
+        lichtGroup.traverse(m=>{
+          if (!m.isMesh || !m.material || !m.userData || m.userData.zSlot === undefined) return;
+
+          // respiración color/emisivo
+          if (m.userData.lcht){
+            const P = m.userData.lcht;
+            const k = P.I0 + P.amp * Math.sin(2*Math.PI*P.f * (t + t0) + P.phi);
+            m.material.emissiveIntensity = Math.max(0, k);
+            if (m.userData.baseHsv){
+              const bh  = m.userData.baseHsv;
+              const h   = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
+              const rgb = hsvToRgb(h, bh.s, bh.v);
+              m.material.color.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
+              m.material.emissive.copy(m.material.color);
+            }
+          }
+
+          // foco/atenuación
+          const z = m.userData.zSlot;
+          let alpha = LCHT_OFF_OPACITY;
+          let gain  = LCHT_OFF_GAIN;
+
+          if (z === focusIndex){
+            const s = smooth(frac);
+            alpha = LCHT_OFF_OPACITY + (LCHT_FOCUS_OPACITY - LCHT_OFF_OPACITY) * s;
+            gain  = LCHT_OFF_GAIN    + (LCHT_FOCUS_GAIN   - LCHT_OFF_GAIN)    * s;
+          } else if (z === prevIndex){
+            const s = smooth(1.0 - frac);
+            // la que sale se desvanece rápidamente
+            alpha = LCHT_OFF_OPACITY + (LCHT_FOCUS_OPACITY - LCHT_OFF_OPACITY) * (s*0.15);
+            gain  = LCHT_OFF_GAIN    + (LCHT_FOCUS_GAIN   - LCHT_OFF_GAIN)    * (s*0.15);
+          }
+          m.material.opacity = alpha;
+          // presencia global
+          m.material.emissiveIntensity *= 0.55 + 0.45*gain;
+          m.material.color.multiplyScalar(gain);
+          m.material.emissive.multiplyScalar(gain);
+        });
+
+        window.__lchtRAF = requestAnimationFrame(__lchtLoop);
       }
-    
-      if (!m.userData || !m.userData.lcht) return;
-      const P = m.userData.lcht;
-      const k = P.I0 + P.amp * Math.sin(2*Math.PI*P.f * (t + t0) + P.phi);
-      m.material.emissiveIntensity = Math.max(0, k);
-    
-      if (m.userData.baseHsv){
-        const bh  = m.userData.baseHsv;
-        const h   = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
-        const rgb = hsvToRgb(h, bh.s, bh.v);
-        m.material.color.setRGB(rgb[0]/255, rgb[1]/255, rgb[2]/255);
-        m.material.emissive.copy(m.material.color);
-      }
-    
-      // — Protagonismo rotativo por Z (intensidad/“presencia”)
-      const z = (m.userData.zSlot ?? 0) % 5;
-      // capa en foco: z === focusIndex
-      let w = (z === focusIndex) ? smoothPulse(frac) : 0.0;
-      // vecinos reciben un poco al entrar/salir (contigüidad en anillo)
-      const prev = (focusIndex + 4) % 5, next = (focusIndex + 1) % 5;
-      if (z === prev) w = smoothPulse(1.0 - frac) * 0.35;
-      if (z === next) w = Math.max(w, smoothPulse(frac) * 0.35);
-    
-      const dim = LCHT_BASE_DIM;
-      const gain = dim + (LCHT_FOCUS_GAIN - dim) * w;
-      // aplicamos como escala de “brillo” (color + emisivo)
-      m.material.emissiveIntensity *= 0.6 + 0.4*gain;
-      m.material.color.multiplyScalar(gain);
-      m.material.emissive.multiplyScalar(gain);
-    });
-    
-    window.__lchtRAF = requestAnimationFrame(__lchtLoop);
-  }
-  window.__lchtRAF = requestAnimationFrame(__lchtLoop);
-}
+      window.__lchtRAF = requestAnimationFrame(__lchtLoop);
+    }
     /* ════════════════════════════════════════════════════════════ */
-    
+
     function toggleLCHT(){
       if (!isLCHT && isOFFNNG) toggleOFFNNG();
       if (!isLCHT && isTMSL)  toggleTMSL();
       if (!isLCHT && isKEPLR) toggleKEPLR();
       isLCHT = !isLCHT;
-    
+
       if (isLCHT){
         leaveBuildRenderBoost();
         if(!cubeUniverse.userData.prevMat){
@@ -1397,8 +1361,6 @@ function initSkySphere() {
           });
         }
         if (!lchtPrevBg) lchtPrevBg = scene.background ? scene.background.clone() : null;
-        scene.background = new THREE.Color(0xf4f4f4);
-        if (isFRBN) toggleFRBN();
         buildLCHT();
         lichtGroup.visible        = true;
         cubeUniverse.visible      = false;


### PR DESCRIPTION
## Summary
- replace the inline LCHT engine in `index.html` with the new deterministic raster implementation featuring animated background hue drift and rotating focus logic
- mirror the updated LCHT behaviour in `engines/lcht.js` so the registered engine matches the new implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbc4c7a434832c8126a82f0dd33d5b