### PR TITLE
Clamp frame margins when classifying raster lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -1291,11 +1291,23 @@ function initSkySphere() {
       const halfW  = panelW * 0.5;
       const halfH  = panelH * 0.5;
 
-      const Lx = frameCols?.L|0, Rx = frameCols?.R|0;
-      const Ty = frameRows?.T|0, By = frameRows?.B|0;
+      // nº de columnas/filas de marco por lado (aseguramos enteros y rango)
+      const Lx = Math.max(0, Math.min(tilesX, (frameCols?.L|0)));
+      const Rx = Math.max(0, Math.min(tilesX, (frameCols?.R|0)));
+      const Ty = Math.max(0, Math.min(tilesY, (frameRows?.T|0)));
+      const By = Math.max(0, Math.min(tilesY, (frameRows?.B|0)));
 
-      const isOuterCol = (i) => (i <= Lx) || (i >= tilesX - Rx);
-      const isOuterRow = (j) => (j <= By) || (j >= tilesY - Ty);
+      /*
+       * Clasificación CORRECTA por índices de líneas:
+       *   - Verticales i = 0..tilesX   (delimitan tilesX columnas)
+       *   - Horizontales j = 0..tilesY  (delimitan tilesY filas)
+       *
+       * El marco ocupa Lx/Rx columnas y By/Ty filas por lado.
+       * Las 4 líneas de interfaz (i==Lx, i==tilesX-Rx, j==By, j==tilesY-Ty)
+       * PERTENECEN AL INTERIOR (frío) → por eso usamos < y > (NO ≤ ni ≥).
+       */
+      const isOuterCol = (i) => (i < Lx) || (i > tilesX - Rx);
+      const isOuterRow = (j) => (j < By) || (j > tilesY - Ty);
 
       function place(x, y, isVertical, isOuter){
         const geo  = isVertical


### PR DESCRIPTION
### **User description**
## Summary
- clamp frame column and row counts to valid ranges in addRootRaster
- adjust interior classification of interface lines to use strict comparisons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0df023c70832cb668500384b1cfbc


___

### **PR Type**
Bug fix


___

### **Description**
- Clamp frame margin values to valid ranges

- Fix interface line classification with strict comparisons

- Add comprehensive documentation for raster line logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Frame Margins Input"] --> B["Clamp to Valid Range"]
  B --> C["Classify Raster Lines"]
  C --> D["Interior vs Outer Lines"]
  D --> E["Corrected Interface Logic"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Fix frame margin validation and line classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Clamp frame column/row counts using <code>Math.max</code> and <code>Math.min</code><br> <li> Change interface line classification from <code><=</code>/<code>>=</code> to <code><</code>/<code>></code><br> <li> Add detailed Spanish comments explaining the classification logic<br> <li> Ensure frame margins stay within valid tile boundaries</ul>


</details>


  </td>
  <td><a href="https://github.com/gari01234/PRMTTN/pull/632/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+17/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

