### PR TITLE
Adjust LCHT lighting balance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1089,37 +1089,51 @@ function initSkySphere() {
     let isLCHT     = false;
     let lchtPrevBg = null;
 
-    /* ——— Fondo animado HSL (rotación completa del tono) ——— */
-    let __lchtBgHueSeed = 0;       // semilla determinista de tono 0..1
+    /* ——— Fondo animado HSL (frío, tranquilo) ——— */
+    let __lchtBgHueSeed = 0;
+    const LCHT_BG_HUE_SPEED   = 0.005;  // MUY lento
+    const LCHT_BG_S_BASE      = 0.22;   // baja saturación (calmo)
+    const LCHT_BG_L_BASE      = 0.94;   // alto, pero sin deslumbrar
+    const LCHT_BG_DRIFT_AMP   = 0.05;   // pequeña deriva alrededor del frío
 
-    const LCHT_BG_HUE_SPEED   = 0.02;  // vueltas de HUE por segundo (0.02 ≈ 50 s/vuelta)
-    const LCHT_BG_S_BASE      = 0.38;  // saturación base (0..1) — nunca blanco
-    const LCHT_BG_L_BASE      = 0.92;  // luminosidad base (0..1)
-
-    const LCHT_BG_S_WOBBLE_AMP   = 0.06;  // respiración de S
-    const LCHT_BG_S_WOBBLE_SPEED = 0.018;
-
-    const LCHT_BG_L_WOBBLE_AMP   = 0.03;  // respiración de L (suave para no deslumbrar)
-    const LCHT_BG_L_WOBBLE_SPEED = 0.013;
-
-    /* ——— Protagonismo rotativo (suave, sin apagados) ——— */
+    /* ——— Protagonismo (igual que backup) ——— */
     const LCHT_FOCUS_PERIOD = 18.0;
+    const LCHT_FOCUS_SIGMA  = 0.55;
+    const LCHT_FOCUS_SHAPE  = 0.60;
 
-    const LCHT_FOCUS_OPACITY = 1.00;  // prota 100% opaca
-    const LCHT_OFF_OPACITY   = 0.58;  // nunca por debajo de este valor
+    const LCHT_FOCUS_OPACITY = 1.00;
+    const LCHT_OFF_OPACITY   = 0.58;
+    const LCHT_OPACITY_FLOOR = 0.58;
 
-    const LCHT_FOCUS_GAIN    = 1.80;  // color base en prota
-    const LCHT_OFF_GAIN      = 1.00;  // el resto no pierde color
+    const LCHT_FOCUS_GAIN  = 1.80;
+    const LCHT_OFF_GAIN    = 1.00;
+    const LCHT_GAIN_FLOOR  = 1.00;
 
-    const LCHT_FOCUS_SIGMA   = 0.55;  // cruce suave
-    const LCHT_FOCUS_SHAPE   = 0.60;  // 0..1 (0.6 = pico amable)
+    /* Emissive */
+    const LCHT_BASE_EI         = 0.40;
+    const LCHT_PROTAG_EI_BOOST = 3.20;
 
-    const LCHT_OPACITY_FLOOR = 0.58;  // pisos duros
-    const LCHT_GAIN_FLOOR    = 1.00;
+    /* — Push & Pull cromático (solo desde color) — */
+    const PP_WARM_CENTER = 0.00;   // rojo
+    const PP_COOL_CENTER = 0.58;   // cian/azulado estable
 
-    /* brillo extra de la protagonista (emissive) */
-    const LCHT_BASE_EI       = 0.40;  // base
-    const LCHT_PROTAG_EI_BOOST = 2.50; // × sobre la base cuando wn→1
+    // bias de tono hacia cálido en la prota y hacia frío en el resto
+    const WARM_BIAS = 0.22;        // cuánto se acerca la prota al rojo (0..1)
+    const COOL_BIAS = 0.18;        // cuánto se enfrían las no-prota (0..1)
+
+    // ligera respiración según calidez (igual que backup)
+    const PP_SAT_PUSH = 0.12;
+    const PP_VAL_PUSH = 0.06;
+
+    // separación Z entre capas (↑) y micro-push
+    const LAYER_Z_SEP = 1.85;      // ← MÁS separación entre rasters
+    const PP_Z_PUSH   = 0.12;      // micro-parallax por calidez (conservar)
+
+    /* Halo (igual base, pero más discreto en no-protas) */
+    const HALO_SCALE       = 1.55;
+    const HALO_BASE        = 0.08;
+    const HALO_FOCUS_BOOST = 0.85;
+    const HALO_COOL_CUT    = 0.35;
 
     /* color determinista base */
     function colorForPerm(pa){
@@ -1209,8 +1223,8 @@ function initSkySphere() {
       }
 
       const step = cubeSize / 5;
-      const SIDE = 0.24 * 3.0;  // ← grosor ×3
-      const JOIN = 0.02 * 3.0;  // uniones acordes
+      const SIDE = 0.24 * 1.5;   // ← mitad de grosor
+      const JOIN = 0.02 * 1.5;   // ajusta uniones acorde
 
       // Altura de tile fija para TODOS los rasters
       const TILE_H = step * 0.92 * 3.0;
@@ -1252,7 +1266,7 @@ function initSkySphere() {
         const y0 = Math.floor((I % 25) / 5);
         const cx = (x0 - 2) * step;
         const cy = (y0 - 2) * step;
-        const cz = (zSlot - 2) * step;
+        const cz = (zSlot - 2) * step * LAYER_Z_SEP;  // ← más separación Z
 
         const baseTilesX = 4;
         const tilesX     = baseTilesX * REPEAT;
@@ -1299,21 +1313,11 @@ function initSkySphere() {
         if (!isLCHT || !lichtGroup) { window.__lchtRAF = null; return; }
         const t = ts * 0.001;
 
-        // — Fondo animado HSL: H rota 360°, S y L “respiran” suavemente
+        // — Fondo: siempre frío y calmado (no compite con los rasters)
         {
-          const h = (__lchtBgHueSeed + (t + t0) * LCHT_BG_HUE_SPEED) % 1;
-
-          const s = THREE.MathUtils.clamp(
-            LCHT_BG_S_BASE + LCHT_BG_S_WOBBLE_AMP * Math.sin(2*Math.PI*LCHT_BG_S_WOBBLE_SPEED * (t + t0)),
-            0.20, 0.80
-          );
-
-          const l = THREE.MathUtils.clamp(
-            LCHT_BG_L_BASE + LCHT_BG_L_WOBBLE_AMP * Math.cos(2*Math.PI*LCHT_BG_L_WOBBLE_SPEED * (t + t0)),
-            0.70, 0.95
-          );
-
-          scene.background.setHSL(h, s, l);
+          const h = (PP_COOL_CENTER + LCHT_BG_DRIFT_AMP *
+                    Math.sin(2*Math.PI*LCHT_BG_HUE_SPEED * t)) % 1;
+          scene.background.setHSL(h, LCHT_BG_S_BASE, LCHT_BG_L_BASE);
         }
 
         // — Foco rotativo con softmax gaussiano (continuo, sin saltos)
@@ -1345,18 +1349,28 @@ function initSkySphere() {
         lichtGroup.traverse(m=>{
           if (!m.isMesh || !m.material || !m.userData || m.userData.zSlot === undefined) return;
 
-          // — color “respirando” SIEMPRE desde la base (sin *=)
           const base = m.userData;
+          const weightRaw = Math.max(0, Math.min(1, (weights[base.zSlot] ?? 0)));
+          const wn = Math.pow(weightRaw, LCHT_FOCUS_SHAPE);
+
+          // — color “respirando” SIEMPRE desde la base (sin *=)
           let r = base.baseRGB[0], g = base.baseRGB[1], b = base.baseRGB[2];
           if (base.lcht && base.baseHsv){
             const P  = base.lcht, bh = base.baseHsv;
-            const h  = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
-            const rgb = hsvToRgb(h, bh.s, bh.v);
+            let h = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
+
+            // sesgo Hofmann: prota → cálido, no-protas → frío
+            // wn = peso de foco [0..1] ya calculado arriba
+            h = THREE.MathUtils.lerp(h, PP_WARM_CENTER, WARM_BIAS * wn);
+            h = THREE.MathUtils.lerp(h, PP_COOL_CENTER, COOL_BIAS * (1.0 - wn));
+
+            // respiración suave de S y V (como antes)
+            const s = THREE.MathUtils.clamp(bh.s * (1.0 + (wn - 0.5)*PP_SAT_PUSH*2), 0, 1);
+            const v = THREE.MathUtils.clamp(bh.v * (1.0 + (wn - 0.5)*PP_VAL_PUSH*2), 0, 1);
+
+            const rgb = hsvToRgb(h, s, v);
             r = rgb[0]/255; g = rgb[1]/255; b = rgb[2]/255;
           }
-
-          // peso suavizado y CLAMP para evitar NaN/Inf
-          let wn = Math.pow(Math.max(0, Math.min(1, weights[base.zSlot])), LCHT_FOCUS_SHAPE);
 
           // — ganancia y opacidad ABSOLUTAS con pisos altos (no desaparecen)
           const gainAbs    = Math.max(LCHT_GAIN_FLOOR,
@@ -1368,17 +1382,25 @@ function initSkySphere() {
           m.material.color.setRGB(Math.min(1, r * gainAbs), Math.min(1, g * gainAbs), Math.min(1, b * gainAbs));
           m.material.emissive.setRGB(Math.min(1, r * gainAbs), Math.min(1, g * gainAbs), Math.min(1, b * gainAbs));
 
-          // — brillo: la protagonista recibe un gran boost en emissive
           const P  = base.lcht || { I0:1.0, amp:0.0, f:0.0, phi:0.0 };
           const breath = Math.max(0, P.I0 + P.amp * Math.sin(2*Math.PI*P.f * (t + t0) + P.phi));
-          const ei = base.baseEI * (0.85 + 0.25*wn) * (1.0 + LCHT_PROTAG_EI_BOOST*wn);
-          m.material.emissiveIntensity = breath * ei;
 
           // opacidad estable; depthWrite ON evita “lavados”
           if (!m.material.transparent){ m.material.transparent = true; m.material.needsUpdate = true; }
           m.material.depthWrite = true;
-          // clamp extra por si alguna plataforma trata NaN como 0
-          m.material.opacity = Math.min(1, Math.max(0.0, opacityAbs));
+
+          if (base.lcht){
+            // — brillo: la protagonista recibe un gran boost en emissive
+            const ei = base.baseEI * (0.85 + 0.25*wn) * (1.0 + LCHT_PROTAG_EI_BOOST*wn);
+            m.material.emissiveIntensity = breath * ei;
+
+            // clamp extra por si alguna plataforma trata NaN como 0
+            m.material.opacity = Math.min(1, Math.max(0.0, opacityAbs));
+          } else {
+            // halo: su presencia depende casi totalmente del foco (evita blanqueos)
+            m.material.opacity = THREE.MathUtils.clamp(HALO_BASE*0.25 + HALO_FOCUS_BOOST*wn, 0, 1);
+            m.material.emissiveIntensity = base.baseEI * (0.9 + 1.3*wn) * breath;
+          }
         });
 
         window.__lchtRAF = requestAnimationFrame(__lchtLoop);


### PR DESCRIPTION
### **User description**
## Summary
- retune the LCHT background, focus, and halo constants for a calmer scene with stronger protagonists
- halve raster line thickness and increase layer spacing for clearer separation
- bias raster hues toward warm focus and cool off-focus while easing halo intensity outside the spotlight

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce6fccee8832ca7e8daced2a2f811


___

### **PR Type**
Enhancement


___

### **Description**
- Rebalanced LCHT lighting system for calmer visual experience

- Reduced raster line thickness and increased layer separation

- Added warm/cool color bias for focus/off-focus elements

- Refined halo intensity and background animation parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Background Animation"] --> B["Color Temperature Bias"]
  B --> C["Focus Weight Calculation"]
  C --> D["Opacity & Emissive Adjustments"]
  D --> E["Halo Intensity Control"]
  F["Layer Separation"] --> G["Visual Clarity"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>LCHT lighting system rebalancing and visual refinements</code>&nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Reduced background animation speed and saturation for calmer <br>appearance<br> <li> Added warm/cool color bias system for focus vs off-focus elements<br> <li> Halved raster line thickness and increased Z-layer separation<br> <li> Refined halo opacity calculations to reduce visual noise</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/609/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+73/-51</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

