### PR TITLE
Adjust LCHT aperture fitting and RAUM color dynamics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,30 +1129,30 @@ function initSkySphere() {
 
     // ==== Apertura y escalado (REEMPLAZA) ====
     const APERTURE_UNITS    = 4.05;  // tamaño interno aprox. en múltiplos de step
-    const APERTURE_OVERSCAN = 1.03;  // 3% de respiración
+    const APERTURE_OVERSCAN = 1.02;  // respiración mínima (2%)
 
-    // Encaja SIEMPRE por ambos ejes con un único factor uniforme:
-    const SAFE_FIT_X = 0.98;         // no exceder 98% del ancho útil
-    const SAFE_FIT_Y = 0.98;         // no exceder 98% del alto útil
-    const FILL_BOOST = 1.015;        // pequeño “empuje” para llenar sin tocar bisel
-    const SCALE_MIN  = 0.80, SCALE_MAX = 1.40; // límites de seguridad
+    // Encaje seguro **uniforme** en ambos ejes (sin boosts):
+    const SAFE_FIT_X = 0.965;        // no exceder 96.5% del ancho útil
+    const SAFE_FIT_Y = 0.965;        // no exceder 96.5% del alto útil
+    const SCALE_MIN  = 0.80, SCALE_MAX = 1.40;
 
     // Centrado fijo en la apertura
     const ANCHOR_TO_APERTURE = true;
 
-    // Eliminamos la dependencia del “GRID_SCALE” para el tamaño final del panel:
-    const GRID_SCALE = 1.00; // ← déjalo neutro; el tamaño vendrá del fit
+    // El tamaño final lo decide el fit, no el grid:
+    const GRID_SCALE = 1.00;
 
     // ==== RAUM: marco cálido / interior frío (REEMPLAZA) ====
-    const FRAME_LINES       = 2;     // nº de líneas exteriores que cuentan como “marco”
-    const FRAME_WARM_BIAS   = 0.72;  // empuje de tono hacia cálido en marco
-    const FRAME_COOL_BIAS   = 0.60;  // empuje de tono hacia frío en interior
-    const FRAME_SAT_ADD     = 0.14;  // +S en marco
-    const FRAME_VAL_ADD     = 0.08;  // +V en marco
-    const INNER_SAT_CUT     = 0.10;  // −S en interior
-    const INNER_VAL_CUT     = 0.06;  // −V en interior
-    const FRAME_EI_BOOST    = 0.60;  // +60% emissive en marco
-    const INNER_EI_CUT      = 0.30;  // −30% emissive en interior
+    // nº de líneas exteriores que cuentan como “marco”
+    const FRAME_LINES       = 2;
+    const FRAME_WARM_BIAS   = 0.75;  // empuje de tono hacia cálido en marco
+    const FRAME_COOL_BIAS   = 0.62;  // empuje de tono hacia frío en interior
+    const FRAME_SAT_ADD     = 0.16;  // +S en marco
+    const FRAME_VAL_ADD     = 0.10;  // +V en marco
+    const INNER_SAT_CUT     = 0.12;  // −S en interior
+    const INNER_VAL_CUT     = 0.08;  // −V en interior
+    const FRAME_EI_BOOST    = 0.70;  // +70% emissive en marco
+    const INNER_EI_CUT      = 0.35;  // −35% emissive en interior
 
     // ligera respiración según calidez (igual que backup)
     const PP_SAT_PUSH = 0.12;
@@ -1195,12 +1195,12 @@ function initSkySphere() {
         transparent: true,
         opacity: LCHT_OFF_OPACITY,
         depthTest: true,
-        depthWrite: true,                 // ← no “lava” con el fondo
+        depthWrite: true,
         blending: THREE.NormalBlending,
-        toneMapped: true
+        toneMapped: false            // ← CLAVE: no lavar el emissive/HSV
       });
       matBase.emissive = color.clone();
-      matBase.emissiveIntensity = LCHT_BASE_EI;  // ← base visible
+      matBase.emissiveIntensity = LCHT_BASE_EI;
 
       const [h0,s0,v0] = rgbToHsv(color.r*255, color.g*255, color.b*255);
       const baseHsv = { h: h0, s: Math.min(1, s0*1.04), v: Math.min(1, v0*1.03) };
@@ -1212,8 +1212,8 @@ function initSkySphere() {
       const halfH  = panelH * 0.5;
 
       // --- helpers para decidir si es “marco” por CONTEO de líneas ---
-      const isFrameIndexX = (i) => (i < FRAME_LINES) || (i > tilesX - FRAME_LINES);
-      const isFrameIndexY = (j) => (j < FRAME_LINES) || (j > tilesY - FRAME_LINES);
+      const isFrameIndexX = (i) => (i <= FRAME_LINES) || (i >= tilesX - FRAME_LINES);
+      const isFrameIndexY = (j) => (j <= FRAME_LINES) || (j >= tilesY - FRAME_LINES);
 
       function place(x, y, isVertical, isOuter){
         const geo  = isVertical
@@ -1327,21 +1327,38 @@ function initSkySphere() {
 
         const cz = (zSlot - 2) * step * LAYER_Z_SEP;  // ← más separación Z
 
-        // ---------- DERIVA LOS TILES DESDE LA ABERTURA (nuevo) ----------
-        const baseTilesX = 4 * DENSITY_MULT;     // densidad base por “familia”
+        // ---------- DERIVA LOS TILES DESDE LA ABERTURA (robusto) ----------
         const safeRatio  = ratio > 0 ? ratio : 1.0;
-
-        // Priorizamos contar tiles para que el panel “nazca” del hueco:
-        const apertureW = (APERTURE_UNITS * step) * APERTURE_OVERSCAN;
-        const apertureH = (APERTURE_UNITS * step) * APERTURE_OVERSCAN;
+        const apertureW  = (APERTURE_UNITS * step) * APERTURE_OVERSCAN;
+        const apertureH  = (APERTURE_UNITS * step) * APERTURE_OVERSCAN;
 
         // altura de tile fija, ancho = ratio * altura
         const widthTile  = safeRatio * TILE_H;
         const heightTile = TILE_H;
 
-        // número de tiles aproximado que cabrían, con un ligero over para no quedar corto
-        const tilesX = Math.max(baseTilesX, Math.round((apertureW / widthTile)  * 1.05));
-        const tilesY = Math.max(3, Math.round((apertureH / heightTile) * 1.05));
+        // nº de tiles aproximado que cabrían SIN escala (ligero over para no quedar corto)
+        const tilesX = Math.max(4 * DENSITY_MULT, Math.ceil(apertureW / widthTile)  + FRAME_LINES + 1);
+        const tilesY = Math.max(3,                 Math.ceil(apertureH / heightTile) + FRAME_LINES + 1);
+
+        // Escalas base (sin fit)
+        const baseScaleW = PANEL_SCALE_W;
+        const baseScaleH = PANEL_SCALE_H * (ratio > 1.0 ? PANEL_EXTRA_H_WIDE : 1.0);
+
+        // Tamaño del panel sin encaje
+        const panelW0 = tilesX * widthTile  * baseScaleW;
+        const panelH0 = tilesY * heightTile * baseScaleH;
+
+        // factor **uniforme**: encaja dentro de la apertura en ambos ejes
+        let s = Math.min(
+          (apertureW * SAFE_FIT_X) / Math.max(1e-6, panelW0),
+          (apertureH * SAFE_FIT_Y) / Math.max(1e-6, panelH0)
+        );
+        s = THREE.MathUtils.clamp(s, SCALE_MIN, SCALE_MAX);
+
+        // En apaisados estrecha un toque para evitar “asomar” por los laterales
+        const WIDE_X_TIGHTEN = 0.975;
+        const scaleW = s * (ratio > 1.0 ? WIDE_X_TIGHTEN : 1.0);
+        const scaleH = s;
 
         const sig  = computeSignature(pa);
         const rng  = computeRange(sig);
@@ -1355,24 +1372,6 @@ function initSkySphere() {
 
         const faceForward = (((lehmerRank(pa) + sceneSeed + S_global) & 1) === 0);
         const normal = faceForward ? 1 : -1;
-
-        // Tamaño del panel sin escalado
-        const panelW0 = tilesX * widthTile  * PANEL_SCALE_W;
-        const panelH0 = tilesY * heightTile * (PANEL_SCALE_H * (ratio > 1.0 ? PANEL_EXTRA_H_WIDE : 1.0));
-
-        // factor **uniforme**: llenamos sin sobrepasar ninguno de los dos ejes
-        let s = Math.min(
-          (apertureW * SAFE_FIT_X) / Math.max(1e-6, panelW0),
-          (apertureH * SAFE_FIT_Y) / Math.max(1e-6, panelH0)
-        ) * FILL_BOOST;
-
-        s = THREE.MathUtils.clamp(s, SCALE_MIN, SCALE_MAX);
-
-        // En apaisados, estrecha 2–3% para evitar “asomar” por los laterales.
-        const WIDE_X_TIGHTEN = 0.975;
-
-        const scaleW = s * (ratio > 1.0 ? WIDE_X_TIGHTEN : 1.0);
-        const scaleH = s;
 
         addRootRaster({
           center: new THREE.Vector3(cx, cy, cz),


### PR DESCRIPTION
### **User description**
## Summary
- tighten the LCHT aperture fit constants and RAUM push/pull biases
- disable tone mapping on the root raster material and clamp frame detection indices
- derive tile counts and uniform scale directly from the aperture for more robust fitting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68debf768f40832cabca893737a766f5


___

### **PR Type**
Enhancement


___

### **Description**
- Tighten LCHT aperture fitting constants for more robust scaling

- Adjust RAUM color dynamics with stronger warm/cool biases

- Disable tone mapping on root raster material

- Improve frame detection logic with inclusive bounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Aperture Constants"] --> B["Uniform Scale Calculation"]
  C["RAUM Color Parameters"] --> D["Frame/Interior Detection"]
  E["Material Settings"] --> F["Tone Mapping Disabled"]
  B --> G["Robust Panel Fitting"]
  D --> H["Enhanced Color Dynamics"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Refine aperture fitting and color dynamics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Reduced aperture overscan from 3% to 2% and tightened safe fit margins<br> <li> Strengthened RAUM warm/cool biases and increased saturation/value <br>adjustments<br> <li> Disabled tone mapping on root raster material to preserve emissive/HSV<br> <li> Fixed frame detection logic to use inclusive bounds instead of <br>exclusive<br> <li> Reorganized tile count derivation and uniform scale calculation for <br>better robustness</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/625/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+48/-49</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

