### PR TITLE
Adjust LCHT grid scaling

### DIFF
--- a/engines/lcht.js
+++ b/engines/lcht.js
@@ -52,6 +52,10 @@ const PP_VAL_PUSH = 0.06;
 const LAYER_Z_SEP = 1.85;      // ← MÁS separación entre rasters
 const PP_Z_PUSH   = 0.12;      // micro-parallax por calidez (conservar)
 
+/* ——— Escalado del grid y tamaño del rectángulo raíz ——— */
+const GRID_SCALE    = 1.25;  // ↑ hace el panel (grid) más grande
+const TILE_H_SHRINK = 2.40;  // ↓ hace cada rectángulo raíz más pequeño (antes 3.0)
+
 /* Halo (igual base, pero más discreto en no-protas) */
 const HALO_SCALE       = 1.55;
 const HALO_BASE        = 0.08;
@@ -175,7 +179,7 @@ function build(){
   __lchtStep = step;  // ← para PP_Z_PUSH
   const SIDE = 0.24 * 1.5;   // ← mitad de grosor
   const JOIN = 0.02 * 1.5;   // ajusta uniones acorde
-  const TILE_H = step * 0.92 * 3.0;
+  const TILE_H = step * 0.92 * TILE_H_SHRINK;  // rectángulo raíz más pequeño
   const ROOT_RATIOS = [0, 1.0, Math.SQRT2, Math.sqrt(3), 2.0, Math.sqrt(5)];
 
   const perms = getPerms();
@@ -190,7 +194,7 @@ function build(){
     layers.push({ zSlot:z, permIdx: pick });
   }
 
-  const REPEAT = 10;
+  const REPEAT = 12;  // panel final más amplio
   const sceneKey = (37*window.sceneSeed + 101*window.S_global) % 360;
   __lchtBgHueSeed = (sceneKey / 360);
 
@@ -214,9 +218,9 @@ function build(){
     const cy = (y0 - 2) * step;
     const cz = (zSlot - 2) * step * LAYER_Z_SEP;
 
-    const baseTilesX = 4;
-    const tilesX     = baseTilesX * REPEAT;
-    const tilesY     = Math.max(2, Math.round(tilesX / ratio));
+    const baseTilesX = 5;   // un poco más denso
+    const tilesX     = Math.round(baseTilesX * REPEAT * GRID_SCALE);          // panel más grande
+    const tilesY     = Math.max(2, Math.round((baseTilesX * REPEAT * GRID_SCALE) / ratio));
 
     const sig  = window.computeSignature(pa);
     const rng  = window.computeRange(sig);


### PR DESCRIPTION
### **User description**
## Summary
- add grid scaling and tile shrink constants for the LCHT engine
- shrink base tile height and increase grid density using the new constants
- enlarge the rendered panel by applying grid scaling to the tile counts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd9ddd7ecc832cb00a30380e10929d


___

### **PR Type**
Enhancement


___

### **Description**
- Add grid scaling and tile shrink constants for LCHT engine

- Increase grid density and enlarge rendered panel

- Shrink base tile height for better visual proportions

- Adjust tile count calculations with new scaling factors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  constants["Grid Scaling Constants"] --> calculations["Tile Calculations"]
  calculations --> panel["Enlarged Panel"]
  calculations --> tiles["Smaller Tiles"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lcht.js</strong><dd><code>Add grid scaling constants and adjust tile dimensions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

engines/lcht.js

<ul><li>Add <code>GRID_SCALE</code> and <code>TILE_H_SHRINK</code> constants for grid scaling<br> <li> Replace hardcoded tile height calculation with <code>TILE_H_SHRINK</code> constant<br> <li> Increase <code>REPEAT</code> from 10 to 12 for wider panel<br> <li> Update tile count calculations to use <code>GRID_SCALE</code> for larger grid<br> <li> Increase <code>baseTilesX</code> from 4 to 5 for denser grid</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/614/files#diff-01c62f14cf22c1d02dfa86ec40752f98048177b17f013164f74cfc53332ba004">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

