### PR TITLE
Remove legacy UI panels and obsolete controls while preserving minimal 120 flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,10 +72,6 @@
 
   #saveImageButton { background:rgba(255,255,255,0.2); }
 
-  /* Ocultar los no usados */
-  #btnDebugColors{
-    display:none !important;
-  }
 
   #controls {
     position: absolute;
@@ -185,11 +181,6 @@
 
   <button id="frontWallButton" onclick="toggleFrontWall()">Hide Front Wall</button>
   <button id="xrayButton" onclick="toggleXRay()">X-Ray: Off</button>
-  <button id="btnDebugColors"
-          style="position:fixed;bottom:180px;right:10px;z-index:260;display:none;"
-          onclick="mostrarDebugColores()">
-    Debug Colors
-  </button>
 
 
 
@@ -443,13 +434,6 @@ function updateViewButtonsUI(){
   }
 }
 
-
-function hideHoverPopup(){
-  const pop = document.getElementById('hoverPopup');
-  if (!pop) return;
-  pop.style.opacity = 0;
-  pop.style.display = 'none';
-}
 
 
 
@@ -1064,16 +1048,6 @@ function rebuildSceneColours(){
         Z
       };
     }
-
-    function computeShiftRankXYZ(p){
-      const info = getShiftRankCellInfo(p);
-      return [info.X, info.Y, info.Z];
-    }
-
-    function getSelectedPerms(){
-      return Array.from(document.getElementById('permutationList').selectedOptions)
-                  .map(o => o.value.split(',').map(Number));
-    }
     
     function updateTopRightDisplay(){
       // HUD desactivado (topRightDisplay está oculto por CSS)
@@ -1172,33 +1146,7 @@ function autoResolveColisionesGlobal(){
  * ============================== */
 let perm120List = getAttributeMappings([0,1,2,3,4]); // 120
 let perm120Index = 0;
-let perm120Timer = null;
 
-function togglePerm120Panel(){
-  const p = document.getElementById('perm120Panel');
-  if (!p) return;
-
-  const isHidden = (p.style.display === 'none' || !p.style.display);
-  p.style.display = isHidden ? 'block' : 'none';
-
-  const cc = document.getElementById('customCursor');
-  if (cc) cc.style.display = 'block';
-}
-
-function msFromUI(){
-  const slider = document.getElementById('perm120Slider');
-  return parseInt(slider.value, 10);
-}
-function syncPerm120InputsFromSlider(){
-  const ms = msFromUI();
-  document.getElementById('perm120Seconds').value = Math.round(ms/1000);
-}
-function syncPerm120SliderFromSeconds(){
-  const sec = parseInt(document.getElementById('perm120Seconds').value,10) || 1;
-  const clamped = Math.max(1, Math.min(720, sec));
-  document.getElementById('perm120Seconds').value = clamped;
-  document.getElementById('perm120Slider').value = clamped * 1000;
-}
 
 function updatePerm120Status(){
   const stat = document.getElementById('perm120Status');
@@ -1215,30 +1163,6 @@ function applyPerm120Index(i){
 }
 
 function nextPerm120(){ applyPerm120Index(perm120Index + 1); }
-function prevPerm120(){ applyPerm120Index(perm120Index - 1); }
-
-function playPerm120(){
-  if(perm120Timer) return;
-  const interval = msFromUI();
-  perm120Timer = setInterval(nextPerm120, interval);
-  nextPerm120();
-}
-function pausePerm120(){
-  if(perm120Timer){
-    clearInterval(perm120Timer);
-    perm120Timer = null;
-  }
-}
-
-async function showPerm120Info(){
-  try{
-    const text = await loadTextPartial('./texts/perm120-info.txt');
-    alert(text);
-  }catch(err){
-    alert('Error cargando perm120-info.txt');
-    console.error(err);
-  }
-}
 
 
     /* ============================================================
@@ -1649,9 +1573,6 @@ function layoutLeftControlsPanel(){
         if(e) e.style.display = textsVisible ? 'block' : 'none';
       });
 
-      // Mantener SIEMPRE cerrado el panel de 120 perms
-      const p = document.getElementById('perm120Panel');
-      if (p) p.style.display = 'none';
 
       document.getElementById('toggleTextButton').textContent =
         textsVisible ? 'Show UI' : 'Minimal UI';
@@ -1869,6 +1790,58 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       if(p.get('hide')==='1') toggleTexts();
     }
 
+function exportCurrentConfiguration(){
+  const perms = Array.from(document.getElementById('permutationList').selectedOptions).map(o=>o.value);
+
+  const mapping = {
+    forma: attributeMapping[0],
+    color: attributeMapping[1],
+    x: attributeMapping[2],
+    y: attributeMapping[3],
+    z: attributeMapping[4]
+  };
+
+  // Colors ahora es por permutación (N entradas)
+  const colors = {};
+  perms.forEach(ps=>{
+    const autoHex = canonicalHexForPermStr(ps);
+    const ovHex   = permOverride[ps] || null;
+    const effHex  = (chromaMode === 'HABITATED' && ovHex) ? ovHex : autoHex;
+    colors[ps] = effHex;
+  });
+
+  const bg   = normHex6(document.getElementById('bgColor').value)   || document.getElementById('bgColor').value;
+  const cube = normHex6(document.getElementById('cubeColor').value) || document.getElementById('cubeColor').value;
+
+  const permsSorted = {};
+  Object.keys(permOverride || {}).sort().forEach(ps=>{
+    const hv = normHex6(permOverride[ps]);
+    if(hv) permsSorted[ps] = hv;
+  });
+
+  const overrides = {
+    perms: permsSorted,
+    bg: bgOverride ? normHex6(bgOverride) : null,
+    cube: cubeOverride ? normHex6(cubeOverride) : null
+  };
+
+  const view = "front";
+
+  return {
+    perms,
+    mapping,
+    colors,
+    bg,
+    cube,
+    view,
+    sceneSeed,
+    S_global,
+    globalShift,
+    chroma_mode: chromaMode,
+    overrides
+  };
+}
+
     function exportEmbed(){
       const config = exportCurrentConfiguration();     // ← usa la misma fuente de verdad
       const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
@@ -1879,33 +1852,6 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     }
-
-    function mostrarDebugColores(){
-  if(!permutationGroup || !permutationGroup.children.length){
-    alert('No hay permutaciones en pantalla'); return;
-  }
-
-  let txt =
-    'Permutación | r | hIdx | sIdx | vIdx | h° |  s  |  v  | #hex\n' +
-    '────────────┼───┼──────┼──────┼──────┼────┼─────┼─────┼────────\n';
-
-  permutationGroup.children.forEach(mesh => {
-    const paArr = mesh.userData.permStr.split(',').map(Number);
-    const info  = colorInfoForPermutation(paArr);
-
-    txt += `${mesh.userData.permStr.padEnd(12)}|`+
-           `${info.r.toString().padStart(3)}|`+
-           `${info.hIdx.toString().padStart(6)}|`+
-           `${info.sIdx.toString().padStart(6)}|`+
-           `${info.vIdx.toString().padStart(6)}|`+
-           `${normHue(info.hsv.h).toFixed(1).padStart(4)}|`+
-           `${info.hsv.s.toFixed(2).padStart(5)}|`+
-           `${info.hsv.v.toFixed(2).padStart(5)}| ${info.hex}\n`;
-  });
-
-  console.log(txt);
-  alert(txt);
-}
 
         function initCustomCursor(){
       const c=document.getElementById('customCursor');
@@ -2186,199 +2132,6 @@ Nada más. No incluyas texto ni explicaciones fuera del JSON.
   window.WW_applyFor = function(){ wall.setVisible(frontWallVisible); };
 })();
 ;
-
-
-
-        /* ======== CERTIFICADO DE EDICIÓN: utilidades base ======== */
-
-    /* Ordena claves de forma determinista (objetos y arrays) */
-    function sortDeep(x){
-      if (Array.isArray(x)) return x.map(sortDeep);
-      if (x && typeof x === 'object') {
-        const out = {};
-        Object.keys(x).sort().forEach(k => { out[k] = sortDeep(x[k]); });
-        return out;
-      }
-      return x;
-    }
-    /* JSON canónico (minificado y con claves ordenadas) */
-    function stableStringify(obj){ return JSON.stringify(sortDeep(obj)); }
-
-    /* SHA‑256 en hex */
-    async function sha256Hex(text){
-      const enc = new TextEncoder().encode(text);
-      const buf = await crypto.subtle.digest('SHA-256', enc);
-      const bytes = Array.from(new Uint8Array(buf));
-      return bytes.map(b => b.toString(16).padStart(2,'0')).join('');
-    }
-
-    /* Descarga un blob */
-    function downloadBlob(filename, blob){
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url; a.download = filename;
-      document.body.appendChild(a); a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    }
-
-    /* PNG A2 de la vista ACTUAL (sin recortar lo que ves) → Blob */
-    async function renderA2ImageBlob(){
-      const A2_W = 7016, A2_H = 4961;
-
-      // backups
-      const prevPixelRatio = renderer.getPixelRatio();
-      const prevSize       = renderer.getSize(new THREE.Vector2());
-      const prevAspect     = camera.aspect;
-      const prevRt         = renderer.getRenderTarget?.() || null;
-      const prevBg         = scene.background ? scene.background.clone() : null;
-
-      const screenAspect = prevSize.x / prevSize.y;
-      const a2Aspect = A2_W / A2_H;
-      let renderW, renderH;
-      if (screenAspect > a2Aspect) { renderW = A2_W; renderH = Math.round(A2_W / screenAspect); }
-      else { renderH = A2_H; renderW = Math.round(A2_H * screenAspect); }
-
-      renderer.setPixelRatio(1);
-      renderer.setSize(renderW, renderH, false);
-      camera.aspect = screenAspect;
-      camera.updateProjectionMatrix();
-
-      const rt = new THREE.WebGLRenderTarget(renderW, renderH, { depthBuffer:true, stencilBuffer:false });
-      rt.texture.encoding = THREE.sRGBEncoding; // IMPORTANT: igualar salida a pantalla
-      const clearHex = __bgHexSRGB || '#ffffff'; // canvas wants sRGB
-
-      renderer.setClearColor(prevBg || new THREE.Color(clearHex).convertSRGBToLinear(), 1);
-      renderer.setRenderTarget(rt);
-      renderer.clear(true, true, true);
-      renderer.render(scene, camera);
-
-      const pixels = new Uint8Array(renderW * renderH * 4);
-      renderer.readRenderTargetPixels(rt, 0, 0, renderW, renderH, pixels);
-
-      // canvas intermedio con flip vertical
-      const tmp = document.createElement('canvas');
-      tmp.width = renderW; tmp.height = renderH;
-      const tctx = tmp.getContext('2d');
-      const imgData = tctx.createImageData(renderW, renderH);
-      const row = renderW * 4;
-      for (let y = 0; y < renderH; y++) {
-        const src = (renderH - 1 - y) * row;
-        const dst = y * row;
-        imgData.data.set(pixels.subarray(src, src + row), dst);
-      }
-      tctx.putImageData(imgData, 0, 0);
-
-
-      // composita A2 con cubierta según modo
-      const final = document.createElement('canvas');
-      final.width = A2_W; final.height = A2_H;
-      const fctx = final.getContext('2d');
-
-      fctx.fillStyle = clearHex;
-      fctx.fillRect(0, 0, A2_W, A2_H);
-      const offX = Math.floor((A2_W - renderW) / 2);
-      const offY = Math.floor((A2_H - renderH) / 2);
-      fctx.drawImage(tmp, offX, offY);
-
-      const blob = await new Promise(res => final.toBlob(res, 'image/png'));
-      // restaurar
-      renderer.setRenderTarget(prevRt);
-      rt.dispose();
-      renderer.setPixelRatio(prevPixelRatio);
-      renderer.setSize(prevSize.x, prevSize.y);
-      camera.aspect = prevAspect;
-      camera.updateProjectionMatrix();
-      if (prevBg) scene.background = prevBg;
-      controls.update();
-
-      return blob;
-    }
-
-    /* Configuración actual (mismo formato que exportEmbed) */
-    function exportCurrentConfiguration(){
-  const perms = Array.from(document.getElementById('permutationList').selectedOptions).map(o=>o.value);
-
-  const mapping = {
-    forma: attributeMapping[0],
-    color: attributeMapping[1],
-    x: attributeMapping[2],
-    y: attributeMapping[3],
-    z: attributeMapping[4]
-  };
-
-  // Colors ahora es por permutación (N entradas)
-  const colors = {};
-  perms.forEach(ps=>{
-    const autoHex = canonicalHexForPermStr(ps);
-    const ovHex   = permOverride[ps] || null;
-    const effHex  = (chromaMode === 'HABITATED' && ovHex) ? ovHex : autoHex;
-    colors[ps] = effHex;
-  });
-
-  const bg   = normHex6(document.getElementById('bgColor').value)   || document.getElementById('bgColor').value;
-  const cube = normHex6(document.getElementById('cubeColor').value) || document.getElementById('cubeColor').value;
-
-  const permsSorted = {};
-  Object.keys(permOverride || {}).sort().forEach(ps=>{
-    const hv = normHex6(permOverride[ps]);
-    if(hv) permsSorted[ps] = hv;
-  });
-
-  const overrides = {
-    perms: permsSorted,
-    bg: bgOverride ? normHex6(bgOverride) : null,
-    cube: cubeOverride ? normHex6(cubeOverride) : null
-  };
-
-  const view = "front";
-
-  return {
-    perms,
-    mapping,
-    colors,
-    bg,
-    cube,
-    view,
-    sceneSeed,
-    S_global,
-    globalShift,
-    chroma_mode: chromaMode,
-    overrides
-  };
-}
-
-    function exportCanonicalConfiguration(){
-  const base = exportCurrentConfiguration();
-
-  const canonicalColors = {};
-  base.perms.forEach(ps=>{
-    canonicalColors[ps] = canonicalHexForPermStr(ps);
-  });
-
-  return {
-    perms: base.perms,
-    mapping: base.mapping,
-    colors: canonicalColors,
-    bg: hsvToHex(bgHSV),
-    cube: hsvToHex(wallHSV),
-    view: base.view,
-    sceneSeed: base.sceneSeed,
-    S_global: base.S_global,
-    globalShift: base.globalShift,
-    chroma_mode: 'CANONICAL',
-    overrides: { perms:{}, bg:null, cube:null }
-  };
-}
-
-    /* Hash de configuración */
-    async function computeConfigHash(){
-      const cfg = exportCurrentConfiguration();
-      const canonical = stableStringify(cfg);
-      return sha256Hex(canonical);
-    }
-
-
 
 </script>
 


### PR DESCRIPTION
### Motivation
- Remove obsolete UI controls, panels and debug helpers that are no longer needed while keeping the minimal UI and scene-generation logic intact. 
- Keep the minimal `120` button and its core permutation-stepping logic so minimal workflows continue to work.

### Description
- Removed legacy visible UI elements and panels: the architectural/info/certificate buttons and the full visible 120-permutations panel HTML, while preserving the minimal button `<button id="permNextButton" onclick="nextPerm120()">120</button>`.
- Cleaned initial CSS by removing selectors/blocks for removed controls and panels (removed `#archDescButton`, `#perm120Button`, `#certButton` selectors and the `#archPanel`, `#infoPanel`, `#perm120Panel` CSS blocks and related debug CSS). 
- Simplified `toggleTexts()` by removing stale id entries and the `perm120Panel` handling and kept `miniBtns = ['permNextButton']` unchanged so minimal UI shows the `120` button.
- Removed the visible-panel helper functions tied to the deleted 120 panel (`togglePerm120Panel`, `msFromUI`, `syncPerm120InputsFromSlider`, `syncPerm120SliderFromSeconds`, `prevPerm120`, `playPerm120`, `pausePerm120`, `showPerm120Info`) while keeping `perm120List`, `perm120Index`, `updatePerm120Status`, `applyPerm120Index(i)` and `nextPerm120()` so the core stepping flow still works without panel dependencies.
- Deleted the full Architectural Description, Information panel and Edition Certificate utility blocks, and removed the legacy debug button and `mostrarDebugColores()` function; reinserted/preserved `exportCurrentConfiguration()` so `Save JSON`/export features continue functioning.
- Removed a small set of minor helper functions that were unused after the cleanup (`computeShiftRankXYZ`, `getSelectedPerms`, `hideHoverPopup`) after confirming they had no other references.

### Testing
- Ran automated presence/absence checks for required and forbidden strings (custom Python/rg checks) which reported all required symbols/functions present and no forbidden legacy strings found, and the validation script returned `missing []` and `forbidden_present []` (success).
- Performed targeted grep/ripgrep inspections across `index.html` to confirm removed CSS/HTML blocks and deleted functions are absent and that `nextPerm120`, `applyPerm120Index`, `generateRandomConfigurationNoCollision`, `buildTempGroup`, `findCollisionFreeMapping`, `pickRandomPerms`, `updateScene`, `refreshAll`, `exportCurrentConfiguration`, `saveImage`, `applyPalette` and `enterBuildRenderBoost` remain present (success).
- Manual browser/visual interaction tests were not executed in this environment (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c6cfae3a8832cb07572345b65e689)