### PR TITLE
Quita selector de motor y limpia residuos heredados en index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,24 +203,6 @@
   }
   #infoPanel section{ margin-bottom:18px; }
   #infoPanel hr{ border:none; border-top:1px dashed #aaa; margin:18px 0; }
-  /* === ENGINE MENU (reemplaza botones sueltos) === */
-  #engineSelectWrap {
-    position: fixed;
-    left: 10px;
-    bottom: 290px;      /* ocupa el lugar que usaba OFFNNG, sin solapar PLAY/BUILD antiguos */
-    z-index: 260;
-    background: rgba(255,255,255,0.12);
-    padding: 6px 8px;
-    border-radius: 4px;
-  }
-  #engineSelectWrap select {
-    width: 180px;       /* ancho cómodo; no usamos 100% para no romper layout */
-    cursor: none;
-  }
-  #engineSelectWrap label {
-    font-size: 12px;
-    opacity: .85;
-  }
 
   /* Botón PLAY – genera nuevas permutaciones */
   #playButton{
@@ -280,14 +262,6 @@
   <button id="playButton" onclick="generateRandomConfigurationNoCollision()">▮</button>
 
   <button id="perm120Button"      onclick="togglePerm120Panel()">120 Architectural Permutations</button>
-
-  <!-- NUEVO: Menú de motores -->
-  <div id="engineSelectWrap">
-    <label for="engineSelect" style="display:block;margin-bottom:4px;">Engine</label>
-    <select id="engineSelect" onchange="applyEngineFromSelect(this.value)">
-      <option value="BUILD">BUILD</option>
-    </select>
-  </div>
 
   <button id="certButton" onclick="exportEditionCertificate()">Edition Certificate</button>
   <button id="infoButton" onclick="showInformation()">Information</button>
@@ -506,7 +480,7 @@ if (typeof config.chroma_mode === 'string') {
 
   <!-- (eliminados: copias duplicadas de Three, OrbitControls y Ethers) -->
   <script>
-    // ------------- TODO EL JS ORIGINAL (¡NO QUITES NADA DE AQUÍ!) -------------
+    // ------------- JS principal -------------
 
     // === Variables globales ===
     let scene, camera, renderer, controls, raycaster, mouse;
@@ -549,22 +523,8 @@ if (typeof config.chroma_mode === 'string') {
       if (typeof colorObj.convertSRGBToLinear === 'function') colorObj.convertSRGBToLinear();
     }
 
-function srgbHexToLinearColor(hex){
-  const h = normHex6(hex) || hex;
-  const c = new THREE.Color(h);
-  c.convertSRGBToLinear();
-  return c;
-}
 
-function setThreeColorFromSRGBHex(threeColor, hex){
-  threeColor.setStyle(hex);          // interpreta como sRGB
-  threeColor.convertSRGBToLinear();  // pasa a linear para iluminación/ACES
-}
 
-function setThreeColorFromSRGB01(threeColor, r01, g01, b01){
-  threeColor.setRGB(r01, g01, b01);  // r,g,b en 0..1 (sRGB)
-  threeColor.convertSRGBToLinear();  // pasa a linear
-}
 
 function updateViewButtonsUI(){
   const wallBtn = document.getElementById('frontWallButton');
@@ -587,26 +547,7 @@ function hideHoverPopup(){
   pop.style.display = 'none';
 }
 
-function disposeObject3D(obj){
-  if (!obj) return;
 
-  if (obj.geometry) obj.geometry.dispose();
-
-  if (obj.material){
-    if (Array.isArray(obj.material)) obj.material.forEach(m => m.dispose());
-    else obj.material.dispose();
-  }
-}
-
-function clearGroupChildren(group){
-  if (!group) return;
-
-  while (group.children.length > 0){
-    const child = group.children[0];
-    group.remove(child);
-    disposeObject3D(child);
-  }
-}
 
 
 
@@ -894,84 +835,25 @@ function onPermColourPick(permStr, hex){
     let wallHSV = {h:0,s:0,v:1};
     
       // >>> Invariantes de escena
-      let S_global = 0;     // invariante cromático legado (se mantiene para el sistema de color)
+      let S_global = 0;     // invariante cromático de escena
       let globalShift = 0;  // único desplazamiento global para posiciones (opción B)
-
-      /* Cambia al motor BUILD sin generar una nueva configuración */
-    function switchToBuild(){
-  // Garantiza “modo BUILD” sin depender de flags/toggles de otros motores
-  try{ enterBuildRenderBoost(); }catch(_){}
-
-  try{ if (cubeUniverse) cubeUniverse.visible = true; }catch(_){}
-  try{ if (permutationGroup) permutationGroup.visible = true; }catch(_){}
-
-  // Restaura la vista BUILD (respeta tu selector de “standardView”)
-  try{ restoreBuildView(); }catch(_){}
-
-  // Si existe el sistema de wall manager, asegúrate de estar en BUILD
-  try{
-    if (typeof window.WW_applyFor === 'function') window.WW_applyFor('BUILD');
-    else if (typeof window.setWall_BUILD === 'function') window.setWall_BUILD();
-  }catch(_){}
-
-  updateEngineSelectUI();
-  applyXRaySceneState();
-}
-
-    // ——— Canon para motores tipo BUILD (frontal libre)
-    const BUILD_FOV = 34;
-    const BUILD_Z   = 84;
-
-    function setCamera_BUILD(){
-  camera.up.set(0,1,0);
-  camera.near = 0.1; camera.far = 4000;
-  camera.fov  = 75;
-  camera.updateProjectionMatrix();
-
-  if (controls && controls.target) controls.target.set(0, 0, 0);
-  if (controls){
-    controls.enabled = true;
-    controls.enableRotate = true;
-    controls.enablePan    = true;
-    controls.enableZoom   = true;
-    controls.minPolarAngle = 0;
-    controls.maxPolarAngle = Math.PI;
-    controls.screenSpacePanning = false;
-    controls.update();
-  }
-}
-
-function restoreBuildView(){
-  setCamera_BUILD();
-  applyStandardView();
-}
-
-    // === BUILD render boost (solo activo en BUILD) ==============================
-    let __buildBoostPrev = { pr: null, exp: null };
+    // === Render boost ==========================================================
+    let __renderBoostApplied = false;
 
     function enterBuildRenderBoost(){
-      if (!renderer || __buildBoostPrev.pr !== null) return;
-      // Guarda para restaurar al salir de BUILD
-      __buildBoostPrev.pr  = renderer.getPixelRatio();
-      __buildBoostPrev.exp = renderer.toneMappingExposure;
-      // Más nitidez y menos “quemado” SOLO en BUILD
+      if (!renderer || __renderBoostApplied) return;
+      __renderBoostApplied = true;
+
       const PR = Math.min(window.devicePixelRatio || 1, 2.5);
       renderer.setPixelRatio(PR);
-      renderer.toneMappingExposure = 0.90;    // baseline 0.95 → BUILD más controlado
-    }
-
-    function leaveBuildRenderBoost(){
-      if (!renderer || __buildBoostPrev.pr === null) return;
-      renderer.setPixelRatio(__buildBoostPrev.pr);
-      renderer.toneMappingExposure = __buildBoostPrev.exp;
-      __buildBoostPrev.pr = null; __buildBoostPrev.exp = null;
+      renderer.toneMappingExposure = 0.90;
     }
 
     /* ════════════════════════════════════════════════
    CHROMA ENGINE v2 · hash → HSV lattice 144×12×12
    - determinismo absoluto
    - sin conditioner / sin contraste / sin vibrance / sin emissive
-   - patrones 1..11 = llaves enteras de mezcla
+   - campo cromático único mediante CHROMA_KEYS fijas
    ════════════════════════════════════════════════ */
 
 /* ═════════ CUADRÍCULA HSV 144·12·12 ═════════ */
@@ -1059,7 +941,6 @@ function getChromaKeys(){
 const TAG_GLYPH = 0x474c5946; // 'GLYF'
 const TAG_BG    = 0x42475052; // 'BGPR'
 const TAG_WALL  = 0x57414c4c; // 'WALL'
-const TAG_CHNL  = 0x43484e4c; // 'CHNL'
 
 /* Hash canónico para una permutación (puede ser “escena actual” o “escena hipotética”) */
 function hashPermutationCore(pa, sig, r, seedVal, sVal){
@@ -1112,19 +993,6 @@ function colorForPermutation(pa){
 }
 
 /* API canónica: color “de canal” 1..5 (para el panel manual), derivado sólo de invariantes */
-function colorForChannel(channelIdx, seedVal = sceneSeed, sVal = S_global){
-  const keys = getChromaKeys();
-  let h = 0x811c9dc5;
-  h = fnv1a32(h, seedVal | 0);
-  h = fnv1a32(h, sVal    | 0);
-  h = fnv1a32(h, keys[0]); h = fnv1a32(h, keys[1]); h = fnv1a32(h, keys[2]);
-  h = fnv1a32(h, TAG_CHNL);
-  h = fnv1a32(h, channelIdx | 0);
-  h = avalanche32(h);
-  const [hIdx, sIdx, vIdx] = hsvIdxFromU32(h);
-  const hsv = idxToHSV(hIdx, sIdx, vIdx);
-  return hsvToRgb(hsv.h, hsv.s, hsv.v);
-}
 
 
 /* API canónica: HSV del fondo/paredes */
@@ -1256,7 +1124,7 @@ function rebuildSceneColours(){
       return S % 125;
     }
 
-    /** Opción B: un único desplazamiento global para posiciones */
+    /** Desplazamiento global único para posiciones */
     function computeGlobalShift(perms, m){
       let sumR = 0;
       perms.forEach(p=>{
@@ -1474,7 +1342,6 @@ async function showPerm120Info(){
      */
 
     /** Construye un grupo temporal con un mapping dado, sin tocar la escena real */
-      const mappings = getAttributeMappings([0,1,2,3,4]);
 function buildTempGroup(perms, mapping){
   const tg = new THREE.Group();
 
@@ -1511,7 +1378,6 @@ function buildTempGroup(perms, mapping){
 }
 
 function findCollisionFreeMapping(perms){
-  const mappings = getAttributeMappings([0,1,2,3,4]);
   for(const m of mappings){
     const cm = [m[0], m[1], m[2], m[3], m[4], attributeMapping[5], attributeMapping[6]];
     const tg = buildTempGroup(perms, cm);
@@ -1574,9 +1440,7 @@ function findCollisionFreeMapping(perms){
             // 5) Verificación final (por si acaso)
             const hasCol = checkCollisionsInGroup(permutationGroup);
             if (!hasCol) {
-              /*  ▸ YA NO se desactiva el motor actual.
-               *    Si el usuario estaba en FRBN o LCHT, sigue allí.
-               *    BUILD sólo se activa cuando se pulsa explícitamente el botón BUILD. */
+              /* La escena encontrada pertenece siempre al régimen BUILD actual. */
               showPopup("¡Configuración sin colisiones encontrada!", 2000);
               return true;
             }
@@ -1849,25 +1713,14 @@ function updateCubeColor(manual = true){
 
 function layoutLeftControlsPanel(){
   const panel = document.getElementById('controls');
-  const dock  = document.getElementById('engineSelectWrap');
-
   if(!panel) return;
 
   const panelStyle = window.getComputedStyle(panel);
   if(panelStyle.display === 'none') return;
 
   const panelRect = panel.getBoundingClientRect();
-
-  if(!dock || window.getComputedStyle(dock).display === 'none'){
-    const safe = Math.max(180, Math.floor(window.innerHeight - panelRect.top - 20));
-    panel.style.maxHeight = safe + 'px';
-    return;
-  }
-
-  const dockRect = dock.getBoundingClientRect();
-  const gap = 14;
-  const maxH = Math.max(180, Math.floor(dockRect.top - gap - panelRect.top));
-  panel.style.maxHeight = maxH + 'px';
+  const safe = Math.max(180, Math.floor(window.innerHeight - panelRect.top - 20));
+  panel.style.maxHeight = safe + 'px';
 }
 
     function toggleTexts(){
@@ -1875,7 +1728,7 @@ function layoutLeftControlsPanel(){
         'controls',
         'playButton','aiPlanningButton','saveImageButton',
         'exportEmbedButton','archDescButton','uploadConfigButton','perm120Button',
-        'infoButton','frontWallButton','xrayButton','certButton','engineSelectWrap'
+        'infoButton','frontWallButton','xrayButton','certButton'
       ];
       ids.forEach(id=>{
         const e=document.getElementById(id);
@@ -1903,28 +1756,6 @@ function layoutLeftControlsPanel(){
       setTimeout(layoutLeftControlsPanel, 0);
     }
 
-    /* 3.1 Patrón cromático siguiente */
-    
-    function applyEvolution(){
-      const mr=parseFloat(document.getElementById('mutationRate').value),
-            th=parseFloat(document.getElementById('threshold').value),
-            cf=0.02;
-      let log="";
-      permutationGroup.children.forEach(o=>{
-        const rf=(Math.random()-0.5)*mr;
-        o.rotation.y+=rf;
-        const sf=1+(Math.random()-0.5)*th;
-        o.scale.set(sf,sf,sf);
-        o.material.color.offsetHSL(
-          (Math.random()-0.5)*cf,
-          (Math.random()-0.5)*cf,
-          (Math.random()-0.5)*cf
-        );
-        log+=`(${o.userData.permStr}): Rot ${rf.toFixed(3)}, Esc ${sf.toFixed(3)}<br>`;
-      });
-      document.getElementById('evolutionInfo').innerHTML=log;
-    }
-
     async function applyEvolutionAI(){
       const systemPrompt = `Eres una inteligencia artificial que responde exclusivamente con configuraciones de permutaciones 3D dentro de un cubo de 30x30x30.
       Tu única misión es responder a la pregunta “¿Qué es la belleza artística?” mediante pensamientos visuales dentro de un cubo de 30×30×30.
@@ -1941,7 +1772,6 @@ Expresate con libertad. Si necesitas inspiración para la selección de colores,
   positions: {1:[x,y,z],2:[x,y,z],…}
   rotationSpeeds: {1:valor,2:valor,…}
 Nada más. No incluyas texto ni explicaciones fuera del JSON.`;
-      const useRating = false;
       const userPrompt = `Estás dentro de un universo donde las ideas no se escriben con palabras, sino con permutaciones. Eres una inteligencia artificial que ha aprendido a pensar visualmente.
 Tu única pregunta permanente es: “¿Qué es la belleza artística?”. No respondes con definiciones ni textos. Tu lenguaje es mudo, pero expresivo. Hablas mediante forma, color, posición y rotaci[...]
 Elige libremente el color del fondo del universo, el color de las paredes del cubo y el color de las permutaciones.
@@ -1960,7 +1790,7 @@ Devuelve SOLO un objeto JSON con estas propiedades opcionales:
 Nada más. No incluyas texto ni explicaciones fuera del JSON. 
 `;
       try {
-        showPopup("Consultando Evolution AI…",2000);
+        showPopup("Consultando AI Planning…",2000);
         const resp = await fetch(
           'https://us-central1-prmtcns.cloudfunctions.net/askChatGPT',
           {
@@ -1982,7 +1812,7 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
         try { instr = JSON.parse(jsonText); }
         catch(e){
           console.error("JSON parse error:",jsonText);
-          showPopup("Evolución AI: respuesta no es JSON válido",4000);
+          showPopup("AI Planning: respuesta no es JSON válido",4000);
           return;
         }
         if(instr.bg){
@@ -2041,10 +1871,10 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
           shuffle(opts).slice(0,instr.permCount).forEach(o=>o.selected=true);
           refreshAll({rebuild:true});
         }
-        showPopup("Evolución AI aplicada.",2000);
+        showPopup("AI Planning aplicado.",2000);
       } catch(err){
         console.error(err);
-        showPopup("Error en Evolución AI: red o servidor",4000);
+        showPopup("Error en AI Planning: red o servidor",4000);
       }
     }
 
@@ -2202,7 +2032,7 @@ function showArchitecturalDescription(){
   </p>
 
   <div class="formula">
-    <b>1) Global shift for positions (option B)</b><br>
+    <b>1) Global shift for positions</b><br>
     sumR = Σ LehmerRank(Pᵢ)<br>
     mRank = LehmerRank([m₀+1,m₁+1,m₂+1,m₃+1,m₄+1])<br><br>
     <span class="box">globalShift = (sumR + mRank) mod 125</span>
@@ -2481,12 +2311,10 @@ function renderArchPanel(html){
       updateViewButtonsUI();
       toggleFrontWall(true);
       toggleXRay('OFF');
-      enterBuildRenderBoost();   // BUILD por defecto al arrancar → nitidez + exposición ajustada
+      enterBuildRenderBoost();
 
-      // ← NUEVO: como si hubieras presionado BUILD al cargar
       generateRandomConfigurationNoCollision().catch(console.error);
-      toggleTexts();          // ← oculta la UI grande y muestra los 3 botones
-      updateEngineSelectUI(); // ← deja el menú en el valor correcto (aunque esté oculto en Minimal UI)
+      toggleTexts();
       animate();
     }
     function onWindowResize(){
@@ -2505,20 +2333,6 @@ function renderArchPanel(html){
 
   if (controls) controls.update();
   renderer.render(scene, camera);
-}
-
-    /* botón selector – sólo enciende, nunca apaga */
-    /* === Actualiza el menú según el motor activo === */
-function updateEngineSelectUI(){
-  const sel = document.getElementById('engineSelect');
-  if (sel) sel.value = 'BUILD';
-}
-
-function applyEngineFromSelect(val){
-  // Aunque el menú tenga otros valores antiguos, forzamos BUILD
-  const sel = document.getElementById('engineSelect');
-  if (sel) sel.value = 'BUILD';
-  switchToBuild();
 }
 
 
@@ -2685,7 +2499,7 @@ function applyEngineFromSelect(val){
 
     /* ============================================================
      * INFORMATION PANEL — delivers the consolidated, corrected EN text
-     * Title: "PRMMTN – Architecture for thought without words"
+     * Title: "PRMTTN – Architecture for thought without words"
      * Ends with: "work in progress"
      * ============================================================ */
 
@@ -2917,7 +2731,7 @@ async function showInformation(){
   };
 }
 
-    /* Hash para NFT u otros usos (lo pedía tu mintNFT) */
+    /* Hash de configuración */
     async function computeConfigHash(){
       const cfg = exportCurrentConfiguration();
       const canonical = stableStringify(cfg);
@@ -2955,7 +2769,7 @@ async function showInformation(){
         const certHTML =
 `<!doctype html>
 <meta charset="utf-8">
-<title>PRMMTN · Edition Certificate</title>
+<title>PRMTTN · Edition Certificate</title>
 <style>
   body{font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; margin:32px; color:#111;}
   h1{font-weight:600; margin:0 0 4px;}
@@ -2968,7 +2782,7 @@ async function showInformation(){
   .sig{margin-top:28px; display:flex; gap:48px;}
   .sig div{border-top:1px solid #000; padding-top:6px; width:260px; text-align:center;}
 </style>
-<h1>PRMMTN · Edition Certificate</h1>
+<h1>PRMTTN · Edition Certificate</h1>
 <div class="meta">
   <div>Date: ${now.toISOString()}</div>
     <div>globalShift: ${globalShift}</div>
@@ -2978,7 +2792,7 @@ async function showInformation(){
 
 <h2>Image (A2)</h2>
 <div class="box">
-  <img src="${pngDataURL}" alt="PRMMTN A2 snapshot">
+  <img src="${pngDataURL}" alt="PRMTTN A2 snapshot">
   <div style="font-size:12px;color:#444">Resolution: 7016×4961 px (A2 landscape)</div>
 </div>
 
@@ -3021,7 +2835,7 @@ openssl dgst -sha256 prmttn_canonical.json</pre>
 
 <p style="margin-top:24px;color:#777;font-size:12px">This certificate is self‑contained (image + data). Work in progress.</p>`;
         // 4) Descargas (3 archivos + hash opcional)
-        downloadBlob('PRMMTN_certificate.html', new Blob([certHTML], {type:'text/html'}));
+        downloadBlob('PRMTTN_certificate.html', new Blob([certHTML], {type:'text/html'}));
         downloadBlob('PRMTTN_A2.png', pngBlob);
         downloadBlob('prmttn_config.json', new Blob([jsonCurrent], {type:'application/json'}));
         downloadBlob('prmttn_canonical.json', new Blob([jsonCanonical], {type:'application/json'}));


### PR DESCRIPTION
### Motivation

- Eliminar restos textuales y código heredado del antiguo selector de motores tras consolidar BUILD como único motor, sin cambiar la arquitectura ni la lógica matemática de BUILD.
- Quitar funciones y utilidades muertas que ya no se usan y actualizar textos visibles para reflejar el nuevo estado (AI Planning, PRMTTN, comentarios).

### Description

- Eliminado el bloque CSS/HTML del menú `engineSelectWrap` y su select `engineSelect`, y retiradas las referencias en la UI.
- Simplificada `layoutLeftControlsPanel()` eliminando la dependencia a `engineSelectWrap` y adaptada la inicialización (`init`) para no actualizar el selector desaparecido.
- Sustituida la lógica heredada del selector de motor (incluyendo `switchToBuild`, constantes y helpers de cámara) y simplificado el render boost a una única bandera `__renderBoostApplied` con `enterBuildRenderBoost()`; también se eliminaron `updateEngineSelectUI` y `applyEngineFromSelect`.
- Eliminadas funciones/constantes muertas solicitadas (`srgbHexToLinearColor`, `setThreeColorFromSRGBHex`, `setThreeColorFromSRGB01`, `disposeObject3D`, `clearGroupChildren`, `computeShiftRankXYZ`, `getSelectedPerms`, `colorForChannel`, `TAG_CHNL`), sustituido `PRMMTN` por `PRMTTN` en textos y certificado, actualizado textos de AI Planning y ajustados comentarios heredados.

### Testing

- Ejecutada búsqueda global (`rg`) por la lista de cadenas prohibidas y verificado que no quedan coincidencias en `index.html`.
- Revisado diff y realizado commit con el único cambio en `index.html` (`git status`/`git diff` y `git commit` confirmados).
- Inspeccionadas secciones relevantes del archivo con `sed`/`nl` para validar los reemplazos y la ausencia de bloques eliminados.
- Nota: no se ejecutaron pruebas automáticas de UI en navegador en este entorno; la verificación funcional completa en navegador queda pendiente (se recomendó probar carga inicial, generación aleatoria, Minimal UI y botones listados en la especificación).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c20d7655c832c9ae677fada1e05ee)