### PR TITLE
Mantener cubeUniverse visible y ajustar opacidad en modo TOPO

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,9 +687,9 @@ function applyXRaySceneState(){
   }
 
   if (cubeUniverse){
-    cubeUniverse.visible = !isTopo;
+    cubeUniverse.visible = true;
     if (cubeUniverse.material){
-      cubeUniverse.material.opacity = isGrid ? 0.08 : 0.20;
+      cubeUniverse.material.opacity = isGrid ? 0.08 : (isTopo ? 0.14 : 0.20);
       cubeUniverse.material.needsUpdate = true;
     }
   }


### PR DESCRIPTION
### Motivation
- Garantizar que `cubeUniverse` permanezca visible en todos los modos y aplicar una opacidad específica para el modo `TOPO` para mejorar la apariencia cuando esa vista está activa.

### Description
- Reemplacé la función `applyXRaySceneState()` en `index.html` con la implementación proporcionada. 
- Se mantienen las visibilidades condicionadas de `rasterGridGroup`, `topographyGroup` y `permutationGroup` usando `isGrid`/`isTopo`/`!isTopo` respectivamente. 
- `cubeUniverse` ahora siempre se establece como visible y su material usa la expresión `cubeUniverse.material.opacity = isGrid ? 0.08 : (isTopo ? 0.14 : 0.20)` y se marca `needsUpdate`. 
- Se conservan las llamadas a `hideHoverPopup()` cuando `isTopo` y a `updateViewButtonsUI()` al final.

### Testing
- No automated tests were run for this static JavaScript/HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9c187c18832c86e080ce1264c925)