### PR TITLE
Adjust LCHT panel sizing to aperture

### DIFF
--- a/index.html
+++ b/index.html
@@ -1266,7 +1266,8 @@ function initSkySphere() {
         layers.push({ zSlot:z, permIdx: pick });
       }
 
-      const REPEAT = 10;
+      // El panel se hace solo un poco más grande que la abertura (≈ 6% extra)
+      const PANEL_MARGIN = 1.06;
 
       // Construcción de capas
       layers.forEach(({zSlot, permIdx})=>{
@@ -1288,9 +1289,18 @@ function initSkySphere() {
         const cy = (y0 - 2) * step;
         const cz = (zSlot - 2) * step * LAYER_Z_SEP;  // ← más separación Z
 
-        const baseTilesX = 4;
-        const tilesX     = baseTilesX * REPEAT;
-        const tilesY     = Math.max(2, Math.round(tilesX / ratio));
+        // Tamaño de la abertura (interior del marco)
+        // Altura de abertura ≈ 3 * step * 0.92  (mismo canon que TILE_H)
+        const apertureH = step * 0.92 * 3.0;
+        const apertureW = apertureH * ratio;
+
+        // Queremos que el panel sea solo un poco mayor que la abertura
+        const targetW = apertureW * PANEL_MARGIN;
+        const targetH = apertureH * PANEL_MARGIN;
+
+        // Número de tiles que cubren ese tamaño (mínimo razonable para que se perciba la trama)
+        const tilesX = Math.max(3, Math.ceil(targetW / widthTile));
+        const tilesY = Math.max(3, Math.ceil(targetH / heightTile));
 
         const sig  = computeSignature(pa);
         const rng  = computeRange(sig);


### PR DESCRIPTION
### **User description**
## Summary
- replace the fixed repeat multiplier with a panel margin constant for LCHT panel sizing
- compute the raster tile counts from the aperture dimensions so the panel just exceeds the opening

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd966b3d30832c9cc36be78d7f80bf


___

### **PR Type**
Enhancement


___

### **Description**
- Replace fixed repeat multiplier with aperture-based panel sizing

- Calculate raster tile counts from aperture dimensions

- Add 6% margin constant for panel sizing optimization

- Ensure panels just exceed opening dimensions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed REPEAT multiplier"] -- "replaced by" --> B["PANEL_MARGIN constant"]
  C["Aperture dimensions"] -- "calculate" --> D["Target panel size"]
  D -- "determine" --> E["Optimal tile counts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Dynamic panel sizing based on aperture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Replace fixed <code>REPEAT = 10</code> with <code>PANEL_MARGIN = 1.06</code> constant<br> <li> Calculate aperture dimensions based on step and ratio<br> <li> Compute tile counts from target panel size with minimum constraints<br> <li> Remove hardcoded <code>baseTilesX</code> and dynamic ratio-based sizing</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/612/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+14/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

