### PR TITLE
Adjust LCHT focus and raster rendering

### DIFF
--- a/engines/lcht.js
+++ b/engines/lcht.js
@@ -20,16 +20,24 @@ const LCHT_BG_S_WOBBLE_SPEED = 0.023;  // Hz
 const LCHT_BG_V_WOBBLE_AMP   = 0.025;
 const LCHT_BG_V_WOBBLE_SPEED = 0.017;  // Hz
 
-/* ——— Protagonismo rotativo (una capa a la vez, MUY suave) ——— */
-const LCHT_FOCUS_PERIOD = 18.0;   // s por vuelta (5 capas)
-const LCHT_FOCUS_OPACITY = 1.00;  // prota sin transparencia
-const LCHT_OFF_OPACITY   = 0.28;  // el resto nunca baja de esto
-const LCHT_FOCUS_GAIN    = 1.35;  // boost del color/emisivo en foco
-const LCHT_OFF_GAIN      = 0.85;  // el resto sigue visible
-const LCHT_FOCUS_SIGMA   = 0.55;  // anchura Gauss (suavidad)
+/* ——— Protagonismo rotativo (suave, sin apagados) ——— */
+const LCHT_FOCUS_PERIOD = 18.0;
+
+const LCHT_FOCUS_OPACITY = 1.00;  // prota 100% opaca
+const LCHT_OFF_OPACITY   = 0.58;  // nunca por debajo de este valor
+
+const LCHT_FOCUS_GAIN    = 1.80;  // color base en prota
+const LCHT_OFF_GAIN      = 1.00;  // el resto no pierde color
+
+const LCHT_FOCUS_SIGMA   = 0.55;  // cruce suave
 const LCHT_FOCUS_SHAPE   = 0.60;  // 0..1 (0.6 = pico amable)
-const LCHT_OPACITY_FLOOR = 0.22;  // piso duro de opacidad
-const LCHT_GAIN_FLOOR    = 0.80;  // piso duro de ganancia
+
+const LCHT_OPACITY_FLOOR = 0.58;  // pisos duros
+const LCHT_GAIN_FLOOR    = 1.00;
+
+/* brillo extra de la protagonista (emissive) */
+const LCHT_BASE_EI       = 0.40;  // base
+const LCHT_PROTAG_EI_BOOST = 2.50; // × sobre la base cuando wn→1
 
 /* ——— Refuerzos de legibilidad de líneas ——— */
 const LCHT_MIN_LINE_LUMA  = 0.42;  // luminancia mínima 0..1
@@ -64,12 +72,13 @@ function addRootRaster({ center, widthTile, heightTile, tilesX, tilesY, line, jo
     flatShading: true,
     transparent: true,
     opacity: LCHT_OFF_OPACITY,
-    depthWrite: true,                          // ← evita lavados por blending
+    depthTest: true,
+    depthWrite: true,                 // ← no “lava” con el fondo
     blending: THREE.NormalBlending,
     toneMapped: true
   });
   matBase.emissive = color.clone();
-  matBase.emissiveIntensity = 0.28;            // base más visible
+  matBase.emissiveIntensity = LCHT_BASE_EI;  // ← base visible
 
   const [h0,s0,v0] = rgbToHsv(color.r*255, color.g*255, color.b*255);
   const baseHsv = { h: h0, s: Math.min(1, s0*1.04), v: Math.min(1, v0*1.03) };
@@ -79,7 +88,7 @@ function addRootRaster({ center, widthTile, heightTile, tilesX, tilesY, line, jo
   const halfW  = panelW * 0.5;
   const halfH  = panelH * 0.5;
 
-  function mkVert(x, y, isVertical){
+  function place(x, y, isVertical){
     const geo  = isVertical
       ? new THREE.BoxGeometry(line, panelH + join, line)
       : new THREE.BoxGeometry(panelW + join, line, line);
@@ -87,31 +96,20 @@ function addRootRaster({ center, widthTile, heightTile, tilesX, tilesY, line, jo
     mesh.position.set(center.x + x, center.y + y, center.z);
     if (nz < 0) mesh.rotateY(Math.PI);
 
-    // —— bases absolutas para animación (nada se “acumula” con el tiempo)
-    mesh.userData.lcht     = lcht;
-    mesh.userData.baseHsv  = baseHsv;
-    mesh.userData.zSlot    = zSlot;
-    mesh.userData.baseRGB  = [
-      mesh.material.color.r,
-      mesh.material.color.g,
-      mesh.material.color.b
-    ];
-    mesh.userData.baseEI   = mesh.material.emissiveIntensity;
-
-    // —— orden de pintado estable por Z (evita popping con transparencias)
-    mesh.renderOrder = 10 + zSlot;
-
+    // bases ABSOLUTAS (no acumulación con el tiempo)
+    mesh.userData = {
+      lcht,
+      baseHsv,
+      baseRGB: [color.r, color.g, color.b],
+      baseEI : LCHT_BASE_EI,
+      zSlot
+    };
+    mesh.renderOrder = 10 + zSlot;   // orden estable por Z
     lichtGroup.add(mesh);
   }
 
-  for (let i=0; i<=tilesX; i++){
-    const x = -halfW + i*widthTile;
-    mkVert(x, 0, true);
-  }
-  for (let j=0; j<=tilesY; j++){
-    const y = -halfH + j*heightTile;
-    mkVert(0, y, false);
-  }
+  for (let i=0; i<=tilesX; i++) place(-halfW + i*widthTile, 0, true);
+  for (let j=0; j<=tilesY; j++) place(0, -halfH + j*heightTile, false);
 }
 
 function build(){
@@ -132,8 +130,8 @@ function build(){
   scene.add(lichtGroup);
 
   const step = cubeSize / 5;
-  const SIDE = 0.32;   // antes 0.24
-  const JOIN = 0.02;
+  const SIDE = 0.24 * 3.0;  // ← grosor ×3
+  const JOIN = 0.02 * 3.0;  // uniones acordes
   const TILE_H = step * 0.92 * 3.0;
   const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
 
@@ -245,59 +243,54 @@ function build(){
       }
     }
 
-    // — Foco rotativo suave con GAUSSIAN SOFTMAX (continuo, sin flips)
+    // — Foco rotativo con softmax gaussiano (continuo, sin saltos)
     const center = (t / LCHT_FOCUS_PERIOD) * 5.0; // 0..5
     const sigma2 = 2.0 * LCHT_FOCUS_SIGMA * LCHT_FOCUS_SIGMA;
 
-    // 1) pesos 0..1 normalizados por capa en anillo de 5
-    const weights = new Array(5);
-    let sumW = 0;
+    // pesos normalizados por capa (anillo de 5)
+    const weights = new Array(5); let sumW = 0;
     for (let z=0; z<5; z++){
-      let d = Math.abs(z - center);
-      d = Math.min(d, 5.0 - d);
+      let d = Math.abs(z - center); d = Math.min(d, 5.0 - d);
       const w = Math.exp(-(d*d)/sigma2);
       weights[z] = w; sumW += w;
     }
     for (let z=0; z<5; z++) weights[z] /= sumW;
 
-    // 2) aplica pesos ABSOLUTOS por malla (no *=)
     lichtGroup.traverse(m=>{
       if (!m.isMesh || !m.material || !m.userData || m.userData.zSlot === undefined) return;
 
-      // — color “respirando” desde HSV base (absoluto cada frame)
-      let r = m.userData.baseRGB ? m.userData.baseRGB[0] : m.material.color.r;
-      let g = m.userData.baseRGB ? m.userData.baseRGB[1] : m.material.color.g;
-      let b = m.userData.baseRGB ? m.userData.baseRGB[2] : m.material.color.b;
-
-      if (m.userData.lcht && m.userData.baseHsv){
-        const P  = m.userData.lcht;
-        const bh = m.userData.baseHsv;
+      // — color “respirando” SIEMPRE desde la base (sin *=)
+      const base = m.userData;
+      let r = base.baseRGB[0], g = base.baseRGB[1], b = base.baseRGB[2];
+      if (base.lcht && base.baseHsv){
+        const P  = base.lcht, bh = base.baseHsv;
         const h  = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
         const rgb = hsvToRgb(h, bh.s, bh.v);
         r = rgb[0]/255; g = rgb[1]/255; b = rgb[2]/255;
       }
 
-      // — peso de protagonismo suavizado y con “pico” configurable
-      const wn = Math.pow(weights[m.userData.zSlot], LCHT_FOCUS_SHAPE);
+      const wn = Math.pow(weights[base.zSlot], LCHT_FOCUS_SHAPE);
 
-      // — ganancia/opacity con pisos (nunca desaparecen)
-      const gainAbs = Math.max(LCHT_GAIN_FLOOR,
+      // — ganancia y opacidad ABSOLUTAS con pisos altos (no desaparecen)
+      const gainAbs    = Math.max(LCHT_GAIN_FLOOR,
                        LCHT_OFF_GAIN + (LCHT_FOCUS_GAIN - LCHT_OFF_GAIN) * wn);
       const opacityAbs = Math.max(LCHT_OPACITY_FLOOR,
-                          LCHT_OFF_OPACITY + (LCHT_FOCUS_OPACITY - LCHT_OFF_OPACITY) * wn);
+                       LCHT_OFF_OPACITY + (LCHT_FOCUS_OPACITY - LCHT_OFF_OPACITY) * wn);
 
-      // — aplica en valor absoluto (sin acumulaciones)
+      // color/emissive aplicados en absoluto
       m.material.color.setRGB(Math.min(1, r*gainAbs), Math.min(1, g*gainAbs), Math.min(1, b*gainAbs));
       m.material.emissive.setRGB(Math.min(1, r*gainAbs), Math.min(1, g*gainAbs), Math.min(1, b*gainAbs));
 
-      const P  = m.userData.lcht || { I0:1.0, amp:0.0, f:0.0, phi:0.0 };
+      // — brillo: la protagonista recibe un gran boost en emissive
+      const P  = base.lcht || { I0:1.0, amp:0.0, f:0.0, phi:0.0 };
       const breath = Math.max(0, P.I0 + P.amp * Math.sin(2*Math.PI*P.f * (t + t0) + P.phi));
-      const baseEI = (m.userData.baseEI != null) ? m.userData.baseEI : 0.28;
-      m.material.emissiveIntensity = baseEI * breath * (0.85 + 0.25*wn);
+      const ei = base.baseEI * (0.85 + 0.25*wn) * (1.0 + LCHT_PROTAG_EI_BOOST*wn);
+      m.material.emissiveIntensity = breath * ei;
 
+      // opacidad estable; depthWrite ON evita “lavados”
       if (!m.material.transparent){ m.material.transparent = true; m.material.needsUpdate = true; }
-      m.material.depthWrite = true;             // ← clave para no “lavar” las líneas
-      m.material.opacity = opacityAbs;
+      m.material.depthWrite = true;
+      m.material.opacity    = opacityAbs;
     });
 
     rafId = requestAnimationFrame(loop);


### PR DESCRIPTION
## Summary
- raise LCHT focus floors and introduce emissive boost constants for the protagonist
- rebuild the root raster material to use thicker geometry, stable depth settings, and absolute base colors
- update the focus animation loop to apply the new weighting, color breathing, and emissive intensity handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc4522ab24832c83fc0fc431efbd37