### PR TITLE
Adjust LCHT grid tiling balance

### DIFF
--- a/engines/lcht.js
+++ b/engines/lcht.js
@@ -60,7 +60,7 @@ const LAYER_Z_SEP = 1.85;      // ← MÁS separación entre rasters
 const PP_Z_PUSH   = 0.12;      // micro-parallax por calidez (conservar)
 
 /* ——— Escalado del grid y tamaño del rectángulo raíz ——— */
-const GRID_SCALE    = 1.25;  // ↑ hace el panel (grid) más grande
+const GRID_SCALE    = 1.15;  // ↑ hace el panel (grid) más grande
 const TILE_H_SHRINK = 2.40;  // ↓ hace cada rectángulo raíz más pequeño (antes 3.0)
 
 /* Halo (igual base, pero más discreto en no-protas) */
@@ -205,7 +205,7 @@ function build(){
     layers.push({ zSlot:z, permIdx: pick });
   }
 
-  const REPEAT = 12;  // panel final más amplio
+  const REPEAT = 1;  // panel final más amplio
   const sceneKey = (37*window.sceneSeed + 101*window.S_global) % 360;
   __lchtBgHueSeed = (sceneKey / 360);
 
@@ -231,7 +231,8 @@ function build(){
 
     const baseTilesX = 4 * DENSITY_MULT;   // ← antes 4; ahora 12 (3×)
     const tilesX     = Math.round(baseTilesX * REPEAT * GRID_SCALE);          // panel más grande
-    const tilesY     = Math.max(2, Math.round(tilesX / ratio));
+    const safeRatio  = ratio > 0 ? ratio : 1.0;
+    const tilesY     = Math.max(2, Math.round(tilesX / safeRatio * 1.15));
 
     const sig  = window.computeSignature(pa);
     const rng  = window.computeRange(sig);

--- a/index.html
+++ b/index.html
@@ -1140,7 +1140,7 @@ function initSkySphere() {
     const PP_Z_PUSH   = 0.12;      // micro-parallax por calidez (conservar)
 
     /* ——— Escalado del grid y tamaño del rectángulo raíz ——— */
-    const GRID_SCALE    = 1.25;  // ↑ hace el panel (grid) más grande
+    const GRID_SCALE    = 1.15;  // ↑ hace el panel (grid) más grande
     const TILE_H_SHRINK = 2.40;  // ↓ hace cada rectángulo raíz más pequeño (antes 3.0)
 
     /* Halo (igual base, pero más discreto en no-protas) */
@@ -1282,7 +1282,7 @@ function initSkySphere() {
         layers.push({ zSlot:z, permIdx: pick });
       }
 
-      const REPEAT = 12;  // panel final más amplio
+      const REPEAT = 1;  // panel final más amplio
 
       // Construcción de capas
       layers.forEach(({zSlot, permIdx})=>{
@@ -1307,7 +1307,7 @@ function initSkySphere() {
         const baseTilesX = 4 * DENSITY_MULT;   // ← antes 4; ahora 12 (3×)
         const tilesX     = Math.round(baseTilesX * REPEAT * GRID_SCALE);
         const safeRatio  = ratio > 0 ? ratio : 1.0;
-        const tilesY     = Math.max(2, Math.round(tilesX / safeRatio));
+        const tilesY     = Math.max(2, Math.round(tilesX / safeRatio * 1.15));
 
         const sig  = computeSignature(pa);
         const rng  = computeRange(sig);


### PR DESCRIPTION
## Summary
- reduce the LCHT grid scaling factor and repetition multiplier to keep panels more controlled
- adjust tile row calculation to add extra height for wide ratios using a safe ratio guard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de3083f0fc832cb31c1af0f0491aa6