### PR TITLE
Adjust LCHT panel margin and tile coverage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1266,8 +1266,10 @@ function initSkySphere() {
         layers.push({ zSlot:z, permIdx: pick });
       }
 
-      // El panel se hace solo un poco más grande que la abertura (≈ 6% extra)
-      const PANEL_MARGIN = 1.06;
+      // Un poco más grande que la abertura (≈ 25% más)
+      const PANEL_MARGIN = 1.25;
+      // Añade 1 tile extra por cada lado para que “rebose” el marco
+      const EXTRA_BORDER_TILES = 1;
 
       // Construcción de capas
       layers.forEach(({zSlot, permIdx})=>{
@@ -1290,17 +1292,20 @@ function initSkySphere() {
         const cz = (zSlot - 2) * step * LAYER_Z_SEP;  // ← más separación Z
 
         // Tamaño de la abertura (interior del marco)
-        // Altura de abertura ≈ 3 * step * 0.92  (mismo canon que TILE_H)
         const apertureH = step * 0.92 * 3.0;
         const apertureW = apertureH * ratio;
 
-        // Queremos que el panel sea solo un poco mayor que la abertura
+        // Panel objetivo (un poco más grande)
         const targetW = apertureW * PANEL_MARGIN;
         const targetH = apertureH * PANEL_MARGIN;
 
-        // Número de tiles que cubren ese tamaño (mínimo razonable para que se perciba la trama)
-        const tilesX = Math.max(3, Math.ceil(targetW / widthTile));
-        const tilesY = Math.max(3, Math.ceil(targetH / heightTile));
+        // Nº de tiles que cubren ese tamaño + 1 tile extra por lado
+        let tilesX = Math.ceil(targetW / widthTile) + 2 * EXTRA_BORDER_TILES;
+        let tilesY = Math.ceil(targetH / heightTile) + 2 * EXTRA_BORDER_TILES;
+
+        // Pisos mínimos para que la rejilla se lea bien
+        tilesX = Math.max(5, tilesX);
+        tilesY = Math.max(5, tilesY);
 
         const sig  = computeSignature(pa);
         const rng  = computeRange(sig);


### PR DESCRIPTION
### **User description**
## Summary
- expand the LCHT panel margin to 25% beyond the aperture and add an explicit extra tile border constant
- ensure tile counts include additional border coverage while enforcing a higher minimum grid size

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd9af28b20832c9752cf6e182bf2c8


___

### **PR Type**
Enhancement


___

### **Description**
- Expand LCHT panel margin from 6% to 25% beyond aperture

- Add explicit extra border tiles constant for better coverage

- Increase minimum grid size from 3x3 to 5x5 tiles

- Improve tile calculation logic for consistent visual coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Panel"] -- "Expand margin 6% → 25%" --> B["Larger Panel"]
  B -- "Add border tiles" --> C["Enhanced Coverage"]
  C -- "Enforce 5x5 minimum" --> D["Improved Grid"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Enhanced LCHT panel sizing and tile coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Increase <code>PANEL_MARGIN</code> constant from 1.06 to 1.25<br> <li> Add <code>EXTRA_BORDER_TILES</code> constant set to 1<br> <li> Update tile calculation to include extra border tiles<br> <li> Raise minimum grid size from 3x3 to 5x5 tiles</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/613/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+12/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

