### PR TITLE
Startup: make initial scene generation non-blocking and avoid duplicate permutations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1247,13 +1247,15 @@ function findCollisionFreeMapping(perms){
 }
     /** Selecciona un subconjunto aleatorio de permutaciones (1..25) */
     function pickRandomPerms(){
-      const n  = Math.floor(Math.random()*25) + 1;
-      const out = [];
-      for(let i=0;i<n;i++){
-        const str = permutationStrings[Math.floor(Math.random()*permutationStrings.length)];
-        out.push(str.split(',').map(Number));
+      const n = Math.floor(Math.random() * 25) + 1;
+      const pool = permutationStrings.slice();
+
+      for(let i = pool.length - 1; i > 0; i--){
+        const j = Math.floor(Math.random() * (i + 1));
+        [pool[i], pool[j]] = [pool[j], pool[i]];
       }
-      return out;
+
+      return pool.slice(0, n).map(str => str.split(',').map(Number));
     }
 
     /**
@@ -1265,9 +1267,9 @@ function findCollisionFreeMapping(perms){
      * No bloquea la UI gracias al pequeño await en cada iteración.
      */
     async function generateRandomConfigurationNoCollision(MAX_TRIES = 5000){
-      let round = 0;
-      while (true) { // sigue intentando hasta que realmente encuentre una sin colisiones
-        round++;
+      const MAX_ROUNDS = 6;
+
+      for (let round = 1; round <= MAX_ROUNDS; round++) {
         for (let t = 0; t < MAX_TRIES; t++) {
           showPopup(`Buscando configuración sin colisiones… (ronda ${round}, intento ${t+1})`, 500);
 
@@ -1275,43 +1277,40 @@ function findCollisionFreeMapping(perms){
           const mapping = findCollisionFreeMapping(perms);
 
           if (mapping) {
-            // 2) Pon las permutaciones en el <select>
             const sel = document.getElementById('permutationList');
             Array.from(sel.options).forEach(o => o.selected = false);
+
             perms.forEach(p=>{
               const val = p.join(',');
               const opt = sel.querySelector(`option[value="${val}"]`);
               if(opt) opt.selected = true;
             });
 
-            // 3) Aplica el mapping encontrado
             attributeMapping = mapping;
 
-            // mantenemos tu ciclo de atributo "color"
             attributeMapping[1] = colorAttrCycle % 5;
             colorAttrCycle++;
 
             document.getElementById('attrMapping').value =
               `${attributeMapping[0]},${attributeMapping[1]},${attributeMapping[2]},${attributeMapping[3]},${attributeMapping[4]}`;
 
-            // 4) Reconstruye escena completa
             refreshAll({rebuild:true});
 
-            // 5) Verificación final (por si acaso)
             const hasCol = checkCollisionsInGroup(permutationGroup);
             if (!hasCol) {
-              /* La escena encontrada pertenece siempre al régimen BUILD actual. */
-              showPopup("¡Configuración sin colisiones encontrada!", 2000);
+              showPopup("Configuración sin colisiones encontrada.", 2000);
               return true;
             }
           }
 
-          // cede el hilo para no congelar la UI
           if ((t % 25) === 0) await new Promise(r => setTimeout(r, 0));
         }
-        // pequeña pausa entre rondas largas
+
         await new Promise(r => setTimeout(r, 10));
       }
+
+      showPopup("No se encontró nueva configuración sin colisiones. Se conserva la escena actual.", 4000);
+      return false;
     }
 
     function showPopup(msg, dur = 2000){
@@ -1956,9 +1955,15 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       toggleXRay('OFF');
       enterBuildRenderBoost();
 
-      generateRandomConfigurationNoCollision().catch(console.error);
-      toggleTexts();
+      // Primero deja la página renderizando y en estado interactivo.
+      toggleTexts();          // oculta la UI grande y muestra los controles mínimos
+      updateEngineSelectUI(); // mantiene BUILD como único motor activo
       animate();
+
+      // Después genera la primera escena, sin bloquear el arranque visual.
+      setTimeout(() => {
+        generateRandomConfigurationNoCollision().catch(console.error);
+      }, 0);
     }
     function onWindowResize(){
       camera.aspect=window.innerWidth/window.innerHeight; camera.updateProjectionMatrix();


### PR DESCRIPTION
### Motivation

- Evitar que la página quede en blanco o incompleta porque `generateRandomConfigurationNoCollision()` bloquea el primer render cuando se ejecuta dentro de `init()`.
- Evitar selecciones con permutaciones duplicadas que pueden producir colisiones imposibles de resolver.
- Reemplazar la búsqueda infinita por un algoritmo acotado y con fallback para evitar bucles sin salida visible.

### Description

- En `index.html` se cambió `init()` para que primero invoque `toggleTexts()`, `updateEngineSelectUI()` y `animate()`, y luego lance la generación inicial con `setTimeout(() => generateRandomConfigurationNoCollision().catch(console.error), 0)` para no bloquear el primer paint.
- `pickRandomPerms()` fue reemplazada por una versión que hace un `shuffle` del pool (`permutationStrings.slice()`), toma `n` sin repeticiones y devuelve las permutaciones como arrays de números.
- `generateRandomConfigurationNoCollision(MAX_TRIES = 5000)` fue reemplazada por una versión que limita rondas con `const MAX_ROUNDS = 6`, mantiene las cesiones periódicas (`await new Promise(r => setTimeout(r, 0))` cada 25 intentos), y devuelve `false` con un `showPopup` si no encuentra una configuración válida dentro del límite.
- No se eliminaron ni modificaron las funciones estructurales indicadas para preservarse (por ejemplo `buildTempGroup`, `findCollisionFreeMapping`, `checkCollisionsInGroup`, `refreshAll`, etc.).

### Testing

- Se verificó mediante búsquedas estáticas con `rg` que las funciones `init`, `pickRandomPerms` y `generateRandomConfigurationNoCollision` fueron actualizadas correctamente, y todas las búsquedas devolvieron las ocurrencias esperadas (éxito).
- Se inspeccionaron las secciones modificadas con `sed`/`nl` para confirmar las sustituciones de código y la presencia de los nuevos `setTimeout` y `MAX_ROUNDS` (éxito).
- Se añadió el cambio a la historia y se creó un commit ( `git commit` ) exitoso que incluye la modificación de `index.html` (éxito).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c5c637ed0832c9588f2a5a63afd7c)