### PR TITLE
Add exterior/interior hue bias to LCHT rasters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1120,6 +1120,9 @@ function initSkySphere() {
     // bias de tono hacia cálido en la prota y hacia frío en el resto
     const WARM_BIAS = 0.22;        // cuánto se acerca la prota al rojo (0..1)
     const COOL_BIAS = 0.18;        // cuánto se enfrían las no-prota (0..1)
+    // — Sesgo extra de tono por posición en el raster (Hofmann: marco cálido / interior frío)
+    const EDGE_WARM_BIAS = 0.25;   // cuánto se calienta el EXTERIOR (0..1)
+    const EDGE_COOL_BIAS = 0.22;   // cuánto se enfría el INTERIOR (0..1)
 
     // ligera respiración según calidez (igual que backup)
     const PP_SAT_PUSH = 0.12;
@@ -1170,7 +1173,15 @@ function initSkySphere() {
       const halfW  = panelW * 0.5;
       const halfH  = panelH * 0.5;
 
-      function place(x, y, isVertical){
+      // — Banda “exterior” = ~1/4 del raster
+      const band = Math.ceil(0.25 * Math.min(tilesX, tilesY));
+
+      function place(x, y, isVertical, idx){
+        // ¿esta línea cae en la banda exterior?
+        const isExterior = isVertical
+          ? (idx < band || idx > tilesX - band)
+          : (idx < band || idx > tilesY - band);
+
         const geo  = isVertical
           ? new THREE.BoxGeometry(line, panelH + join, line)
           : new THREE.BoxGeometry(panelW + join, line, line);
@@ -1178,20 +1189,29 @@ function initSkySphere() {
         mesh.position.set(center.x + x, center.y + y, center.z);
         if (nz < 0) mesh.rotateY(Math.PI);
 
-        // bases ABSOLUTAS (no acumulación con el tiempo)
+        // bases ABSOLUTAS (no acumulación con el tiempo) + flag exterior/interior
         mesh.userData = {
           lcht,
           baseHsv,
           baseRGB: [color.r, color.g, color.b],
           baseEI : LCHT_BASE_EI,
-          zSlot
+          zSlot,
+          isExterior   // true = marco (se calienta); false = interior (se enfría)
         };
         mesh.renderOrder = 10 + zSlot;   // orden estable por Z
         lichtGroup.add(mesh);
       }
 
-      for (let i=0; i<=tilesX; i++) place(-halfW + i*widthTile, 0, true);
-      for (let j=0; j<=tilesY; j++) place(0, -halfH + j*heightTile, false);
+      // Verticales
+      for (let i = 0; i <= tilesX; i++){
+        const x = -halfW + i*widthTile;
+        place(x, 0, true, i);
+      }
+      // Horizontales
+      for (let j = 0; j <= tilesY; j++){
+        const y = -halfH + j*heightTile;
+        place(0, y, false, j);
+      }
     }
 
     /* ———————————————————————————————————————————————————————————— */
@@ -1359,10 +1379,17 @@ function initSkySphere() {
             const P  = base.lcht, bh = base.baseHsv;
             let h = (bh.h + 0.03*Math.sin(2*Math.PI*P.f * (t + t0) + P.phi)) % 1;
 
-            // sesgo Hofmann: prota → cálido, no-protas → frío
-            // wn = peso de foco [0..1] ya calculado arriba
-            h = THREE.MathUtils.lerp(h, PP_WARM_CENTER, WARM_BIAS * wn);
-            h = THREE.MathUtils.lerp(h, PP_COOL_CENTER, COOL_BIAS * (1.0 - wn));
+            // sesgo Hofmann compuesto: prota→cálido, no-protas→frío, y además
+            // EXTERIOR (marco) más cálido / INTERIOR más frío
+            {
+              // wn ya está calculado (0..1). A partir de él armamos pesos de sesgo:
+              const biasWarm = THREE.MathUtils.clamp(WARM_BIAS * wn + (base.isExterior ? EDGE_WARM_BIAS : 0.0), 0, 0.65);
+              const biasCool = THREE.MathUtils.clamp(COOL_BIAS * (1.0 - wn) + (!base.isExterior ? EDGE_COOL_BIAS : 0.0), 0, 0.65);
+
+              // primero atraemos el tono hacia cálido, luego hacia frío (orden suave)
+              h = THREE.MathUtils.lerp(h, PP_WARM_CENTER, biasWarm);
+              h = THREE.MathUtils.lerp(h, PP_COOL_CENTER, biasCool);
+            }
 
             // respiración suave de S y V (como antes)
             const s = THREE.MathUtils.clamp(bh.s * (1.0 + (wn - 0.5)*PP_SAT_PUSH*2), 0, 1);


### PR DESCRIPTION
### **User description**
## Summary
- add warm/cool edge bias constants to the LCHT renderer
- tag raster lines as exterior or interior when building meshes
- blend protagonist and edge hue biases when updating mesh colors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd5b294540832c962b46b7c2340746


___

### **PR Type**
Enhancement


___

### **Description**
- Add exterior/interior hue bias constants for LCHT rasters

- Tag raster lines as exterior/interior during mesh building

- Implement composite Hofmann bias blending warm/cool effects

- Simplify mesh creation by removing halo components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LCHT Constants"] --> B["Edge Bias Constants"]
  C["Mesh Creation"] --> D["Exterior/Interior Tagging"]
  D --> E["Composite Hue Bias"]
  B --> E
  E --> F["Updated Color Rendering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>LCHT raster exterior/interior hue bias implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Add <code>EDGE_WARM_BIAS</code> and <code>EDGE_COOL_BIAS</code> constants<br> <li> Tag mesh lines as exterior/interior based on position<br> <li> Implement composite hue bias blending protagonist and edge effects<br> <li> Simplify mesh creation by removing halo geometry</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/611/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+36/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lcht.js</strong><dd><code>LCHT engine hue bias and mesh simplification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engines/lcht.js

<ul><li>Add edge bias constants for exterior/interior positioning<br> <li> Refactor mesh creation to single geometry without halo<br> <li> Implement exterior/interior band detection logic<br> <li> Apply composite Hofmann bias in color updates</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/611/files#diff-01c62f14cf22c1d02dfa86ec40752f98048177b17f013164f74cfc53332ba004">+52/-61</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

