### PR TITLE
Ajusta encaje LCHT con corrección de perspectiva

### DIFF
--- a/index.html
+++ b/index.html
@@ -1131,6 +1131,19 @@ function initSkySphere() {
     const APERTURE_UNITS    = 4.05;  // tamaño interno aprox. en múltiplos de step
     const APERTURE_OVERSCAN = 1.02;  // respiración mínima (2%)
 
+    // ——— Plano de referencia de la abertura y corrección de perspectiva ———
+    // Z del plano del hueco (centro de la “ventana” en tu escena). En LCHT suele ser 0.
+    // Si tu hueco está en otro Z, ajusta este valor una vez y listo.
+    const APERTURE_PLANE_Z = 0;
+
+    // Margen de seguridad adicional aplicado tras la corrección de perspectiva
+    const PERSPECTIVE_SAFE = 0.995;
+
+    // Diferencia de presencia entre marco e interior (opacidad extra)
+    // (esto refuerza visualmente el push-and-pull)
+    const FRAME_OPA_BOOST = 0.18;  // +18% opacidad en marco
+    const INNER_OPA_CUT   = 0.18;  // −18% opacidad en interior
+
     // Encaje seguro **uniforme** en ambos ejes (sin boosts):
     const SAFE_FIT_X = 0.965;        // no exceder 96.5% del ancho útil
     const SAFE_FIT_Y = 0.965;        // no exceder 96.5% del alto útil
@@ -1349,17 +1362,37 @@ function initSkySphere() {
         const panelW0 = tilesX * widthTile  * baseScaleW;
         const panelH0 = tilesY * heightTile * baseScaleH;
 
-        // factor **uniforme**: encaja dentro de la apertura en ambos ejes
+        // factor **uniforme**: encaja dentro de la apertura en ambos ejes (sin perspectiva)
         let s = Math.min(
           (apertureW * SAFE_FIT_X) / Math.max(1e-6, panelW0),
           (apertureH * SAFE_FIT_Y) / Math.max(1e-6, panelH0)
         );
         s = THREE.MathUtils.clamp(s, SCALE_MIN, SCALE_MAX);
 
-        // En apaisados estrecha un toque para evitar “asomar” por los laterales
+        // ——— Corrección de perspectiva por profundidad de la capa ———
+        // Queremos que el panel, a su profundidad cz, se vea con el MISMO encaje que en el plano de la abertura.
+        const cam = (typeof camera !== 'undefined') ? camera : null;
+        const camZ = cam && cam.position ? cam.position.z : 0;
+        const dPanel = Math.abs(camZ - cz);
+        const dApert = Math.max(1e-6, Math.abs(camZ - APERTURE_PLANE_Z));
+        let persp = dPanel / dApert;           // si está más lejos, hay que escalar ↑ en mundo
+        persp *= PERSPECTIVE_SAFE;             // pequeño margen para no tocar el bisel
+
+        // Escalas provisionales
         const WIDE_X_TIGHTEN = 0.975;
-        const scaleW = s * (ratio > 1.0 ? WIDE_X_TIGHTEN : 1.0);
-        const scaleH = s;
+        let scaleW = s * persp * (ratio > 1.0 ? WIDE_X_TIGHTEN : 1.0);
+        let scaleH = s * persp;
+
+        // ——— Verificación final contra la abertura (por si acaso) ———
+        const visW = panelW0 * scaleW;
+        const visH = panelH0 * scaleH;
+        const kFix = Math.min(
+          (apertureW * SAFE_FIT_X) / Math.max(1e-6, visW),
+          (apertureH * SAFE_FIT_Y) / Math.max(1e-6, visH),
+          1.0
+        );
+        scaleW *= kFix;
+        scaleH *= kFix;
 
         const sig  = computeSignature(pa);
         const rng  = computeRange(sig);
@@ -1493,16 +1526,15 @@ function initSkySphere() {
           m.material.depthWrite = true;
 
           if (base.lcht){
-            // — brillo: la protagonista recibe un gran boost en emissive
+            // opacidad estable + refuerzo RAUM (muy visible)
+            let opa = Math.max(0.0, opacityAbs);
+            opa *= base.isOuter ? (1.0 + FRAME_OPA_BOOST) : (1.0 - INNER_OPA_CUT);
+            m.material.opacity = Math.min(1, Math.max(0.02, opa));
+
+            // emissive (ya tienes el boost para prota + RAUM)
             let ei = base.baseEI * (0.85 + 0.25*wn) * (1.0 + LCHT_PROTAG_EI_BOOST*wn);
-
-            // refuerzo RAUM en presencia (emissive)
             ei *= base.isOuter ? (1.0 + FRAME_EI_BOOST) : (1.0 - INNER_EI_CUT);
-
             m.material.emissiveIntensity = breath * ei;
-
-            // clamp extra por si alguna plataforma trata NaN como 0
-            m.material.opacity = Math.min(1, Math.max(0.0, opacityAbs));
           } else {
             // halo: su presencia depende casi totalmente del foco (evita blanqueos)
             m.material.opacity = THREE.MathUtils.clamp(HALO_BASE*0.25 + HALO_FOCUS_BOOST*wn, 0, 1);


### PR DESCRIPTION
### **User description**
## Summary
- añade constantes de corrección de perspectiva y refuerzo de presencia para las líneas del marco LCHT
- ajusta el encaje del panel LCHT considerando la profundidad de cámara y verificando frente a la abertura
- refuerza el push-and-pull aplicando la modulación RAUM tanto en color como en opacidad y emissive

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded52ae438832c9bf7ecd48ec7030c


___

### **PR Type**
Enhancement


___

### **Description**
- Add perspective correction for LCHT panel fitting based on camera depth

- Implement frame presence boost with opacity modulation for push-and-pull effect

- Add safety constants for aperture plane reference and perspective correction

- Refactor opacity handling with RAUM modulation for enhanced visual depth


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Camera Position"] --> B["Perspective Correction"]
  B --> C["Panel Scaling"]
  C --> D["Aperture Verification"]
  D --> E["Frame/Inner Opacity"]
  E --> F["RAUM Modulation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>LCHT perspective correction and frame presence enhancement</code></dd></summary>
<hr>

index.html

<ul><li>Add perspective correction constants (<code>APERTURE_PLANE_Z</code>, <br><code>PERSPECTIVE_SAFE</code>)<br> <li> Add frame presence boost constants (<code>FRAME_OPA_BOOST</code>, <code>INNER_OPA_CUT</code>)<br> <li> Implement depth-based perspective correction in panel scaling<br> <li> Add final verification against aperture dimensions<br> <li> Refactor opacity handling with RAUM modulation for frame/inner <br>differentiation</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/627/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+43/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

