### PR TITLE
Corregir ReferenceError en findCollisionFreeMapping para nuevas escenas

### DIFF
--- a/index.html
+++ b/index.html
@@ -1378,11 +1378,14 @@ function buildTempGroup(perms, mapping){
 }
 
 function findCollisionFreeMapping(perms){
-  for(const m of mappings){
+  const candidateMappings = getAttributeMappings([0,1,2,3,4]);
+
+  for(const m of candidateMappings){
     const cm = [m[0], m[1], m[2], m[3], m[4], attributeMapping[5], attributeMapping[6]];
     const tg = buildTempGroup(perms, cm);
     if(!checkCollisionsInGroup(tg)) return cm;
   }
+
   return null;
 }
     /** Selecciona un subconjunto aleatorio de permutaciones (1..25) */


### PR DESCRIPTION
### Motivation
- Se corrigió un error que impedía generar nuevas escenas debido a una referencia a la variable indefinida `mappings` dentro de `findCollisionFreeMapping(perms)`.
- El cambio intenta reparar la búsqueda de mappings sin alterar la lógica visual ni refactorizar otras partes del archivo.

### Description
- Reemplacé la implementación de `findCollisionFreeMapping(perms)` para construir localmente `candidateMappings` mediante `getAttributeMappings([0,1,2,3,4])`.
- El bucle ahora itera sobre `candidateMappings` en lugar del símbolo indefinido `mappings` y sigue creando `cm` y comprobando colisiones con `buildTempGroup` y `checkCollisionsInGroup`.
- No se cambió la composición de `cm` que incluye `attributeMapping[5]` y `attributeMapping[6]`, ni se tocaron otras partes del archivo.

### Testing
- Verifiqué que el bloque fue parcheado con `rg -n "findCollisionFreeMapping|mappings|candidateMappings" index.html` y confirmó la presencia de `candidateMappings`; la búsqueda devolvió resultados correctos.
- Revisé el diff con `git diff -- index.html` para asegurar que solo se modificó la función objetivo; el diff mostró la inserción esperada y eliminación de la referencia a `mappings`.
- Confirmé el cambio con `git add` y `git commit`, y el commit se creó exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c256e3120832cb0f02cb732279a5a)